### PR TITLE
Parallel chat downloads

### DIFF
--- a/TwitchDownloaderCLI/Options.cs
+++ b/TwitchDownloaderCLI/Options.cs
@@ -88,7 +88,7 @@ namespace TwitchDownloaderCLI
         public string FfmpegPath { get; set; }
         [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
         public string TempFolder { get; set; }
-        [Option("chat-threads", Default = 10, HelpText = "Number of download threads for chat")]
-        public int ChatThreadCount { get; set; }
+        [Option("chat-connections", Default = 10, HelpText = "Number of downloading connections for chat")]
+        public int ChatConnections { get; set; }
     }
 }

--- a/TwitchDownloaderCLI/Options.cs
+++ b/TwitchDownloaderCLI/Options.cs
@@ -88,5 +88,7 @@ namespace TwitchDownloaderCLI
         public string FfmpegPath { get; set; }
         [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
         public string TempFolder { get; set; }
+        [Option("chat-threads", Default = 10, HelpText = "Number of download threads for chat")]
+        public int ChatThreadCount { get; set; }
     }
 }

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -168,6 +168,7 @@ namespace TwitchDownloaderCLI
             downloadOptions.EmbedEmotes = inputOptions.EmbedEmotes;
             downloadOptions.Filename = inputOptions.OutputFile;
             downloadOptions.TimeFormat = inputOptions.TimeFormat;
+            downloadOptions.ThreadCount = inputOptions.ChatThreadCount;
 
             ChatDownloader chatDownloader = new ChatDownloader(downloadOptions);
             Progress<ProgressReport> progress = new Progress<ProgressReport>();

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -168,7 +168,7 @@ namespace TwitchDownloaderCLI
             downloadOptions.EmbedEmotes = inputOptions.EmbedEmotes;
             downloadOptions.Filename = inputOptions.OutputFile;
             downloadOptions.TimeFormat = inputOptions.TimeFormat;
-            downloadOptions.ThreadCount = inputOptions.ChatThreadCount;
+            downloadOptions.ConnectionCount = inputOptions.ChatConnections;
 
             ChatDownloader chatDownloader = new ChatDownloader(downloadOptions);
             Progress<ProgressReport> progress = new Progress<ProgressReport>();

--- a/TwitchDownloaderCLI/Properties/launchSettings.json
+++ b/TwitchDownloaderCLI/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "TwitchDownloaderCLI": {
-      "commandName": "Project",
-      "commandLineArgs": "-m ChatDownload -o data.json -u 1446299181"
+      "commandName": "Project"
     }
   }
 }

--- a/TwitchDownloaderCLI/Properties/launchSettings.json
+++ b/TwitchDownloaderCLI/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "TwitchDownloaderCLI": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "-m ChatDownload -o data.json -u 1446299181"
     }
   }
 }

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -67,7 +67,7 @@ Sets the timestamp format for .txt chat logs. Valid values are Utc, Relative, an
 **-\-embed-emotes**
 Embeds emotes into the JSON file so in the future when an emote is removed from Twitch or a 3rd party, it will still render correctly. Useful for archival purposes, file size will be larger.
 
-**-\-chat-threads**
+**-\-chat-connections**
 The number of parallel downloads for chat. Default 10.
 ## Arguments for mode ChatRender
 **-i/-\-input**

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -97,6 +97,7 @@ namespace TwitchDownloaderCore
             double videoStart = 0.0;
             double videoEnd = 0.0;
             double videoDuration = 0.0;
+            int threadCount = downloadOptions.ThreadCount;
 
             if (downloadType == DownloadType.Video)
             {
@@ -123,13 +124,12 @@ namespace TwitchDownloaderCore
                 chatRoot.streamer.id = int.Parse(taskInfo.data.clip.broadcaster.id);
                 videoStart = (int)taskInfo.data.clip.videoOffsetSeconds;
                 videoEnd = (int)taskInfo.data.clip.videoOffsetSeconds + taskInfo.data.clip.durationSeconds;
+                threadCount = 1;
             }
 
             chatRoot.video.start = videoStart;
             chatRoot.video.end = videoEnd;
             videoDuration = videoEnd - videoStart;
-
-            int threadCount = downloadOptions.ThreadCount;
 
             SortedSet<Comment> commentsSet = new SortedSet<Comment>(new SortedCommentComparer());
             List<Task> tasks = new List<Task>();
