### PR TITLE
Add rgba support on mac

### DIFF
--- a/TwitchDownloaderCLI/Options.cs
+++ b/TwitchDownloaderCLI/Options.cs
@@ -76,7 +76,7 @@ namespace TwitchDownloaderCLI
         public int Framerate { get; set; }
         [Option("update-rate", Default = 0.2, HelpText = "Time in seconds to update chat render output.")]
         public double UpdateRate { get; set; }
-        [Option("input-args", Default = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", HelpText = "Input arguments for ffmpeg chat render.")]
+        [Option("input-args", Default = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt {pix_fmt} -video_size {width}x{height} -i -", HelpText = "Input arguments for ffmpeg chat render.")]
         public string InputArgs { get; set; }
         [Option("output-args", Default = "-c:v libx264 -preset veryfast -crf 18 -pix_fmt yuv420p \"{save_path}\"", HelpText = "Output arguments for ffmpeg chat render.")]
         public string OutputArgs { get; set; }

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -208,7 +208,8 @@ namespace TwitchDownloaderCore
 
             string inputArgs = renderOptions.InputArgs.Replace("{fps}", renderOptions.Framerate.ToString())
                 .Replace("{height}", renderOptions.ChatHeight.ToString()).Replace("{width}", renderOptions.ChatWidth.ToString())
-                .Replace("{save_path}", renderOptions.OutputFile).Replace("{max_int}", int.MaxValue.ToString());
+                .Replace("{save_path}", renderOptions.OutputFile).Replace("{max_int}", int.MaxValue.ToString())
+                .Replace("{pix_fmt}", bufferBitmap.ColorType == SKColorType.Rgba8888 ? "rgba" : "bgra");
             string outputArgs = renderOptions.OutputArgs.Replace("{fps}", renderOptions.Framerate.ToString())
                 .Replace("{height}", renderOptions.ChatHeight.ToString()).Replace("{width}", renderOptions.ChatWidth.ToString())
                 .Replace("{save_path}", renderOptions.OutputFile).Replace("{max_int}", int.MaxValue.ToString());


### PR DESCRIPTION
It seems like on Mac, the default SKColorType is Rgba8888 instead of Bgra8888, so I was getting a color issue

Before:
<img width="98" alt="before" src="https://user-images.githubusercontent.com/49019782/130342426-9f57cd17-3fa4-4c88-be54-a2fc2e26de5a.png">
After:
<img width="99" alt="after" src="https://user-images.githubusercontent.com/49019782/130342428-00421c6c-9262-416a-8ea5-56308e4a6761.png">