### PR TITLE
Moving the rest of projects to net6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,25 +113,25 @@ jobs:
     - name: Zip Windows CLI
       uses: vimtor/action-zip@v1
       with:
-        files: TwitchDownloaderCLI/bin/Release/netcoreapp3.1/publish/Windows/TwitchDownloaderCLI.exe
+        files: TwitchDownloaderCLI/bin/Release/net6.0/publish/Windows/TwitchDownloaderCLI.exe
         dest: TwitchDownloaderCLI-Windows-x64.zip
         
     - name: Zip Linux CLI
       uses: vimtor/action-zip@v1
       with:
-        files: TwitchDownloaderCLI/bin/Release/netcoreapp3.1/publish/Linux/TwitchDownloaderCLI
+        files: TwitchDownloaderCLI/bin/Release/net6.0/publish/Linux/TwitchDownloaderCLI
         dest: TwitchDownloaderCLI-Linux-x64.zip
         
     - name: Zip LinuxAlpine CLI
       uses: vimtor/action-zip@v1
       with:
-        files: TwitchDownloaderCLI/bin/Release/netcoreapp3.1/publish/LinuxAlpine/TwitchDownloaderCLI
+        files: TwitchDownloaderCLI/bin/Release/net6.0/publish/LinuxAlpine/TwitchDownloaderCLI
         dest: TwitchDownloaderCLI-LinuxAlpine-x64.zip
     
     - name: Zip LinuxArm CLI
       uses: vimtor/action-zip@v1
       with:
-        files: TwitchDownloaderCLI/bin/Release/netcoreapp3.1/publish/LinuxArm/TwitchDownloaderCLI
+        files: TwitchDownloaderCLI/bin/Release/net6.0/publish/LinuxArm/TwitchDownloaderCLI
         dest: TwitchDownloaderCLI-LinuxArm.zip
     
     - name: Download URL
@@ -202,7 +202,7 @@ jobs:
     - name: Zip Release
       uses: vimtor/action-zip@v1
       with:
-        files: TwitchDownloaderCLI/bin/Release/netcoreapp3.1/publish/MacOS/TwitchDownloaderCLI
+        files: TwitchDownloaderCLI/bin/Release/net6.0/publish/MacOS/TwitchDownloaderCLI
         dest: TwitchDownloaderCLI-MacOS-x64.zip
     
     - name: Download URL

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/Linux.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/Linux.pubxml
@@ -7,8 +7,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\Linux</PublishDir>
+    <TargetFramework>net6.0</TargetFramework>
+    <PublishDir>bin\Release\net6.0\publish\Linux</PublishDir>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/Linux.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/Linux.pubxml
@@ -13,5 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishTrimmed>True</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxAlpine.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxAlpine.pubxml
@@ -14,5 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>True</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxAlpine.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxAlpine.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\LinuxAlpine</PublishDir>
+    <PublishDir>bin\Release\net6.0\publish\LinuxAlpine</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifier>linux-musl-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxArm.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxArm.pubxml
@@ -13,5 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishTrimmed>True</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxArm.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/LinuxArm.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\LinuxArm</PublishDir>
+    <PublishDir>bin\Release\net6.0\publish\LinuxArm</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/MacOS.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/MacOS.pubxml
@@ -13,5 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishTrimmed>True</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/MacOS.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/MacOS.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\MacOS</PublishDir>
+    <PublishDir>bin\Release\net6.0\publish\MacOS</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/Windows.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/Windows.pubxml
@@ -14,5 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>True</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCLI/Properties/PublishProfiles/Windows.pubxml
+++ b/TwitchDownloaderCLI/Properties/PublishProfiles/Windows.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish\Windows</PublishDir>
+    <PublishDir>bin\Release\net6.0\publish\Windows</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TwitchDownloaderCLI/TwitchDownloaderCLI.csproj
+++ b/TwitchDownloaderCLI/TwitchDownloaderCLI.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>1.40.7</Version>
     <Platforms>AnyCPU;x64</Platforms>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchDownloaderCore/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/TwitchDownloaderCore/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,8 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\netstandard2.0\publish\</PublishDir>
+    <PublishDir>bin\Release\net6.0\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/TwitchDownloaderCore/TwitchDownloaderCore.csproj
+++ b/TwitchDownloaderCore/TwitchDownloaderCore.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RepositoryUrl>https://github.com/lay295/TwitchDownloader</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Lewis Pardo</Authors>
     <Version>1.1.6</Version>
     <Platforms>AnyCPU;x64</Platforms>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Or could leave `netstandard2.0` for `Core`.
But who uses net framework today for new projects.
And CLI is available cross-platform anyways.