### PR TITLE
toggle disable on crop time boxes via checkbox 

### DIFF
--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -65,14 +65,14 @@
                 <ComboBox Name="comboQuality" Margin="5,10,0,0"/>
                 <StackPanel Margin="5,5,0,0">
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox x:Name="checkStart" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                        <CheckBox x:Name="checkStart" VerticalAlignment="Center" HorizontalAlignment="Left" Checked="checkStart_OnCheckStateChanged" Unchecked="checkStart_OnCheckStateChanged"/>
                         <TextBlock Text="Start" VerticalAlignment="Center" />
                         <xctk:IntegerUpDown Margin="3,-1,0,0" Value="0" Name="numStartHour" />
                         <xctk:IntegerUpDown Margin="3,-1,0,0" Value="0" Name="numStartMinute" />
                         <xctk:IntegerUpDown Margin="3,-1,0,0" Value="0" Name="numStartSecond" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                        <CheckBox x:Name="checkEnd" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                        <CheckBox x:Name="checkEnd" VerticalAlignment="Center" HorizontalAlignment="Left" Checked="checkEnd_OnCheckStateChanged" Unchecked="checkEnd_OnCheckStateChanged"/>
                         <TextBlock Text="End" VerticalAlignment="Center" Margin="0,0,5,0" />
                         <xctk:IntegerUpDown Margin="3,-1,0,0" Value="0" Name="numEndHour" />
                         <xctk:IntegerUpDown Margin="3,-1,0,0" Value="0" Name="numEndMinute" />

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -46,7 +46,7 @@ namespace TwitchDownloaderWPF
         public PageVodDownload()
         {
             InitializeComponent();
-            
+
         }
 
         private void SetEnabled(bool isEnabled)
@@ -54,14 +54,21 @@ namespace TwitchDownloaderWPF
             comboQuality.IsEnabled = isEnabled;
             checkStart.IsEnabled = isEnabled;
             checkEnd.IsEnabled = isEnabled;
+            btnDownload.IsEnabled = isEnabled;
+            btnQueue.IsEnabled = isEnabled;
+        }
+
+        private void SetEnabledCropStart(bool isEnabled)
+        {
             numStartHour.IsEnabled = isEnabled;
             numStartMinute.IsEnabled = isEnabled;
             numStartSecond.IsEnabled = isEnabled;
+        }
+        private void SetEnabledCropEnd(bool isEnabled)
+        {
             numEndHour.IsEnabled = isEnabled;
             numEndMinute.IsEnabled = isEnabled;
             numEndSecond.IsEnabled = isEnabled;
-            btnDownload.IsEnabled = isEnabled;
-            btnQueue.IsEnabled = isEnabled;
         }
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
@@ -318,6 +325,8 @@ namespace TwitchDownloaderWPF
         private void Page_Initialized(object sender, EventArgs e)
         {
             SetEnabled(false);
+            SetEnabledCropStart(false);
+            SetEnabledCropEnd(false);
             WebRequest.DefaultWebProxy = null;
             numDownloadThreads.Value = Settings.Default.VodDownloadThreads;
             textOauth.Text = Settings.Default.OAuth;
@@ -371,6 +380,34 @@ namespace TwitchDownloaderWPF
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void checkStart_OnCheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            bool isStart = (bool)checkStart.IsChecked;
+
+            if (isStart)
+            {
+                SetEnabledCropStart(true);
+            }
+            else
+            {
+                SetEnabledCropStart(false);
+            }
+        }
+
+        private void checkEnd_OnCheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            bool isEnd = (bool)checkEnd.IsChecked;
+
+            if (isEnd)
+            {
+                SetEnabledCropEnd(true);
+            }
+            else
+            {
+                SetEnabledCropEnd(false);
+            }
         }
     }
 }


### PR DESCRIPTION
If vod crop start/end checkbox is not enabled - the hour, minute, second time boxes are disabled.

Disabled:
![QG8toPZrux](https://user-images.githubusercontent.com/24389041/150574970-d2e54bbd-92e7-4530-b59c-13d415e75d4a.png)
Enabled:
![PgTLhgerCS](https://user-images.githubusercontent.com/24389041/150575048-c208ee89-6e22-45ef-8384-e6b33eb22d29.png)

