### PR TITLE
Remove debug files from GUI build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build Windows GUI
-      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows
+      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     
     - name: Download File To Workspace
       # You may pin to the exact commit or the version.
@@ -61,13 +61,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=None -p:DebugSymbols=false
         
     - name: Zip Windows CLI
       uses: vimtor/action-zip@v1
@@ -138,7 +138,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=None -p:DebugSymbols=false
       
     - name: Zip Release
       uses: vimtor/action-zip@v1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore TwitchDownloaderWPF
     - name: Build Windows GUI
       run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,13 +41,13 @@ jobs:
       uses: vimtor/action-zip@v1
       with:
         files: "TwitchDownloaderWPF/bin/Release/net6.0-windows/publish/win-x64"
-        dest: TwitchDownloader-Windows-x64.zip
+        dest: TwitchDownloaderGUI-Windows-x64.zip
 
     - name: Upload Artifact Asset
       uses: actions/upload-artifact@v3
       with:
-        name: TwitchDownloader-Windows-x64.zip
-        path: TwitchDownloader-Windows-x64.zip
+        name: TwitchDownloaderGUI-Windows-x64.zip
+        path: TwitchDownloaderGUI-Windows-x64.zip
 
   build-cli:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,13 +102,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=None -p:DebugSymbols=false
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=None -p:DebugSymbols=false
         
     - name: Zip Windows CLI
       uses: vimtor/action-zip@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore TwitchDownloaderWPF
     - name: Build Windows GUI
       run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS /p:DebugType=None /p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=None -p:DebugSymbols=false
       
     - name: Zip Release
       uses: vimtor/action-zip@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build Windows GUI
-      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows
+      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
     
     - name: Download File To Workspace
       # You may pin to the exact commit or the version.

--- a/TwitchDownloaderWPF/TwitchDownloader.csproj
+++ b/TwitchDownloaderWPF/TwitchDownloader.csproj
@@ -36,10 +36,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Page Remove="Themes\Dark.xaml" />
-    <Page Remove="Themes\Light.xaml" />
-  </ItemGroup>
-  <ItemGroup>
     <Resource Include="Images\settings.png" />
     <Resource Include="Images\donate.png" />
   </ItemGroup>
@@ -68,10 +64,10 @@
     <EmbeddedResource Include="Themes\Dark.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
       <SubType>Designer</SubType>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Themes\Light.xaml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Removed debug files from build via publish arguments
- Remove theme folder from build process as they are extracted at runtime anyways
- Specify `dotnet restore TwitchDownloaderWPF` to reduce build job times[^1]

[^1]:Build logs report restoring CLI takes an additional ~45s