### PR TITLE
ffmpeg not required if RunMode is ChatDownload or ClipDownload

### DIFF
--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -45,7 +45,7 @@ namespace TwitchDownloaderCLI
                 Environment.Exit(1);
 
             
-            if (!File.Exists(ffmpegPath) && (inputOptions.FfmpegPath == null || !File.Exists(inputOptions.FfmpegPath)) && !ExistsOnPath(ffmpegPath) && (inputOptions.RunMode != RunMode.ChatDownload || inputOptions.RunMode != RunMode.ClipDownload))
+            if (!File.Exists(ffmpegPath) && (inputOptions.FfmpegPath == null || !File.Exists(inputOptions.FfmpegPath)) && !ExistsOnPath(ffmpegPath) && inputOptions.RunMode != RunMode.ChatDownload && inputOptions.RunMode != RunMode.ClipDownload)
             {
                 Console.WriteLine("[ERROR] - Unable to find ffmpeg, exiting. You can download ffmpeg automatically with the argument --download-ffmpeg");
                 Environment.Exit(1);


### PR DESCRIPTION
Previous conditional was always true

`(inputOptions.RunMode != RunMode.ChatDownload || inputOptions.RunMode != RunMode.ClipDownload)`

**Examples**
inputOptions.RunMode is RunMode.ChatDownload -> false || true = true

inputOptions.RunMode is RunMode.ClipDownload-> true || false = true

inputOptions.RunMode is RunMode.VideoDownload-> true || true = true