### PR TITLE
Fix CLI arguments

### DIFF
--- a/TwitchDownloaderCLI/Options.cs
+++ b/TwitchDownloaderCLI/Options.cs
@@ -34,11 +34,11 @@ namespace TwitchDownloaderCLI
         public int DownloadThreads { get; set; }
         [Option("oauth", HelpText = "OAuth to be passed when downloading a VOD.")]
         public string Oauth { get; set; }
-        [Option("timestamp", HelpText = "Enable timestamp in chat render.")]
+        [Option("timestamp", Default = false, HelpText = "Enable timestamp in chat render.")]
         public bool Timestamp { get; set; }
         [Option("timestamp-format", HelpText = "Sets the timestamp format for .txt chat logs. Valid values are Utc, Relative, and None", Default = TimestampFormat.Relative)]
         public TimestampFormat TimeFormat { get; set; }
-        [Option("embed-emotes", HelpText = "Embed emotes into chat download.")]
+        [Option("embed-emotes", Default = false, HelpText = "Embed 1st and 3rd party emotes into chat download.")]
         public bool EmbedEmotes { get; set; }
         [Option("background-color", Default = "#111111", HelpText = "Color of background for chat render.")]
         public string BackgroundColor { get; set; }
@@ -48,17 +48,17 @@ namespace TwitchDownloaderCLI
         public int ChatHeight { get; set; }
         [Option('w', "chat-width", Default = 350, HelpText = "Width of chat render.")]
         public int ChatWidth { get; set; }
-        [Option("bttv", Default = true, HelpText = "Enable BTTV emotes in chat render.")]
+        [Option("no-bttv", Default = false, HelpText = "Disable BTTV emotes in chat render.")]
         public bool BttvEmotes { get; set; }
-        [Option("ffz", Default = true, HelpText = "Enable FFZ emotes in chat render.")]
+        [Option("no-ffz", Default = false, HelpText = "Disable FFZ emotes in chat render.")]
         public bool FfzEmotes { get; set; }
-        [Option("stv", Default = true, HelpText = "Enable 7tv emotes in chat render.")]
+        [Option("no-stv", Default = false, HelpText = "Disable 7tv emotes in chat render.")]
         public bool StvEmotes { get; set; }
         [Option("outline", Default = false, HelpText = "Enable outline in chat render.")]
         public bool Outline { get; set; }
-        [Option("sub-messages", Default = true, HelpText = "Enable sub messages.")]
+        [Option("no-badges", Default = false, HelpText = "Disable chat badges.")]
         public bool ChatBadges { get; set; }
-        [Option("badges", Default = true, HelpText = "Enable chat badges.")]
+        [Option("no-sub-messages", Default = false, HelpText = "Disable sub messages.")]
         public bool SubMessages { get; set; }
         [Option("generate-mask", Default = false, HelpText = "Generates a mask file in addition to the regular chat file.")]
         public bool GenerateMask { get; set; }

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -186,9 +186,9 @@ namespace TwitchDownloaderCLI
             renderOptions.MessageColor = SKColor.Parse(inputOptions.MessageColor);
             renderOptions.ChatHeight = inputOptions.ChatHeight;
             renderOptions.ChatWidth = inputOptions.ChatWidth;
-            renderOptions.BttvEmotes = inputOptions.BttvEmotes;
-            renderOptions.FfzEmotes = inputOptions.FfzEmotes;
-            renderOptions.StvEmotes = inputOptions.StvEmotes;
+            renderOptions.BttvEmotes = !inputOptions.BttvEmotes; // Inverted to fix boolean argument
+            renderOptions.FfzEmotes = !inputOptions.FfzEmotes; // Inverted to fix boolean argument
+            renderOptions.StvEmotes = !inputOptions.StvEmotes; // Inverted to fix boolean argument
             renderOptions.Outline = inputOptions.Outline;
             renderOptions.OutlineSize = inputOptions.OutlineSize;
             renderOptions.Font = inputOptions.Font;
@@ -227,8 +227,8 @@ namespace TwitchDownloaderCLI
             renderOptions.OutputArgs = inputOptions.OutputArgs;
             renderOptions.FfmpegPath = inputOptions.FfmpegPath == null || inputOptions.FfmpegPath == "" ? ffmpegPath : Path.GetFullPath(inputOptions.FfmpegPath);
             renderOptions.TempFolder = inputOptions.TempFolder;
-            renderOptions.SubMessages = inputOptions.SubMessages;
-            renderOptions.ChatBadges = inputOptions.ChatBadges;
+            renderOptions.SubMessages = !inputOptions.SubMessages; // Inverted to fix boolean argument
+            renderOptions.ChatBadges = !inputOptions.ChatBadges; // Inverted to fix boolean argument
 
             if (renderOptions.GenerateMask && renderOptions.BackgroundColor.Alpha == 255)
             {

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -85,20 +85,20 @@ Path to JSON chat file input.
 **-w/-\-chat-width**
 (Default: 350) Width of chat render.
 
-**-\-bttv**
-(Default: true) Enable BTTV emotes.
+**-\-no-bttv**
+(Default: false) Disable BTTV emotes.
 
-**-\-ffz**
-(Default: true) Enable FFZ emotes.
+**-\-no-ffz**
+(Default: false) Disable FFZ emotes.
 
-**-\-stv**
-(Default: true) Enable 7TV emotes.
+**-\-no-stv**
+(Default: false) Disable 7TV emotes.
 
-**-\-sub-messages**
-(Default: true) Enable sub/re-sub messages.
+**-\-no-sub-messages**
+(Default: false) Disable sub/re-sub messages.
 
-**-\-badges**
-(Default: true) Enable chat badges.
+**-\-no-badges**
+(Default: false) Disable chat badges.
 
 **-\-outline**
 (Default: false) Enable outline around chat messages.


### PR DESCRIPTION
CommandLineParser only supports raising boolean flags, so if the default is `true` then it can never be set to `false`.

`sub-messages` and `chat-badges` were also accidentally swapped during the last refactor.