### PR TITLE
Readme and license updates

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,21 @@
-Copyright 2020 lay295
+The MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2019-2022 lay295
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ sudo chmod +x TwitchDownloaderCLI
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-5. If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
 ```
 sudo chmod +x ffmpeg
 ```
-6. You can now start using the downloader, for example:
+5. You can now start using the downloader, for example:
 ```
 ./TwitchDownloaderCLI -m VideoDownload --id <vod-id-here> -o out.mp4
 ```
@@ -94,11 +94,11 @@ chmod +x TwitchDownloaderCLI
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-5. If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
 ```
 chmod +x ffmpeg
 ```
-6. You can now start using the downloader, for example:
+5. You can now start using the downloader, for example:
 ```
 ./TwitchDownloaderCLI -m VideoDownload --id <vod-id-here> -o out.mp4
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ No GUI is avaiable for MacOS yet :(
 
 The CLI is cross platform and performs the main functions of the program. It works on Windows, Linux, and MacOS.*
 
-*As of 1.50.5, only Intel Macs have been tested
+*As of 1.50.5, only `VideoDownload`, `ClipDownload`, and `ChatDownload` **without embeded emotes** are known to work on MacOS. Only Intel Macs have been tested
 
 ### [CLI Documentation here](TwitchDownloaderCLI/README.md). 
 
@@ -69,11 +69,11 @@ TwitchDownloaderCLI -m ChatRender -i %vodid%_chat.json -h 1080 -w 422 --framerat
 ```
 sudo chmod +x TwitchDownloaderCLI
 ```
-4. If you do not have ffmpeg, you can download it from [ffmpeg.org](https://ffmpeg.org/download.html) or by using the downloader:
+4. If you do not have ffmpeg, you should install it via your distro package manager, however you can also get it as a standalone file from [ffmpeg.org](https://ffmpeg.org/download.html) or by using TwitchDownloaderCLI:
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-If downloaded via TwitchDownloaderCLI, you must also give it executable rights with:
+If downloaded as a standalone file, you must also give it executable rights with:
 ```
 sudo chmod +x ffmpeg
 ```
@@ -90,11 +90,11 @@ For Arch Linux, there's an [AUR Package](https://aur.archlinux.org/packages/twit
 ```
 chmod +x TwitchDownloaderCLI
 ```
-4. If you do not have ffmpeg, you can download it from [ffmpeg.org](https://ffmpeg.org/download.html) or by using the downloader:
+1. If you do not have ffmpeg, you can install it via [Homebrew package manager](https://brew.sh/), or you can get it as a standalone file from [ffmpeg.org](https://ffmpeg.org/download.html) or by using TwitchDownloaderCLI:
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-If downloaded via TwitchDownloaderCLI, you must also give it executable rights with:
+If downloaded as a standalone file, you must also give it executable rights with:
 ```
 chmod +x ffmpeg
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://www.youtube.com/watch?v=0W3MhfhnYjk
 
 ## Linux?
 
