### PR TITLE
Add additional information to chat jsons

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -232,12 +232,14 @@ namespace TwitchDownloaderCore
 
         public async Task DownloadAsync(IProgress<ProgressReport> progress, CancellationToken cancellationToken)
         {
-            DownloadType downloadType = downloadOptions.Id.All(x => Char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
-            string videoId = "";
+            DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
             ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new Video(), comments = comments };
 
+            string videoId = "";
+            string videoTitle = "";
+            DateTime videoCreatedAt;
             double videoStart = 0.0;
             double videoEnd = 0.0;
             double videoDuration = 0.0;
@@ -246,34 +248,40 @@ namespace TwitchDownloaderCore
             if (downloadType == DownloadType.Video)
             {
                 videoId = downloadOptions.Id;
-                GqlVideoResponse taskInfo = await TwitchHelper.GetVideoInfo(Int32.Parse(videoId));
-                chatRoot.streamer.name = taskInfo.data.video.owner.displayName;
-                chatRoot.streamer.id = int.Parse(taskInfo.data.video.owner.id);
+                GqlVideoResponse taskVideoInfo = await TwitchHelper.GetVideoInfo(int.Parse(videoId));
+                chatRoot.streamer.name = taskVideoInfo.data.video.owner.displayName;
+                chatRoot.streamer.id = int.Parse(taskVideoInfo.data.video.owner.id);
+                videoTitle = taskVideoInfo.data.video.title;
+                videoCreatedAt = taskVideoInfo.data.video.createdAt;
                 videoStart = downloadOptions.CropBeginning ? downloadOptions.CropBeginningTime : 0.0;
-                videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : taskInfo.data.video.lengthSeconds;
+                videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : taskVideoInfo.data.video.lengthSeconds;
             }
             else
             {
-                GqlClipResponse taskInfo = await TwitchHelper.GetClipInfo(downloadOptions.Id);
+                GqlClipResponse taskClipInfo = await TwitchHelper.GetClipInfo(downloadOptions.Id);
 
-                if (taskInfo.data.clip.video == null || taskInfo.data.clip.videoOffsetSeconds == null)
+                if (taskClipInfo.data.clip.video == null || taskClipInfo.data.clip.videoOffsetSeconds == null)
                     throw new Exception("Invalid VOD for clip, deleted/expired VOD possibly?");
 
-                videoId = taskInfo.data.clip.video.id;
+                videoId = taskClipInfo.data.clip.video.id;
                 downloadOptions.CropBeginning = true;
-                downloadOptions.CropBeginningTime = (int)taskInfo.data.clip.videoOffsetSeconds;
+                downloadOptions.CropBeginningTime = (int)taskClipInfo.data.clip.videoOffsetSeconds;
                 downloadOptions.CropEnding = true;
-                downloadOptions.CropEndingTime = downloadOptions.CropBeginningTime + taskInfo.data.clip.durationSeconds;
-                chatRoot.streamer.name = taskInfo.data.clip.broadcaster.displayName;
-                chatRoot.streamer.id = int.Parse(taskInfo.data.clip.broadcaster.id);
-                videoStart = (int)taskInfo.data.clip.videoOffsetSeconds;
-                videoEnd = (int)taskInfo.data.clip.videoOffsetSeconds + taskInfo.data.clip.durationSeconds;
+                downloadOptions.CropEndingTime = downloadOptions.CropBeginningTime + taskClipInfo.data.clip.durationSeconds;
+                chatRoot.streamer.name = taskClipInfo.data.clip.broadcaster.displayName;
+                chatRoot.streamer.id = int.Parse(taskClipInfo.data.clip.broadcaster.id);
+                videoTitle = taskClipInfo.data.clip.title;
+                videoCreatedAt = taskClipInfo.data.clip.createdAt;
+                videoStart = (int)taskClipInfo.data.clip.videoOffsetSeconds;
+                videoEnd = (int)taskClipInfo.data.clip.videoOffsetSeconds + taskClipInfo.data.clip.durationSeconds;
                 connectionCount = 1;
             }
 
+            chatRoot.video.title = videoTitle;
+            chatRoot.video.id = videoId;
+            chatRoot.video.created_at = videoCreatedAt;
             chatRoot.video.start = videoStart;
             chatRoot.video.end = videoEnd;
-            chatRoot.video.id = downloadOptions.Id;
             videoDuration = videoEnd - videoStart;
 
             SortedSet<Comment> commentsSet = new SortedSet<Comment>(new SortedCommentComparer());

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -235,7 +235,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { fileInfo = new ChatRootInfo() { version = "1.1.0" }, streamer = new Streamer(), video = new Video(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { fileInfo = new ChatRootInfo() { version = new ChatRootVersion("1.1.0") }, streamer = new Streamer(), video = new Video(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Web;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 
 namespace TwitchDownloaderCore
 {

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -1,7 +1,4 @@
-using NeoSmart.Unicode;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -239,7 +236,7 @@ namespace TwitchDownloaderCore
             string videoId = "";
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new VideoTime(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new Video(), comments = comments };
 
             double videoStart = 0.0;
             double videoEnd = 0.0;
@@ -276,6 +273,7 @@ namespace TwitchDownloaderCore
 
             chatRoot.video.start = videoStart;
             chatRoot.video.end = videoEnd;
+            chatRoot.video.id = downloadOptions.Id;
             videoDuration = videoEnd - videoStart;
 
             SortedSet<Comment> commentsSet = new SortedSet<Comment>(new SortedCommentComparer());

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -243,6 +243,7 @@ namespace TwitchDownloaderCore
             double videoStart = 0.0;
             double videoEnd = 0.0;
             double videoDuration = 0.0;
+            double videoTotalLength;
             int connectionCount = downloadOptions.ConnectionCount;
 
             if (downloadType == DownloadType.Video)
@@ -255,6 +256,7 @@ namespace TwitchDownloaderCore
                 videoCreatedAt = taskVideoInfo.data.video.createdAt;
                 videoStart = downloadOptions.CropBeginning ? downloadOptions.CropBeginningTime : 0.0;
                 videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : taskVideoInfo.data.video.lengthSeconds;
+                videoTotalLength = taskVideoInfo.data.video.lengthSeconds;
             }
             else
             {
@@ -274,6 +276,7 @@ namespace TwitchDownloaderCore
                 videoCreatedAt = taskClipInfo.data.clip.createdAt;
                 videoStart = (int)taskClipInfo.data.clip.videoOffsetSeconds;
                 videoEnd = (int)taskClipInfo.data.clip.videoOffsetSeconds + taskClipInfo.data.clip.durationSeconds;
+                videoTotalLength = taskClipInfo.data.clip.durationSeconds;
                 connectionCount = 1;
             }
 
@@ -282,6 +285,7 @@ namespace TwitchDownloaderCore
             chatRoot.video.created_at = videoCreatedAt;
             chatRoot.video.start = videoStart;
             chatRoot.video.end = videoEnd;
+            chatRoot.video.length = videoTotalLength;
             videoDuration = videoEnd - videoStart;
 
             SortedSet<Comment> commentsSet = new SortedSet<Comment>(new SortedCommentComparer());

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -235,7 +235,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new VideoInfo(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new Video(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -235,7 +235,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new Video(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new VideoInfo(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -235,7 +235,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { fileInfo = new ChatRootInfo() { version = new ChatRootVersion("1.1.0") }, streamer = new Streamer(), video = new Video(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { FileInfo = new ChatRootInfo() { Version = new ChatRootVersion("1.1.0") }, streamer = new Streamer(), video = new Video(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -236,7 +236,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { FileInfo = new ChatRootInfo() { Version = new ChatRootVersion("1.1.0") }, streamer = new Streamer(), video = new Video(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { FileInfo = new ChatRootInfo() { Version = new ChatRootVersion(1, 1, 0) }, streamer = new Streamer(), video = new Video(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -235,7 +235,7 @@ namespace TwitchDownloaderCore
             DownloadType downloadType = downloadOptions.Id.All(x => char.IsDigit(x)) ? DownloadType.Video : DownloadType.Clip;
 
             List<Comment> comments = new List<Comment>();
-            ChatRoot chatRoot = new ChatRoot() { streamer = new Streamer(), video = new Video(), comments = comments };
+            ChatRoot chatRoot = new ChatRoot() { fileInfo = new ChatRootInfo() { version = "1.1.0" }, streamer = new Streamer(), video = new Video(), comments = comments };
 
             string videoId = "";
             string videoTitle = "";

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1100,7 +1100,7 @@ namespace TwitchDownloaderCore
 
             if (jsonDocument.RootElement.TryGetProperty("video", out JsonElement videoJson))
             {
-                chatRoot.video = videoJson.Deserialize<Video>();
+                chatRoot.video = videoJson.Deserialize<VideoInfo>();
             }
 
             if (jsonDocument.RootElement.TryGetProperty("embeddedData", out JsonElement embedDataJson))

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1100,7 +1100,7 @@ namespace TwitchDownloaderCore
 
             if (jsonDocument.RootElement.TryGetProperty("video", out JsonElement videoJson))
             {
-                chatRoot.video = videoJson.Deserialize<VideoInfo>();
+                chatRoot.video = videoJson.Deserialize<Video>();
             }
 
             if (jsonDocument.RootElement.TryGetProperty("embeddedData", out JsonElement embedDataJson))

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1100,10 +1100,7 @@ namespace TwitchDownloaderCore
 
             if (jsonDocument.RootElement.TryGetProperty("video", out JsonElement videoJson))
             {
-                if (videoJson.TryGetProperty("start", out JsonElement videoStartJson) && videoJson.TryGetProperty("end", out JsonElement videoEndJson))
-                {
-                    chatRoot.video = videoJson.Deserialize<VideoTime>();
-                }
+                chatRoot.video = videoJson.Deserialize<Video>();
             }
 
             if (jsonDocument.RootElement.TryGetProperty("embeddedData", out JsonElement embedDataJson))

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using TwitchDownloaderCore.Properties;
 using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 
 namespace TwitchDownloaderCore
 {

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -126,8 +126,15 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string _next { get; set; }
     }
 
+    public class ChatRootInfo
+    {
+        public string version { get; } = "1.1.0"; // Incrment this when making changes to the chatroot structure
+        public DateTime created_at { get; set; } = DateTime.Now;
+    }
+
     public class ChatRoot
     {
+        public ChatRootInfo fileInfo { get; set; } = new ChatRootInfo();
         public Streamer streamer { get; set; }
         public Video video { get; set; }
         public List<Comment> comments { get; set; }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -79,7 +79,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public bool more_replies { get; set; }
     }
 
-    public class VideoInfo
+    public class Video
     {
         public string title { get; set; }
         public string id { get; set; }
@@ -129,7 +129,7 @@ namespace TwitchDownloaderCore.TwitchObjects
     public class ChatRoot
     {
         public Streamer streamer { get; set; }
-        public VideoInfo video { get; set; }
+        public Video video { get; set; }
         public List<Comment> comments { get; set; }
         public EmbeddedData embeddedData { get; set; }
     }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -1,139 +1,136 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
-public class Streamer
+namespace TwitchDownloaderCore.TwitchObjects
 {
-    public string name { get; set; }
-    public int id { get; set; }
-}
+    public class Streamer
+    {
+        public string name { get; set; }
+        public int id { get; set; }
+    }
 
-public class Commenter
-{
-    public string display_name { get; set; }
-    public string _id { get; set; }
-    public string name { get; set; }
-    public string type { get; set; }
-    public string bio { get; set; }
-    public DateTime created_at { get; set; }
-    public DateTime updated_at { get; set; }
-    public string logo { get; set; }
-}
+    public class Commenter
+    {
+        public string display_name { get; set; }
+        public string _id { get; set; }
+        public string name { get; set; }
+        public string type { get; set; }
+        public string bio { get; set; }
+        public DateTime created_at { get; set; }
+        public DateTime updated_at { get; set; }
+        public string logo { get; set; }
+    }
 
-public class Emoticon
-{
-    public string emoticon_id { get; set; }
-    public string emoticon_set_id { get; set; }
-}
+    public class Emoticon
+    {
+        public string emoticon_id { get; set; }
+        public string emoticon_set_id { get; set; }
+    }
 
-public class Fragment
-{
-    public string text { get; set; }
-    public Emoticon emoticon { get; set; }
-}
+    public class Fragment
+    {
+        public string text { get; set; }
+        public Emoticon emoticon { get; set; }
+    }
 
-public class UserBadge
-{
-    public string _id { get; set; }
-    public string version { get; set; }
-}
+    public class UserBadge
+    {
+        public string _id { get; set; }
+        public string version { get; set; }
+    }
 
-public class Emoticon2
-{
-    public string _id { get; set; }
-    public int begin { get; set; }
-    public int end { get; set; }
-}
+    public class Emoticon2
+    {
+        public string _id { get; set; }
+        public int begin { get; set; }
+        public int end { get; set; }
+    }
 
-public class Message
-{
-    public string body { get; set; }
-    public int bits_spent { get; set; }
-    public List<Fragment> fragments { get; set; }
-    public bool is_action { get; set; }
-    public List<UserBadge> user_badges { get; set; }
-    public string user_color { get; set; }
-    public UserNoticeParams user_notice_params { get; set; }
-    public List<Emoticon2> emoticons { get; set; }
-}
+    public class Message
+    {
+        public string body { get; set; }
+        public int bits_spent { get; set; }
+        public List<Fragment> fragments { get; set; }
+        public bool is_action { get; set; }
+        public List<UserBadge> user_badges { get; set; }
+        public string user_color { get; set; }
+        public UserNoticeParams user_notice_params { get; set; }
+        public List<Emoticon2> emoticons { get; set; }
+    }
 
-public class UserNoticeParams
-{
-    [JsonPropertyName("msg-id")]
-    public string msg_id { get; set; }
-}
+    public class UserNoticeParams
+    {
+        public string msg_id { get; set; }
+    }
 
-public class Comment
-{
-    public string _id { get; set; }
-    public DateTime created_at { get; set; }
-    public DateTime updated_at { get; set; }
-    public string channel_id { get; set; }
-    public string content_type { get; set; }
-    public string content_id { get; set; }
-    public double content_offset_seconds { get; set; }
-    public Commenter commenter { get; set; }
-    public string source { get; set; }
-    public string state { get; set; }
-    public Message message { get; set; }
-    public bool more_replies { get; set; }
-}
+    public class Comment
+    {
+        public string _id { get; set; }
+        public DateTime created_at { get; set; }
+        public DateTime updated_at { get; set; }
+        public string channel_id { get; set; }
+        public string content_type { get; set; }
+        public string content_id { get; set; }
+        public double content_offset_seconds { get; set; }
+        public Commenter commenter { get; set; }
+        public string source { get; set; }
+        public string state { get; set; }
+        public Message message { get; set; }
+        public bool more_replies { get; set; }
+    }
 
-public class Video
-{
-    public string title { get; set; }
-    public string id { get; set; }
-    public DateTime created_at { get; set; }
-    public double start { get; set; }
-    public double end { get; set; }
-    public double length { get; set; }
-}
+    public class VideoInfo
+    {
+        public string title { get; set; }
+        public string id { get; set; }
+        public DateTime created_at { get; set; }
+        public double start { get; set; }
+        public double end { get; set; }
+        public double length { get; set; }
+    }
 
-public class EmbedEmoteData
-{
-    public string id { get; set; }
-    public int imageScale { get; set; }
-    public byte[] data { get; set; }
-    public string name { get; set; }
-    public string url { get; set; }
-    public int width { get; set; }
-    public int height { get; set; }
-}
+    public class EmbedEmoteData
+    {
+        public string id { get; set; }
+        public int imageScale { get; set; }
+        public byte[] data { get; set; }
+        public string name { get; set; }
+        public string url { get; set; }
+        public int width { get; set; }
+        public int height { get; set; }
+    }
 
-public class EmbedChatBadge
-{
-    public string name { get; set; }
-    public Dictionary<string, byte[]> versions { get; set; }
-}
+    public class EmbedChatBadge
+    {
+        public string name { get; set; }
+        public Dictionary<string, byte[]> versions { get; set; }
+    }
 
-public class EmbedCheerEmote
-{
-    public string prefix { get; set; }
-    public Dictionary<int, EmbedEmoteData> tierList { get; set; }
-}
+    public class EmbedCheerEmote
+    {
+        public string prefix { get; set; }
+        public Dictionary<int, EmbedEmoteData> tierList { get; set; }
+    }
 
-public class EmbeddedData
-{
-    public List<EmbedEmoteData> thirdParty { get; set; }
-    public List<EmbedEmoteData> firstParty { get; set; }
-    public List<EmbedChatBadge> twitchBadges { get; set; }
-    public List<EmbedCheerEmote> twitchBits { get; set; }
-}
+    public class EmbeddedData
+    {
+        public List<EmbedEmoteData> thirdParty { get; set; }
+        public List<EmbedEmoteData> firstParty { get; set; }
+        public List<EmbedChatBadge> twitchBadges { get; set; }
+        public List<EmbedCheerEmote> twitchBits { get; set; }
+    }
 
-public class CommentResponse
-{
-    public List<Comment> comments { get; set; }
-    public string _next { get; set; }
-}
+    public class CommentResponse
+    {
+        public List<Comment> comments { get; set; }
+        public string _next { get; set; }
+    }
 
-public class ChatRoot
-{
-    [JsonPropertyOrder(0)]
-    public Streamer streamer { get; set; }
-    [JsonPropertyOrder(1)]
-    public Video video { get; set; }
-    [JsonPropertyOrder(2)]
-    public List<Comment> comments { get; set; }
-    [JsonPropertyOrder(3)]
-    public EmbeddedData embeddedData { get; set; }
+    public class ChatRoot
+    {
+        public Streamer streamer { get; set; }
+        public VideoInfo video { get; set; }
+        public List<Comment> comments { get; set; }
+        public EmbeddedData embeddedData { get; set; }
+    }
 }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -128,17 +128,17 @@ namespace TwitchDownloaderCore.TwitchObjects
 
     public class ChatRootVersion
     {
-        public int major { get; set; }
-        public int minor { get; set; }
-        public int patch { get; set; }
+        public int Major { get; set; }
+        public int Minor { get; set; }
+        public int Patch { get; set; }
 
         public ChatRootVersion() { }
 
-        public ChatRootVersion(int _major, int _minor, int _patch)
+        public ChatRootVersion(int major, int minor, int patch)
         {
-            major = _major;
-            minor = _minor;
-            patch = _patch;
+            Major = major;
+            Minor = minor;
+            Patch = patch;
         }
 
         public ChatRootVersion(string version)
@@ -147,29 +147,34 @@ namespace TwitchDownloaderCore.TwitchObjects
             if (versionArray.Length == 0)
                 return;
 
-            major = int.Parse(versionArray[0]);
+            Major = int.Parse(versionArray[0]);
 
             if (versionArray.Length == 1)
                 return;
 
-            minor = int.Parse(versionArray[1]);
+            Minor = int.Parse(versionArray[1]);
 
             if (versionArray.Length == 2)
                 return;
 
-            patch = int.Parse(versionArray[2]);
+            Patch = int.Parse(versionArray[2]);
+        }
+
+        public override string ToString()
+        {
+            return $"{Major}.{Minor}.{Patch}";
         }
     }
 
     public class ChatRootInfo
     {
-        public ChatRootVersion version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
-        public DateTime created_at { get; set; } = DateTime.Now;
+        public ChatRootVersion Version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
     }
 
     public class ChatRoot
     {
-        public ChatRootInfo fileInfo { get; set; } = new ChatRootInfo();
+        public ChatRootInfo FileInfo { get; set; } = new ChatRootInfo();
         public Streamer streamer { get; set; }
         public Video video { get; set; }
         public List<Comment> comments { get; set; }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -128,23 +128,36 @@ namespace TwitchDownloaderCore.TwitchObjects
 
     public class ChatRootVersion
     {
-        public uint major { get; set; }
-        public uint minor { get; set; }
-        public uint patch { get; set; }
+        public int major { get; set; }
+        public int minor { get; set; }
+        public int patch { get; set; }
 
         public ChatRootVersion() { }
 
-        public ChatRootVersion(string version)
+        public ChatRootVersion(int _major, int _minor, int _patch)
         {
-            string[] versionArray = version.Split('.');
-
-            uint.TryParse(versionArray[0] ?? "1", out uint _major);
-            uint.TryParse(versionArray[1] ?? "0", out uint _minor);
-            uint.TryParse(versionArray[2] ?? "0", out uint _patch);
-
             major = _major;
             minor = _minor;
             patch = _patch;
+        }
+
+        public ChatRootVersion(string version)
+        {
+            string[] versionArray = version.Split('.', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (versionArray.Length == 0)
+                return;
+
+            major = int.Parse(versionArray[0]);
+
+            if (versionArray.Length == 1)
+                return;
+
+            minor = int.Parse(versionArray[1]);
+
+            if (versionArray.Length == 2)
+                return;
+
+            patch = int.Parse(versionArray[2]);
         }
     }
 

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -126,9 +126,31 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string _next { get; set; }
     }
 
+    public class ChatRootVersion
+    {
+        public uint major { get; set; }
+        public uint minor { get; set; }
+        public uint patch { get; set; }
+
+        public ChatRootVersion() { }
+
+        public ChatRootVersion(string version)
+        {
+            string[] versionArray = version.Split('.');
+
+            uint.TryParse(versionArray[0] ?? "1", out uint _major);
+            uint.TryParse(versionArray[1] ?? "0", out uint _minor);
+            uint.TryParse(versionArray[2] ?? "0", out uint _patch);
+
+            major = _major;
+            minor = _minor;
+            patch = _patch;
+        }
+    }
+
     public class ChatRootInfo
     {
-        public string version { get; set; } = "1.0.0"; // Default to 1.0.0 for older jsons that don't have this field
+        public ChatRootVersion version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
         public DateTime created_at { get; set; } = DateTime.Now;
     }
 

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -128,7 +128,7 @@ namespace TwitchDownloaderCore.TwitchObjects
 
     public class ChatRootInfo
     {
-        public string version { get; set; } = "1.1.0"; // Incrment this when making changes to the chatroot structure
+        public string version { get; set; } = "1.0.0"; // Default to 1.0.0 for older jsons that don't have this field
         public DateTime created_at { get; set; } = DateTime.Now;
     }
 

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -81,9 +81,11 @@ public class Comment
 
 public class Video
 {
+    public string title { get; set; }
+    public string id { get; set; }
+    public DateTime created_at { get; set; }
     public double start { get; set; }
     public double end { get; set; }
-    public string id { get; set; }
 }
 
 public class EmbedEmoteData

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -126,52 +126,6 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string _next { get; set; }
     }
 
-    public class ChatRootVersion
-    {
-        public int Major { get; set; }
-        public int Minor { get; set; }
-        public int Patch { get; set; }
-
-        public ChatRootVersion() { }
-
-        public ChatRootVersion(int major, int minor, int patch)
-        {
-            Major = major;
-            Minor = minor;
-            Patch = patch;
-        }
-
-        public ChatRootVersion(string version)
-        {
-            string[] versionArray = version.Split('.', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            if (versionArray.Length == 0)
-                return;
-
-            Major = int.Parse(versionArray[0]);
-
-            if (versionArray.Length == 1)
-                return;
-
-            Minor = int.Parse(versionArray[1]);
-
-            if (versionArray.Length == 2)
-                return;
-
-            Patch = int.Parse(versionArray[2]);
-        }
-
-        public override string ToString()
-        {
-            return $"{Major}.{Minor}.{Patch}";
-        }
-    }
-
-    public class ChatRootInfo
-    {
-        public ChatRootVersion Version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
-        public DateTime CreatedAt { get; set; } = DateTime.Now;
-    }
-
     public class ChatRoot
     {
         public ChatRootInfo FileInfo { get; set; } = new ChatRootInfo();

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -128,7 +128,7 @@ namespace TwitchDownloaderCore.TwitchObjects
 
     public class ChatRootInfo
     {
-        public string version { get; } = "1.1.0"; // Incrment this when making changes to the chatroot structure
+        public string version { get; set; } = "1.1.0"; // Incrment this when making changes to the chatroot structure
         public DateTime created_at { get; set; } = DateTime.Now;
     }
 

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -86,6 +86,7 @@ public class Video
     public DateTime created_at { get; set; }
     public double start { get; set; }
     public double end { get; set; }
+    public double length { get; set; }
 }
 
 public class EmbedEmoteData

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -79,10 +79,11 @@ public class Comment
     public bool more_replies { get; set; }
 }
 
-public class VideoTime
+public class Video
 {
     public double start { get; set; }
     public double end { get; set; }
+    public string id { get; set; }
 }
 
 public class EmbedEmoteData
@@ -127,7 +128,7 @@ public class ChatRoot
     [JsonPropertyOrder(0)]
     public Streamer streamer { get; set; }
     [JsonPropertyOrder(1)]
-    public VideoTime video { get; set; }
+    public Video video { get; set; }
     [JsonPropertyOrder(2)]
     public List<Comment> comments { get; set; }
     [JsonPropertyOrder(3)]

--- a/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
@@ -1,0 +1,115 @@
+﻿using System;
+
+namespace TwitchDownloaderCore.TwitchObjects
+{
+    public class ChatRootInfo
+    {
+        public ChatRootVersion Version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+    }
+
+    public class ChatRootVersion
+    {
+        // Fields
+        public int Major { get; set; }
+        public int Minor { get; set; }
+        public int Patch { get; set; }
+
+        // Constructors
+        public ChatRootVersion() { Major = 1; Minor = 0; Patch = 0; }
+
+        public ChatRootVersion(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        public ChatRootVersion(string version)
+        {
+            string[] versionArray = version.Split('.', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            Major = 1;
+            Minor = 0;
+            Patch = 0;
+
+            if (versionArray.Length == 0)
+                return;
+
+            Major = int.Parse(versionArray[0]);
+
+            if (versionArray.Length == 1)
+                return;
+
+            Minor = int.Parse(versionArray[1]);
+
+            if (versionArray.Length == 2)
+                return;
+
+            Patch = int.Parse(versionArray[2]);
+        }
+
+        // Methods
+        public override string ToString()
+            => $"{Major}.{Minor}.{Patch}";
+
+        public override int GetHashCode()
+            => ToString().GetHashCode();
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            if (!(obj is ChatRootVersion crv))
+                return false;
+
+            return this == crv;
+        }
+
+        // Operators
+        public static bool operator >(ChatRootVersion crvA, ChatRootVersion crvB)
+        {
+            if (crvA.Major > crvB.Major) return true;
+            else if (crvA.Major == crvB.Major)
+            {
+                if (crvA.Minor > crvB.Minor) return true;
+                else if (crvA.Minor == crvB.Minor)
+                {
+                    if (crvA.Patch > crvB.Patch) return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool operator <(ChatRootVersion crvA, ChatRootVersion crvB)
+        {
+            if (crvA.Major < crvB.Major) return true;
+            else if (crvA.Major == crvB.Major)
+            {
+                if (crvA.Minor < crvB.Minor) return true;
+                else if (crvA.Minor == crvB.Minor)
+                {
+                    if (crvA.Patch < crvB.Patch) return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool operator ==(ChatRootVersion crvA, ChatRootVersion crvB)
+        {
+            if (crvA.Major != crvB.Major) return false;
+            if (crvA.Minor != crvB.Minor) return false;
+            if (crvA.Patch != crvB.Patch) return false;
+            return true;
+        }
+
+        public static bool operator !=(ChatRootVersion crvA, ChatRootVersion crvB)
+            => !(crvA == crvB);
+
+        public static bool operator >=(ChatRootVersion crvA, ChatRootVersion crvB)
+            => (crvA > crvB) || (crvA == crvB);
+
+        public static bool operator <=(ChatRootVersion crvA, ChatRootVersion crvB)
+            => (crvA < crvB) || (crvA == crvB);
+    }
+}

--- a/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
@@ -4,48 +4,31 @@ namespace TwitchDownloaderCore.TwitchObjects
 {
     public class ChatRootInfo
     {
-        public ChatRootVersion Version { get; set; } = new ChatRootVersion("1.0.0"); // Default to 1.0.0 for older jsons that don't have this field
+        public ChatRootVersion Version { get; set; } = new ChatRootVersion();
         public DateTime CreatedAt { get; set; } = DateTime.Now;
     }
 
     public class ChatRootVersion
     {
         // Fields
-        public int Major { get; set; }
-        public int Minor { get; set; }
-        public int Patch { get; set; }
+        public int Major { get; set; } = 1;
+        public int Minor { get; set; } = 0;
+        public int Patch { get; set; } = 0;
 
         // Constructors
-        public ChatRootVersion() { Major = 1; Minor = 0; Patch = 0; }
+        /// <summary>
+        /// Initializes a new <see cref="ChatRootVersion"/> object with the default version of 1.0.0
+        /// </summary>
+        public ChatRootVersion() { }
 
+        /// <summary>
+        /// Initializes a new <see cref="ChatRootVersion"/> object with the version number of <paramref name="major"/>.<paramref name="minor"/>.<paramref name="patch"/>
+        /// </summary>
         public ChatRootVersion(int major, int minor, int patch)
         {
             Major = major;
             Minor = minor;
             Patch = patch;
-        }
-
-        public ChatRootVersion(string version)
-        {
-            string[] versionArray = version.Split('.', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            Major = 1;
-            Minor = 0;
-            Patch = 0;
-
-            if (versionArray.Length == 0)
-                return;
-
-            Major = int.Parse(versionArray[0]);
-
-            if (versionArray.Length == 1)
-                return;
-
-            Minor = int.Parse(versionArray[1]);
-
-            if (versionArray.Length == 2)
-                return;
-
-            Patch = int.Parse(versionArray[2]);
         }
 
         // Methods
@@ -67,49 +50,49 @@ namespace TwitchDownloaderCore.TwitchObjects
         }
 
         // Operators
-        public static bool operator >(ChatRootVersion crvA, ChatRootVersion crvB)
+        public static bool operator >(ChatRootVersion left, ChatRootVersion right)
         {
-            if (crvA.Major > crvB.Major) return true;
-            else if (crvA.Major == crvB.Major)
+            if (left.Major > right.Major) return true;
+            else if (left.Major == right.Major)
             {
-                if (crvA.Minor > crvB.Minor) return true;
-                else if (crvA.Minor == crvB.Minor)
+                if (left.Minor > right.Minor) return true;
+                else if (left.Minor == right.Minor)
                 {
-                    if (crvA.Patch > crvB.Patch) return true;
+                    if (left.Patch > right.Patch) return true;
                 }
             }
             return false;
         }
 
-        public static bool operator <(ChatRootVersion crvA, ChatRootVersion crvB)
+        public static bool operator <(ChatRootVersion left, ChatRootVersion right)
         {
-            if (crvA.Major < crvB.Major) return true;
-            else if (crvA.Major == crvB.Major)
+            if (left.Major < right.Major) return true;
+            else if (left.Major == right.Major)
             {
-                if (crvA.Minor < crvB.Minor) return true;
-                else if (crvA.Minor == crvB.Minor)
+                if (left.Minor < right.Minor) return true;
+                else if (left.Minor == right.Minor)
                 {
-                    if (crvA.Patch < crvB.Patch) return true;
+                    if (left.Patch < right.Patch) return true;
                 }
             }
             return false;
         }
 
-        public static bool operator ==(ChatRootVersion crvA, ChatRootVersion crvB)
+        public static bool operator ==(ChatRootVersion left, ChatRootVersion right)
         {
-            if (crvA.Major != crvB.Major) return false;
-            if (crvA.Minor != crvB.Minor) return false;
-            if (crvA.Patch != crvB.Patch) return false;
+            if (left.Major != right.Major) return false;
+            if (left.Minor != right.Minor) return false;
+            if (left.Patch != right.Patch) return false;
             return true;
         }
 
-        public static bool operator !=(ChatRootVersion crvA, ChatRootVersion crvB)
-            => !(crvA == crvB);
+        public static bool operator !=(ChatRootVersion left, ChatRootVersion right)
+            => !(left == right);
 
-        public static bool operator >=(ChatRootVersion crvA, ChatRootVersion crvB)
-            => (crvA > crvB) || (crvA == crvB);
+        public static bool operator >=(ChatRootVersion left, ChatRootVersion right)
+            => (left > right) || (left == right);
 
-        public static bool operator <=(ChatRootVersion crvA, ChatRootVersion crvB)
-            => (crvA < crvB) || (crvA == crvB);
+        public static bool operator <=(ChatRootVersion left, ChatRootVersion right)
+            => (left < right) || (left == right);
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlCheerResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlCheerResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class Tier
     {

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class ClipBroadcaster
     {

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipSearchResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipSearchResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class ClipNode
     {

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlCommentResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlCommentResponse.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class CommentChannel
     {

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoResponse.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class VideoOwner
     {

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoSearchResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoSearchResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace TwitchDownloaderCore.TwitchObjects
+namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
     public class VideoNode
     {

--- a/TwitchDownloaderCore/TwitchObjects/GqlVideoResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/GqlVideoResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchDownloaderCore.TwitchObjects
 {
@@ -10,7 +9,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string displayName { get; set; }
     }
 
-    public class Video
+    public class VideoInfo
     {
         public string title { get; set; }
         public List<string> thumbnailURLs { get; set; }
@@ -21,7 +20,7 @@ namespace TwitchDownloaderCore.TwitchObjects
 
     public class VideoData
     {
-        public Video video { get; set; }
+        public VideoInfo video { get; set; }
     }
 
     public class GqlVideoResponse

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -12,12 +12,12 @@ using TwitchDownloader;
 using TwitchDownloader.Properties;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
-using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using WpfAnimatedGif;
 
 namespace TwitchDownloaderWPF
 {
-	public enum DownloadType { Clip, Video }
+    public enum DownloadType { Clip, Video }
 	/// <summary>
 	/// Interaction logic for PageChatDownload.xaml
 	/// </summary>

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -12,7 +12,7 @@ using TwitchDownloader;
 using TwitchDownloader.Properties;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
-using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using WpfAnimatedGif;
 
 namespace TwitchDownloaderWPF

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -18,7 +18,7 @@ using TwitchDownloader;
 using TwitchDownloader.Properties;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
-using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using WpfAnimatedGif;
 
 namespace TwitchDownloaderWPF

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -10,7 +10,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using TwitchDownloader.TwitchTasks;
 using TwitchDownloaderCore;
-using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF;
 using static TwitchDownloaderWPF.App;
 

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -6,7 +6,7 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 using TwitchDownloader.TwitchTasks;
 using TwitchDownloaderCore;
-using TwitchDownloaderCore.TwitchObjects;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF;
 using static TwitchDownloaderWPF.App;
 


### PR DESCRIPTION
- Move GQL classes to `TwitchObjects.Gql`
- Put `ChatRoot` class in namespace `TwitchObjects`
- Rename `ChatRoot.VideoTime` to `ChatRoot.Video`
- Add `title`, `id`, `created_at`, and `length` fields to `ChatRoot.Video`
- Add `ChatRootInfo` class
- Add `ChatRootVersion` class for keeping track of compatibility

I also created some unit tests to ensure sure the ChatRootVersion operators worked correctly. If you would like for these to be added this PR, I can do that. It could be nice to have some unit tests for several parts of Core 