@@ -163,9 +163,10 @@ namespace TwitchDownloaderCore
                         progress.Report(new ProgressReport() { reportType = ReportType.Percent, data = percent });
                     }
                 });
-                double start = chunk * i;
+                double start = videoStart + chunk * i;
                 tasks.Add(DownloadSection(threadProgress, cancellationToken, start, start + chunk, videoId, commentsSet));
             }
+
             await Task.WhenAll(tasks);
 
             comments = commentsSet.ToList();

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -24,7 +24,7 @@ namespace TwitchDownloaderCore
             downloadOptions = DownloadOptions;
         }
 
-        public async Task DownloadAsync(IProgress<ProgressReport> progress, CancellationToken cancellationToken)
+        public async Task DownloadSection(IProgress<ProgressReport> progress, CancellationToken cancellationToken, double videoStart, double videoEnd, string videoId, SortedSet<Comment> comments)
         {
             using (WebClient client = new WebClient())
             {
@@ -32,51 +32,11 @@ namespace TwitchDownloaderCore
                 client.Headers.Add("Accept", "application/vnd.twitchtv.v5+json; charset=UTF-8");
                 client.Headers.Add("Client-Id", "kimne78kx3ncx6brgo4mv6wki5h1ko");
 
-                DownloadType downloadType = downloadOptions.Id.All(x => Char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
-                string videoId = "";
-
-                List<Comment> comments = new List<Comment>();
-                ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new VideoTime(), comments = comments };
-
-                double videoStart = 0.0;
-                double videoEnd = 0.0;
-                double videoDuration = 0.0;
-                int errorCount = 0;
-
-                if (downloadType == DownloadType.Video)
-                {
-                    videoId = downloadOptions.Id;
-                    GqlVideoResponse taskInfo = await TwitchHelper.GetVideoInfo(Int32.Parse(videoId));
-                    chatRoot.streamer.name = taskInfo.data.video.owner.displayName;
-                    chatRoot.streamer.id = int.Parse(taskInfo.data.video.owner.id);
-                    videoStart = downloadOptions.CropBeginning ? downloadOptions.CropBeginningTime : 0.0;
-                    videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : taskInfo.data.video.lengthSeconds;
-                }
-                else
-                {
-                    GqlClipResponse taskInfo = await TwitchHelper.GetClipInfo(downloadOptions.Id);
-
-                    if (taskInfo.data.clip.video == null || taskInfo.data.clip.videoOffsetSeconds == null)
-                        throw new Exception("Invalid VOD for clip, deleted/expired VOD possibly?");
-
-                    videoId = taskInfo.data.clip.video.id;
-                    downloadOptions.CropBeginning = true;
-                    downloadOptions.CropBeginningTime = (int)taskInfo.data.clip.videoOffsetSeconds;
-                    downloadOptions.CropEnding = true;
-                    downloadOptions.CropEndingTime = downloadOptions.CropBeginningTime + taskInfo.data.clip.durationSeconds;
-                    chatRoot.streamer.name = taskInfo.data.clip.broadcaster.displayName;
-                    chatRoot.streamer.id = int.Parse(taskInfo.data.clip.broadcaster.id);
-                    videoStart = (int)taskInfo.data.clip.videoOffsetSeconds;
-                    videoEnd = (int)taskInfo.data.clip.videoOffsetSeconds + taskInfo.data.clip.durationSeconds;
-                }
-
-                chatRoot.video.start = videoStart;
-                chatRoot.video.end = videoEnd;
-                videoDuration = videoEnd - videoStart;
-
+                double videoDuration = videoEnd - videoStart;
                 double latestMessage = videoStart - 1;
                 bool isFirst = true;
                 string cursor = "";
+                int errorCount = 0;
 
                 while (latestMessage < videoEnd)
                 {
@@ -117,7 +77,6 @@ namespace TwitchDownloaderCore
 
                     int percent = (int)Math.Floor((latestMessage - videoStart) / videoDuration * 100);
                     progress.Report(new ProgressReport() { reportType = ReportType.Percent, data = percent });
-                    progress.Report(new ProgressReport() { reportType = ReportType.MessageInfo, data = $"Downloading {percent}%" });
 
                     cancellationToken.ThrowIfCancellationRequested();
 
@@ -125,86 +84,178 @@ namespace TwitchDownloaderCore
                         isFirst = false;
 
                 }
+            }
+        }
+        public async Task DownloadAsync(IProgress<ProgressReport> progress, CancellationToken cancellationToken)
+        {
+            DownloadType downloadType = downloadOptions.Id.All(x => Char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
+            string videoId = "";
 
-                if (downloadOptions.EmbedEmotes && downloadOptions.IsJson)
-                {
-                    progress.Report(new ProgressReport() { reportType = ReportType.Message, data = "Downloading + Embedding Emotes" });
-                    chatRoot.emotes = new Emotes();
-                    List<FirstPartyEmoteData> firstParty = new List<FirstPartyEmoteData>();
-                    List<ThirdPartyEmoteData> thirdParty = new List<ThirdPartyEmoteData>();
+            List<Comment> comments = new List<Comment>();
+            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new VideoTime(), comments = comments };
 
-                    string cacheFolder = Path.Combine(Path.GetTempPath(), "TwitchDownloader", "cache");
-                    List<TwitchEmote> thirdPartyEmotes = new List<TwitchEmote>();
-                    List<TwitchEmote> firstPartyEmotes = new List<TwitchEmote>();
+            double videoStart = 0.0;
+            double videoEnd = 0.0;
+            double videoDuration = 0.0;
 
-                    await Task.Run(() => {
-                        thirdPartyEmotes = TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder);
-                        firstPartyEmotes = TwitchHelper.GetEmotes(comments, cacheFolder).ToList();
-                    });
+            if (downloadType == DownloadType.Video)
+            {
+                videoId = downloadOptions.Id;
+                GqlVideoResponse taskInfo = await TwitchHelper.GetVideoInfo(Int32.Parse(videoId));
+                chatRoot.streamer.name = taskInfo.data.video.owner.displayName;
+                chatRoot.streamer.id = int.Parse(taskInfo.data.video.owner.id);
+                videoStart = downloadOptions.CropBeginning ? downloadOptions.CropBeginningTime : 0.0;
+                videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : taskInfo.data.video.lengthSeconds;
+            }
+            else
+            {
+                GqlClipResponse taskInfo = await TwitchHelper.GetClipInfo(downloadOptions.Id);
 
-                    foreach (TwitchEmote emote in thirdPartyEmotes)
+                if (taskInfo.data.clip.video == null || taskInfo.data.clip.videoOffsetSeconds == null)
+                    throw new Exception("Invalid VOD for clip, deleted/expired VOD possibly?");
+
+                videoId = taskInfo.data.clip.video.id;
+                downloadOptions.CropBeginning = true;
+                downloadOptions.CropBeginningTime = (int)taskInfo.data.clip.videoOffsetSeconds;
+                downloadOptions.CropEnding = true;
+                downloadOptions.CropEndingTime = downloadOptions.CropBeginningTime + taskInfo.data.clip.durationSeconds;
+                chatRoot.streamer.name = taskInfo.data.clip.broadcaster.displayName;
+                chatRoot.streamer.id = int.Parse(taskInfo.data.clip.broadcaster.id);
+                videoStart = (int)taskInfo.data.clip.videoOffsetSeconds;
+                videoEnd = (int)taskInfo.data.clip.videoOffsetSeconds + taskInfo.data.clip.durationSeconds;
+            }
+
+            chatRoot.video.start = videoStart;
+            chatRoot.video.end = videoEnd;
+            videoDuration = videoEnd - videoStart;
+
+            int threadCount = downloadOptions.ThreadCount;
+
+            SortedSet<Comment> commentsSet = new SortedSet<Comment>(new SortedCommentComparer());
+            List<Task> tasks = new List<Task>();
+            List<int> percentages = new List<int>(threadCount);
+
+            double chunk = videoDuration / threadCount;
+            for (int i=0;i<threadCount;i++)
+            {
+                int tc = i;
+                percentages.Add(0);
+                var threadProgress = new Progress<ProgressReport>(progressReport => {
+                    if (progressReport.reportType != ReportType.Percent)
                     {
-                        ThirdPartyEmoteData newEmote = new ThirdPartyEmoteData();
-                        newEmote.id = emote.id;
-                        newEmote.imageScale = emote.imageScale;
-                        newEmote.data = emote.imageData;
-                        newEmote.name = emote.name;
-                        thirdParty.Add(newEmote);
+                        progress.Report(progressReport);
                     }
-                    foreach (TwitchEmote emote in firstPartyEmotes)
+                    else
                     {
-                        FirstPartyEmoteData newEmote = new FirstPartyEmoteData();
-                        newEmote.id = emote.id;
-                        newEmote.imageScale = 1;
-                        newEmote.data = emote.imageData;
-                        firstParty.Add(newEmote);
-                    }
-
-                    chatRoot.emotes.thirdParty = thirdParty;
-                    chatRoot.emotes.firstParty = firstParty;
-                }
-
-                if (downloadOptions.IsJson)
-                {
-                    using (TextWriter writer = File.CreateText(downloadOptions.Filename))
-                    {
-                        var serializer = new JsonSerializer();
-                        serializer.Serialize(writer, chatRoot);
-                    }
-                }
-                else
-                {
-                    using (StreamWriter sw = new StreamWriter(downloadOptions.Filename))
-                    {
-                        foreach (var comment in chatRoot.comments)
+                        int percent = (int)(progressReport.data);
+                        if (percent > 100)
                         {
-                            string username = comment.commenter.display_name;
-                            string message = comment.message.body;
-                            if (downloadOptions.TimeFormat == TimestampFormat.Utc)
-                            {
-                                string timestamp = comment.created_at.ToString("u").Replace("Z", " UTC");
-                                sw.WriteLine(String.Format("[{0}] {1}: {2}", timestamp, username, message));
-                            }
-                            else if (downloadOptions.TimeFormat == TimestampFormat.Relative)
-                            {
-                                TimeSpan time = new TimeSpan(0, 0, (int)comment.content_offset_seconds);
-                                string timestamp = time.ToString(@"h\:mm\:ss");
-                                sw.WriteLine(String.Format("[{0}] {1}: {2}", timestamp, username, message));
-                            }
-                            else if (downloadOptions.TimeFormat == TimestampFormat.None)
-                            {
-                                sw.WriteLine(String.Format("{0}: {1}", username, message));
-                            }
+                            percent = 100;
                         }
 
-                        sw.Flush();
-                        sw.Close();
+                        percentages[tc] = percent;
+
+                        percent = 0;
+                        percentages.ForEach(p => percent += p);
+                        percent = percent / threadCount;
+
+                        progress.Report(new ProgressReport() { reportType = ReportType.MessageInfo, data = $"Downloading {percent}%" });
+                        progress.Report(new ProgressReport() { reportType = ReportType.Percent, data = percent });
                     }
-                }
-                
-                chatRoot = null;
-                GC.Collect();
+                });
+                double start = chunk * i;
+                tasks.Add(DownloadSection(threadProgress, cancellationToken, start, start + chunk, videoId, commentsSet));
             }
