### PR TITLE
Fix command prompt for mac CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ chmod +x ffmpeg
 ```
 5. You can now start using the downloader, for example:
 ```
-./TwitchDownloaderCLI videodownload --id <vod-id-here> -o out.mp4
+./TwitchDownloaderCLI -m VideoDownload -u <vod-id-here> -o out.mp4
 ```
 
 # License


### PR DESCRIPTION
Current example command throws error:
ERROR(S):
  Option 'm, mode' is defined with a bad format.
  Required option 'm, mode' is missing.
  
It also appears the mode is case sensitive.