-Check [twitch-downloader-gui](https://github.com/mohad12211/twitch-downloader-gui) for a linux GUI wrapper for the CLI.
+Check twitch-downloader-gui on [github](https://github.com/mohad12211/twitch-downloader-gui) or on the [AUR](https://aur.archlinux.org/packages/twitch-downloader-gui) for a Linux GUI wrapper for the CLI.
 
 ## MacOS?
 
@@ -44,9 +44,9 @@ No GUI is avaiable for MacOS yet :(
 
 # CLI
 
-The CLI is cross platform and performs the main functions of the program. It works on Windows and Linux, but has not been tested on MacOS. 
+The CLI is cross platform and performs the main functions of the program. It works on Windows Linux, and MacOS. Currently, only Intel Macs have been tested.
 
-[Documentation here](TwitchDownloaderCLI/README.md). 
+### [CLI Documentation here](TwitchDownloaderCLI/README.md). 
 
 I've never really made a command line utility before so things may change in the future. If you're on Linux, make sure `fontconfig` and `libfontconfig1` are installed `(apt-get install fontconfig libfontconfig1)`.
 
@@ -67,8 +67,40 @@ TwitchDownloaderCLI -m ChatRender -i %vodid%_chat.json -h 1080 -w 422 --framerat
 ```
 sudo chmod +x TwitchDownloaderCLI
 ```
-4. You can now start using the downloader, for example:
+4. If you do not have ffmpeg, you can download it from [ffmpeg.org](https://ffmpeg.org/download.html) or by using the downloader:
+```
+./TwitchDownloaderCLI --download-ffmpeg
+```
+5. If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+```
+sudo chmod +x ffmpeg
+```
+6. You can now start using the downloader, for example:
 ```
 ./TwitchDownloaderCLI -m VideoDownload --id <vod-id-here> -o out.mp4
 ```
 For Arch Linux, there's an [AUR Package](https://aur.archlinux.org/packages/twitch-downloader-bin/)
+
+### MacOS – Getting started
+1. Go to [Releases](https://github.com/lay295/TwitchDownloader/releases/) and download the latest version for MacOS.
+2. Extract `TwitchDownloaderCLI`
+3. Browse to where you extracted the file and give it executable rights in Terminal:
+```
+chmod +x TwitchDownloaderCLI
+```
+4. If you do not have ffmpeg, you can download it from [ffmpeg.org](https://ffmpeg.org/download.html) or by using the downloader:
+```
+./TwitchDownloaderCLI --download-ffmpeg
+```
+5. If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+```
+chmod +x ffmpeg
+```
+6. You can now start using the downloader, for example:
+```
+./TwitchDownloaderCLI -m VideoDownload --id <vod-id-here> -o out.mp4
+```
+
+# License
+
+[MIT](./LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ No GUI is avaiable for MacOS yet :(
 
 # CLI
 
-The CLI is cross platform and performs the main functions of the program. It works on Windows Linux, and MacOS. Currently, only Intel Macs have been tested.
+The CLI is cross platform and performs the main functions of the program. It works on Windows, Linux, and MacOS.*
+
+*As of 1.50.5, only Intel Macs have been tested
 
 ### [CLI Documentation here](TwitchDownloaderCLI/README.md). 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sudo chmod +x TwitchDownloaderCLI
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+If downloaded via TwitchDownloaderCLI, you must also give it executable rights with:
 ```
 sudo chmod +x ffmpeg
 ```
@@ -94,7 +94,7 @@ chmod +x TwitchDownloaderCLI
 ```
 ./TwitchDownloaderCLI --download-ffmpeg
 ```
-If not downloaded from [ffmpeg.org](https://ffmpeg.org/download.html), you must also give it executable rights with:
+If downloaded via TwitchDownloaderCLI, you must also give it executable rights with:
 ```
 chmod +x ffmpeg
 ```

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -1,5 +1,5 @@
 
-### TwitchDownloaderCLI
+# TwitchDownloaderCLI
 A cross platform command line tool that can do the main functions of the GUI program, which can download VODs/Clips/Chats and render chats.
 
  - [Global Arguments](#global-arguments)
@@ -29,6 +29,7 @@ Path to temporary folder for cache.
 **-\-clear-cache**
 Clears the default cache folder.
 
+
 ## Arguments for mode VideoDownload
 **-u/-\-id**
 The ID of the VOD to download, currently only accepts Integer IDs and will accept URLs in the future.
@@ -48,12 +49,16 @@ Extra example, if I wanted only seconds 3-6 in a 10 second stream I would do `-b
 
 **-\-oauth**
 OAuth to be passed when downloading a VOD. Used when downloading sub only VODs.
+
+
 ## Arguments for mode ClipDownload
 **-u/-\-id**
 The ID of the Clip to download, currently only accepts the string identifier and will accept URLs in the future.
 
 **-q/-\-quality**
 The quality the program will attempt to download, for example "1080p60", if not found will download highest quality video.
+
+
 ## Arguments for mode ChatDownload
 **IMPORTANT NOTE**: If output file argument does not end in .json or .html it will download it as a plain text file
 
@@ -73,16 +78,18 @@ Time in seconds to crop ending. For example if I had a 10 second stream but only
 (Default: false) Embeds emotes into the JSON file so in the future when an emote is removed from Twitch or a 3rd party, it will still render correctly. Useful for archival purposes, file size will be larger.
 
 **-\-bttv**
-(Default: true) BTTV emote embedding. Requires `-\-embed-emotes`.
+(Default: true) BTTV emote embedding. Requires `--embed-emotes`.
 
 **-\-ffz**
-(Default: true) FFZ emote embedding. Requires `-\-embed-emotes`.
+(Default: true) FFZ emote embedding. Requires `--embed-emotes`.
 
 **-\-stv**
-(Default: true) 7TV emote embedding. Requires `-\-embed-emotes`.
+(Default: true) 7TV emote embedding. Requires `--embed-emotes`.
 
 **-\-chat-connections**
 (Default: 4) The number of parallel downloads for chat.
+
+
 ## Arguments for mode ChatRender
 **-i/-\-input**
 Path to JSON chat file input.
@@ -156,14 +163,15 @@ Path to JSON chat file input.
 **-\-badge-filter**
 (Default: 0) Bitmask of types of Chat Badges to filter out. Add the numbers of the types of badges you want to filter. For example, to filter out Moderator and Broadcaster badges only enter the value of 6.
 
-Other = 1
-Broadcaster = 2
-Moderator = 4
-VIP = 8
-Subscriber = 16
-Predictions = 32
-NoAudioVisual = 64
-PrimeGaming = 128
+Other = `1`,
+Broadcaster = `2`,
+Moderator = `4`,
+VIP = `8`,
+Subscriber = `16`,
+Predictions = `32`,
+NoAudioVisual = `64`,
+PrimeGaming = `128`
+
 
 ## Example Commands
 Download a VOD
@@ -188,6 +196,6 @@ Render a chat with custom ffmpeg arguments
 
     TwitchDownloaderCLI -m ChatRender -i chat.json --output-args='-c:v libx264 -preset veryfast -crf 18 -pix_fmt yuv420p "{save_path}"' -o chat.mp4
 
-## Notes
 
-Default true boolean flags must be assigned as `--true-bool=false`. Default false boolean flags must be raised normally `--false-bool`
+## Notes
+Due to some limitations, default true boolean flags must be assigned: `--default-true-flag=false`. Default false boolean flags must still be raised normally: `--default-false-flag`


### PR DESCRIPTION
- I tested 1.50.5 CLI on an Intel Macbook and it mostly worked, updated README to reflect that.
- Added a reference to an [AUR package](https://aur.archlinux.org/packages/twitch-downloader-gui) for twitch-downloader-gui from the same maintainer of the CLI [AUR package](https://aur.archlinux.org/packages/twitch-downloader-bin)
- Updated the copyright date, added word wrap, and added a header to the license