+            await Task.WhenAll(tasks);
+
+            comments = commentsSet.ToList();
+            chatRoot.comments = comments;
+
+            if (downloadOptions.EmbedEmotes && downloadOptions.IsJson)
+            {
+                progress.Report(new ProgressReport() { reportType = ReportType.Message, data = "Downloading + Embedding Emotes" });
+                chatRoot.emotes = new Emotes();
+                List<FirstPartyEmoteData> firstParty = new List<FirstPartyEmoteData>();
+                List<ThirdPartyEmoteData> thirdParty = new List<ThirdPartyEmoteData>();
+
+                string cacheFolder = Path.Combine(Path.GetTempPath(), "TwitchDownloader", "cache");
+                List<TwitchEmote> thirdPartyEmotes = new List<TwitchEmote>();
+                List<TwitchEmote> firstPartyEmotes = new List<TwitchEmote>();
+
+                await Task.Run(() => {
+                    thirdPartyEmotes = TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder);
+                    firstPartyEmotes = TwitchHelper.GetEmotes(comments, cacheFolder).ToList();
+                });
+
+                foreach (TwitchEmote emote in thirdPartyEmotes)
+                {
+                    ThirdPartyEmoteData newEmote = new ThirdPartyEmoteData();
+                    newEmote.id = emote.id;
+                    newEmote.imageScale = emote.imageScale;
+                    newEmote.data = emote.imageData;
+                    newEmote.name = emote.name;
+                    thirdParty.Add(newEmote);
+                }
+                foreach (TwitchEmote emote in firstPartyEmotes)
+                {
+                    FirstPartyEmoteData newEmote = new FirstPartyEmoteData();
+                    newEmote.id = emote.id;
+                    newEmote.imageScale = 1;
+                    newEmote.data = emote.imageData;
+                    firstParty.Add(newEmote);
+                }
+
+                chatRoot.emotes.thirdParty = thirdParty;
+                chatRoot.emotes.firstParty = firstParty;
+            }
+
+            if (downloadOptions.IsJson)
+            {
+                using (TextWriter writer = File.CreateText(downloadOptions.Filename))
+                {
+                    var serializer = new JsonSerializer();
+                    serializer.Serialize(writer, chatRoot);
+                }
+            }
+            else
+            {
+                using (StreamWriter sw = new StreamWriter(downloadOptions.Filename))
+                {
+                    foreach (var comment in chatRoot.comments)
+                    {
+                        string username = comment.commenter.display_name;
+                        string message = comment.message.body;
+                        if (downloadOptions.TimeFormat == TimestampFormat.Utc)
+                        {
+                            string timestamp = comment.created_at.ToString("u").Replace("Z", " UTC");
+                            sw.WriteLine(String.Format("[{0}] {1}: {2}", timestamp, username, message));
+                        }
+                        else if (downloadOptions.TimeFormat == TimestampFormat.Relative)
+                        {
+                            TimeSpan time = new TimeSpan(0, 0, (int)comment.content_offset_seconds);
+                            string timestamp = time.ToString(@"h\:mm\:ss");
+                            sw.WriteLine(String.Format("[{0}] {1}: {2}", timestamp, username, message));
+                        }
+                        else if (downloadOptions.TimeFormat == TimestampFormat.None)
+                        {
+                            sw.WriteLine(String.Format("{0}: {1}", username, message));
+                        }
+                    }
+
+                    sw.Flush();
+                    sw.Close();
+                }
+            }
+                
+            chatRoot = null;
+            GC.Collect();
+        }
+    }
+    internal class SortedCommentComparer : IComparer<Comment>
+    {
+        public int Compare(Comment x, Comment y)
+        {
+            return x.content_offset_seconds.CompareTo(y.content_offset_seconds);
         }
     }
 }

