### PR TITLE
7tv animated emotes

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -617,7 +617,7 @@ namespace TwitchDownloaderCore
                             if (drawPos.X + (currentEmote.width / currentEmote.imageScale) * renderOptions.EmoteScale > canvasSize.Width)
                                 sectionImage = AddImageSection(sectionImage, imageList, renderOptions, currentGifEmotes, canvasSize, ref drawPos, default_x);
 
-                            if (currentEmote.imageType == "gif")
+                            if (currentEmote.imageType == "gif" || currentEmote.imageType == "webp")
                             {
                                 GifEmote emote = new GifEmote(new Point(drawPos.X, drawPos.Y), currentEmote.name, currentEmote.codec, currentEmote.imageScale, currentEmote.emote_frames);
                                 currentGifEmotes.Add(emote);

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -164,11 +164,12 @@ namespace TwitchDownloaderCore
                         {
                             string id = emote["id"].ToString();
                             string name = emote["code"].ToString();
+                            string mime = emote["imageType"].ToString();
                             if (alreadyAdded.Contains(name))
                                 continue;
-                            string fileName = Path.Combine(bttvFolder, id + "_2x.png");
+                            string fileName = Path.Combine(bttvFolder, id + "_2x." + mime);
                             string url = String.Format("https://cdn.betterttv.net/emote/{0}/2x", id);
-                            TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, emote["imageType"].ToString(), id, 2);
+                            TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, mime, id, 2);
                             if (newEmote != null)
                             {
                                 returnList.Add(newEmote);
@@ -179,11 +180,12 @@ namespace TwitchDownloaderCore
                         {
                             string id = emote["id"].ToString();
                             string name = emote["code"].ToString();
+                            string mime = emote["imageType"].ToString();
                             if (alreadyAdded.Contains(name))
                                 continue;
-                            string fileName = Path.Combine(bttvFolder, id + "_2x.png");
+                            string fileName = Path.Combine(bttvFolder, id + "_2x." + mime);
                             string url = String.Format("https://cdn.betterttv.net/emote/{0}/2x", id);
-                            TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, emote["imageType"].ToString(), id, 2);
+                            TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, mime, id, 2);
                             if (newEmote != null)
                             {
                                 returnList.Add(newEmote);
@@ -205,11 +207,12 @@ namespace TwitchDownloaderCore
                     {
                         string id = emote["id"].ToString();
                         string name = emote["code"].ToString();
+                        string mime = emote["imageType"].ToString();
                         if (alreadyAdded.Contains(name))
                             continue;
-                        string fileName = Path.Combine(ffzFolder, id + "_1x.png");
+                        string fileName = Path.Combine(ffzFolder, id + "_1x." + mime);
                         string url = String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/1", id);
-                        TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, emote["imageType"].ToString(), id, 2);
+                        TwitchEmote newEmote = GetTwitchEmote(fileName, url, name, mime, id, 2);
                         if (newEmote != null)
                         {
                             returnList.Add(newEmote);
@@ -225,20 +228,21 @@ namespace TwitchDownloaderCore
                         {
                             string id = emote["id"].ToString();
                             string name = emote["code"].ToString();
+                            string mime = emote["imageType"].ToString();
                             if (alreadyAdded.Contains(name))
                                 continue;
-                            string fileName = Path.Combine(ffzFolder, id + "_2x.png");
-                            string fileNameLow = Path.Combine(ffzFolder, id + "_1x.png");
+                            string fileName = Path.Combine(ffzFolder, id + "_2x." + mime);
+                            string fileNameLow = Path.Combine(ffzFolder, id + "_1x" + mime);
                             TwitchEmote newEmote = null;
                             if (File.Exists(fileNameLow))
                             {
-                                newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/1", id), name, emote["imageType"].ToString(), id, 1);
+                                newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/1", id), name, mime, id, 1);
                             }
                             if (newEmote == null)
                             {
-                                newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/2", id), name, emote["imageType"].ToString(), id, 2);
+                                newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/2", id), name, mime, id, 2);
                                 if (newEmote == null)
-                                    newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/1", id), name, emote["imageType"].ToString(), id, 1);
+                                    newEmote = GetTwitchEmote(fileName, String.Format("https://cdn.betterttv.net/frankerfacez_emote/{0}/1", id), name, mime, id, 1);
                             }
                             if (newEmote != null)
                             {
@@ -261,11 +265,12 @@ namespace TwitchDownloaderCore
                     {
                         string id = emote["id"].ToString();
                         string name = emote["name"].ToString();
+                        string mime = emote["mime"].ToString().Split('/')[1];
                         string url2x = emote["urls"][1][1].ToString(); // 2x
                         if (alreadyAdded.Contains(name))
                             continue;
                         byte[] bytes;
-                        string fileName = Path.Combine(stvFolder, id + "_2x.png");
+                        string fileName = Path.Combine(stvFolder, id + "_2x." + mime);
                         if (File.Exists(fileName))
                             bytes = File.ReadAllBytes(fileName);
                         else
@@ -273,9 +278,8 @@ namespace TwitchDownloaderCore
                             bytes = client.DownloadData(url2x);
                             File.WriteAllBytes(fileName, bytes);
                         }
-
                         MemoryStream ms = new MemoryStream(bytes);
-                        returnList.Add(new TwitchEmote(new List<SKBitmap>() { SKBitmap.Decode(bytes) }, SKCodec.Create(ms), name, emote["mime"].ToString().Split('/')[1], id, 2, bytes));
+                        returnList.Add(new TwitchEmote(new List<SKBitmap>() { SKBitmap.Decode(bytes) }, SKCodec.Create(ms), name, mime, id, 2, bytes));
                         alreadyAdded.Add(name);
                     }
 
@@ -287,11 +291,12 @@ namespace TwitchDownloaderCore
                         {
                             string id = emote["id"].ToString();
                             string name = emote["name"].ToString();
+                            string mime = emote["mime"].ToString().Split('/')[1];
                             string url2x = emote["urls"][1][1].ToString(); // 2x
                             if (alreadyAdded.Contains(name))
                                 continue;
                             byte[] bytes;
-                            string fileName = Path.Combine(stvFolder, id + "_2x.png");
+                            string fileName = Path.Combine(stvFolder, id + "_2x." + mime);
                             if (File.Exists(fileName))
                                 bytes = File.ReadAllBytes(fileName);
                             else
@@ -300,7 +305,7 @@ namespace TwitchDownloaderCore
                                 File.WriteAllBytes(fileName, bytes);
                             }
                             MemoryStream ms = new MemoryStream(bytes);
-                            returnList.Add(new TwitchEmote(new List<SKBitmap>() { SKBitmap.Decode(bytes) }, SKCodec.Create(ms), name, emote["mime"].ToString().Split('/')[1], id, 2, bytes));
+                            returnList.Add(new TwitchEmote(new List<SKBitmap>() { SKBitmap.Decode(bytes) }, SKCodec.Create(ms), name, mime, id, 2, bytes));
                             alreadyAdded.Add(name);
                         }
                     }

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -532,7 +532,11 @@ namespace TwitchDownloaderCore
                     var emojis = archive.Entries.Where(x => Path.GetDirectoryName(x.FullName) == @"twemoji-13.1.0\assets\72x72" && !String.IsNullOrWhiteSpace(x.Name));
                     foreach (var emoji in emojis)
                     {
-                        emoji.ExtractToFile(Path.Combine(emojiFolder, emoji.Name));
+                        try
+                        {
+                            emoji.ExtractToFile(Path.Combine(emojiFolder, emoji.Name));
+                        }
+                        catch { }
                     }
                 }
             }

