### PR TITLE
fix typo in argument name in CLI

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -30,7 +30,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("ffmpeg-path", HelpText = "Path to ffmpeg executable.")]
         public string FfmpegPath { get; set; }
 
-        [Option("cache-path", Default = "", HelpText = "Path to temporary caching folder.")]
+        [Option("temp-path", Default = "", HelpText = "Path to temporary caching folder.")]
         public string TempFolder { get; set; }
     }
 }


### PR DESCRIPTION
cache-path should be temp-path, the like the README says, and like the other modes use