--- a/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
@@ -16,6 +16,8 @@ namespace TwitchDownloaderCore.Options
         public double CropEndingTime { get; set; }
         public bool Timestamp { get; set; }
         public bool EmbedEmotes { get; set; }
+
+        public int ThreadCount { get; set; }
         public TimestampFormat TimeFormat { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
@@ -17,7 +17,7 @@ namespace TwitchDownloaderCore.Options
         public bool Timestamp { get; set; }
         public bool EmbedEmotes { get; set; }
 
-        public int ThreadCount { get; set; }
+        public int ConnectionCount { get; set; }
         public TimestampFormat TimeFormat { get; set; }
     }
 }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -58,7 +58,7 @@
                 <TextBlock Visibility="Collapsed" x:Name="timeText" Text="Timestamp Format:" HorizontalAlignment="Right" Margin="0,10,0,0"/>
                 <TextBlock Text="Crop Chat:" HorizontalAlignment="Right" Margin="0,10,0,0"/>
                 <TextBlock HorizontalAlignment="Right" Margin="0,29,0,0">Embed Emotes <Hyperlink ToolTipService.ShowDuration="30000"><Hyperlink.ToolTip>Embeds emotes into the JSON file so in the future when an emote is removed from Twitch or a 3rd party, it will still render correctly. Useful for archival purposes, file size will be larger.</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
