### PR TITLE
Fix #397 so any extension not .json or .html is txt

### DIFF
--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -153,7 +153,7 @@ namespace TwitchDownloaderCLI
                 Environment.Exit(1);
             }
             
-            //If output file doesn't end in .txt, assume JSON
+            //If output file doesn't end in .json or.html, assume text
             if (Path.GetFileName(inputOptions.OutputFile).Contains('.'))
             {
                 string extension = Path.GetFileName(inputOptions.OutputFile).Split('.').Last();
@@ -161,6 +161,8 @@ namespace TwitchDownloaderCLI
                     downloadOptions.DownloadFormat = DownloadFormat.Json;
                 else if (extension.ToLower() == "html")
                     downloadOptions.DownloadFormat = DownloadFormat.Html;
+                else
+                    downloadOptions.DownloadFormat = DownloadFormat.Text;
             }
             else
             {

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -154,20 +154,13 @@ namespace TwitchDownloaderCLI
             }
             
             //If output file doesn't end in .json or.html, assume text
-            if (Path.GetFileName(inputOptions.OutputFile).Contains('.'))
+            string extension = Path.GetExtension(inputOptions.OutputFile).ToLower();
+            downloadOptions.DownloadFormat = extension switch
             {
-                string extension = Path.GetFileName(inputOptions.OutputFile).Split('.').Last();
-                if (extension.ToLower() == "json")
-                    downloadOptions.DownloadFormat = DownloadFormat.Json;
-                else if (extension.ToLower() == "html")
-                    downloadOptions.DownloadFormat = DownloadFormat.Html;
-                else
-                    downloadOptions.DownloadFormat = DownloadFormat.Text;
-            }
-            else
-            {
-                downloadOptions.DownloadFormat = DownloadFormat.Text;
-            }
+            	".json" => DownloadFormat.Json,
+            	".html" => DownloadFormat.Html,
+            	_ => DownloadFormat.Text
+            };
 
             downloadOptions.Id = inputOptions.Id;
             downloadOptions.CropBeginning = inputOptions.CropBeginningTime == 0.0 ? false : true;


### PR DESCRIPTION
Fixing code for extension which is not .json or .html to assume it is plain text as currently it only makes it plain text if no extension. It does not set output format if it has an extension but it is not json or html.