### PR TITLE
User provided video quality is no longer required to match the available video qualities exactly

### DIFF
--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -59,8 +59,8 @@ namespace TwitchDownloaderCore
                         }
                     }
 
-                    if (videoQualities.Any(x => x.Key.Equals(downloadOptions.Quality)))
-                        playlistUrl = videoQualities.Where(x => x.Key.Equals(downloadOptions.Quality)).First().Value;
+                    if (videoQualities.Any(x => x.Key.StartsWith(downloadOptions.Quality)))
+                        playlistUrl = videoQualities.Where(x => x.Key.StartsWith(downloadOptions.Quality)).First().Value;
                     else
                     {
                         //Unable to find specified quality, defaulting to highest quality


### PR DESCRIPTION
This ensures that, for instance, -q "360p" also works when only "360p30" is available.

I don't know if Twitch introduced the "p30" options recently, but I believe it is easier for CLI users if they only have to provide "360p" instead of looking up whether the available quality is "360p" or "360p30". This also avoids the fallback to the highest quality. 

Example VODS:
https://www.twitch.tv/videos/1625525138
Provides only "___p30" options.

https://www.twitch.tv/videos/1631016426
Provides the regular "___p" options.