-                <TextBlock Text="Download Threads:" Margin="0,6,0,0"/>
+                <TextBlock Text="Connections:" Margin="0,6,0,0"/>
             </StackPanel>
             <StackPanel>
                 <StackPanel Margin="5,12,0,0" Orientation="Horizontal">
@@ -87,7 +87,7 @@
                     </StackPanel>
                 </StackPanel>
                 <CheckBox x:Name="checkEmbed" Margin="5,8,0,0"></CheckBox>
-                <xctk:IntegerUpDown Margin="2,5,0,0" Value="10" Width="40" x:Name="numChatDownloadThreads" HorizontalAlignment="Left" ValueChanged="numChatDownloadThreads_ValueChanged" />
+                <xctk:IntegerUpDown Margin="2,5,0,0" Value="10" Width="40" x:Name="numChatDownloadConnections" HorizontalAlignment="Left" ValueChanged="numChatDownloadconnections_ValueChanged" />
             </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" Margin="80,0,20,10" VerticalAlignment="Bottom">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -58,6 +58,7 @@
                 <TextBlock Visibility="Collapsed" x:Name="timeText" Text="Timestamp Format:" HorizontalAlignment="Right" Margin="0,10,0,0"/>
                 <TextBlock Text="Crop Chat:" HorizontalAlignment="Right" Margin="0,10,0,0"/>
                 <TextBlock HorizontalAlignment="Right" Margin="0,29,0,0">Embed Emotes <Hyperlink ToolTipService.ShowDuration="30000"><Hyperlink.ToolTip>Embeds emotes into the JSON file so in the future when an emote is removed from Twitch or a 3rd party, it will still render correctly. Useful for archival purposes, file size will be larger.</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                <TextBlock Text="Download Threads:" Margin="0,6,0,0"/>
             </StackPanel>
             <StackPanel>
                 <StackPanel Margin="5,12,0,0" Orientation="Horizontal">