--- a/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
@@ -23,14 +23,20 @@ namespace TwitchDownloaderCore.TwitchObjects
             emote_frames = Emote_frames;
             codec = Codec;
             name = Name;
-            imageType = ImageType;
             id = Id;
             width = Emote_frames.First().Width;
             height = Emote_frames.First().Height;
             imageScale = ImageScale;
             imageData = ImageData;
 
-            if (imageType == "gif")
+            // If we are webp, with zero frame count then we are a static image
+            // Thus we should just treat it as a differnt imageType so we don't animate it
+            imageType = ImageType;
+            if (imageType == "webp" && Codec.FrameCount == 0)
+                imageType = "webp_static";
+
+            // Split animated image into a list of images
+            if (imageType == "gif" || imageType == "webp")
             {
                 emote_frames.Clear();
                 for (int i = 0; i < Codec.FrameCount; i++)


### PR DESCRIPTION
Add 7tv animated emote support for webp
Need to have special case for static webp when the frame count is 0.

Also made the cache folder use the correct file endings so it is easy to debug and see the animated files

Example files:
[7tv_chat_testing1.json.txt](https://github.com/lay295/TwitchDownloader/files/7214674/7tv_chat_testing1.json.txt)
[7tv_chat_testing2.json.txt](https://github.com/lay295/TwitchDownloader/files/7214675/7tv_chat_testing2.json.txt)