@@ -86,6 +87,7 @@
                     </StackPanel>
                 </StackPanel>
                 <CheckBox x:Name="checkEmbed" Margin="5,8,0,0"></CheckBox>
+                <xctk:IntegerUpDown Margin="2,5,0,0" Value="10" Width="40" x:Name="numChatDownloadThreads" HorizontalAlignment="Left" ValueChanged="numChatDownloadThreads_ValueChanged" />
             </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" Margin="80,0,20,10" VerticalAlignment="Bottom">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -87,7 +87,7 @@
                     </StackPanel>
                 </StackPanel>
                 <CheckBox x:Name="checkEmbed" Margin="5,8,0,0"></CheckBox>
-                <xctk:IntegerUpDown Margin="2,5,0,0" Value="10" Width="40" x:Name="numChatDownloadConnections" HorizontalAlignment="Left" ValueChanged="numChatDownloadconnections_ValueChanged" />
+                <xctk:IntegerUpDown Margin="2,5,0,0" Value="10" Width="40" x:Name="numChatDownloadConnections" HorizontalAlignment="Left" ValueChanged="numChatDownloadConnections_ValueChanged" />
             </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" Margin="80,0,20,10" VerticalAlignment="Bottom">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -272,6 +272,7 @@ namespace TwitchDownloaderWPF
             options.Timestamp = true;
             options.EmbedEmotes = (bool)checkEmbed.IsChecked;
             options.Filename = filename;
+            options.ThreadCount = (int)numChatDownloadThreads.Value;
             return options;
         }
 
@@ -335,6 +336,10 @@ namespace TwitchDownloaderWPF
         {
             WindowQueueOptions queueOptions = new WindowQueueOptions(this);
             queueOptions.ShowDialog();
+        }
+        private void numChatDownloadThreads_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            numChatDownloadThreads.Value = Math.Clamp((int)numChatDownloadThreads.Value, 1, 50);
         }
     }
 }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -272,7 +272,7 @@ namespace TwitchDownloaderWPF
             options.Timestamp = true;
             options.EmbedEmotes = (bool)checkEmbed.IsChecked;
             options.Filename = filename;
-            options.ThreadCount = (int)numChatDownloadThreads.Value;
+            options.ConnectionCount = (int)numChatDownloadConnections.Value;
             return options;
         }
 
@@ -337,9 +337,9 @@ namespace TwitchDownloaderWPF
             WindowQueueOptions queueOptions = new WindowQueueOptions(this);
             queueOptions.ShowDialog();
         }
-        private void numChatDownloadThreads_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        private void numChatDownloadConnections_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
-            numChatDownloadThreads.Value = Math.Clamp((int)numChatDownloadThreads.Value, 1, 50);
+            numChatDownloadConnections.Value = Math.Clamp((int)numChatDownloadConnections.Value, 1, 50);
         }
     }
 }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -337,6 +337,7 @@ namespace TwitchDownloaderWPF
             WindowQueueOptions queueOptions = new WindowQueueOptions(this);
             queueOptions.ShowDialog();
         }
+
         private void numChatDownloadConnections_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
             numChatDownloadConnections.Value = Math.Clamp((int)numChatDownloadConnections.Value, 1, 50);


### PR DESCRIPTION
Fixes #202

Implements an asynchronous chat fetcher. Defaults to 10 parallel connections, limited it to 50 for rate limiting. The default and max can be changed.

A benchmark on the first hour of 1446466302:

Task no.|Speed|Time
-|-|-
1|~1.3 Mbps|3m31s
10|~12 Mbps|25s
50|~36 Mbps|10s

Final percentages can be slower due to rate limiting kicking in.