### PR TITLE
Unstable drive fix

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
@@ -89,5 +89,8 @@ namespace TwitchDownloaderCLI.Modes.Arguments
 
         [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
         public string TempFolder { get; set; }
+
+        [Option("verbose-ffmpeg", Default = false, HelpText = "Prints every message from ffmpeg.")]
+        public bool LogFfmpegOutput { get; set; }
     }
 }

--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -12,6 +12,16 @@ namespace TwitchDownloaderCLI.Modes
     {
         internal static void Download(ChatDownloadArgs inputOptions)
         {
+            ChatDownloadOptions downloadOptions = GetDownloadOptions(inputOptions);
+
+            ChatDownloader chatDownloader = new(downloadOptions);
+            Progress<ProgressReport> progress = new();
+            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
+            chatDownloader.DownloadAsync(progress, new CancellationToken()).Wait();
+        }
+
+        private static ChatDownloadOptions GetDownloadOptions(ChatDownloadArgs inputOptions)
+        {
             if (string.IsNullOrWhiteSpace(inputOptions.Id))
             {
                 Console.WriteLine("[ERROR] - Invalid ID, unable to parse.");
@@ -41,10 +51,7 @@ namespace TwitchDownloaderCLI.Modes
                 TempFolder = inputOptions.TempFolder
             };
 
-            ChatDownloader chatDownloader = new(downloadOptions);
-            Progress<ProgressReport> progress = new();
-            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
-            chatDownloader.DownloadAsync(progress, new CancellationToken()).Wait();
+            return downloadOptions;
         }
     }
 }

--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -10,7 +10,15 @@ namespace TwitchDownloaderCLI.Modes
     {
         internal static void Download(ClipDownloadArgs inputOptions)
         {
-            if (inputOptions.Id == string.Empty || inputOptions.Id.All(char.IsDigit))
+            ClipDownloadOptions downloadOptions = GetDownloadOptions(inputOptions);
+
+            ClipDownloader clipDownloader = new(downloadOptions);
+            clipDownloader.DownloadAsync().Wait();
+        }
+
+        private static ClipDownloadOptions GetDownloadOptions(ClipDownloadArgs inputOptions)
+        {
+            if (string.IsNullOrWhiteSpace(inputOptions.Id) || inputOptions.Id.All(char.IsDigit))
             {
                 Console.WriteLine("[ERROR] - Invalid Clip ID, unable to parse.");
                 Environment.Exit(1);
@@ -23,8 +31,7 @@ namespace TwitchDownloaderCLI.Modes
                 Quality = inputOptions.Quality
             };
 
-            ClipDownloader clipDownloader = new(downloadOptions);
-            clipDownloader.DownloadAsync().Wait();
+            return downloadOptions;
         }
     }
 }

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -15,6 +15,16 @@ namespace TwitchDownloaderCLI.Modes
         {
             FfmpegHandler.DetectFfmpeg(inputOptions.FfmpegPath);
 
+            VideoDownloadOptions downloadOptions = GetDownloadOptions(inputOptions);
+
+            VideoDownloader videoDownloader = new(downloadOptions);
+            Progress<ProgressReport> progress = new();
+            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
+            videoDownloader.DownloadAsync(progress, new CancellationToken()).Wait();
+        }
+
+        private static VideoDownloadOptions GetDownloadOptions(VideoDownloadArgs inputOptions)
+        {
             if (string.IsNullOrWhiteSpace(inputOptions.Id) || !inputOptions.Id.All(char.IsDigit))
             {
                 Console.WriteLine("[ERROR] - Invalid VOD ID, unable to parse. Must be only numbers.");
@@ -36,10 +46,7 @@ namespace TwitchDownloaderCLI.Modes
                 TempFolder = inputOptions.TempFolder
             };
 
-            VideoDownloader videoDownloader = new(downloadOptions);
-            Progress<ProgressReport> progress = new();
-            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
-            videoDownloader.DownloadAsync(progress, new CancellationToken()).Wait();
+            return downloadOptions;
         }
     }
 }

--- a/TwitchDownloaderCLI/Modes/UpdateChat.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateChat.cs
@@ -12,6 +12,17 @@ namespace TwitchDownloaderCLI.Modes
     {
         internal static void Update(ChatUpdateArgs inputOptions)
         {
+            ChatUpdateOptions updateOptions = GetUpdateOptions(inputOptions);
+
+            ChatUpdater chatUpdater = new(updateOptions);
+            Progress<ProgressReport> progress = new();
+            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
+            chatUpdater.ParseJsonAsync().Wait();
+            chatUpdater.UpdateAsync(progress, new CancellationToken()).Wait();
+        }
+
+        private static ChatUpdateOptions GetUpdateOptions(ChatUpdateArgs inputOptions)
+        {
             if (!File.Exists(inputOptions.InputFile))
             {
                 Console.WriteLine("[ERROR] - Input file does not exist!");
@@ -62,11 +73,7 @@ namespace TwitchDownloaderCLI.Modes
                 TempFolder = inputOptions.TempFolder
             };
 
-            ChatUpdater chatUpdater = new(updateOptions);
-            Progress<ProgressReport> progress = new();
-            progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
-            chatUpdater.ParseJsonAsync().Wait();
-            chatUpdater.UpdateAsync(progress, new CancellationToken()).Wait();
+            return updateOptions;
         }
     }
 }

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -1,7 +1,6 @@
 ﻿using CommandLine;
 using System;
 using System.IO;
-using System.Linq;
 using TwitchDownloaderCLI.Modes;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
@@ -13,6 +12,24 @@ namespace TwitchDownloaderCLI
         static void Main(string[] args)
         {
             string processFileName = Path.GetFileName(Environment.ProcessPath);
+            
+            WriteNoArgHelpText(args, processFileName);
+
+            string[] preParsedArgs = PreParseArgs.Parse(args, processFileName);
+
+            Parser.Default.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, FfmpegArgs, CacheArgs>(preParsedArgs)
+                .WithParsed<VideoDownloadArgs>(DownloadVideo.Download)
+                .WithParsed<ClipDownloadArgs>(DownloadClip.Download)
+                .WithParsed<ChatDownloadArgs>(DownloadChat.Download)
+                .WithParsed<ChatUpdateArgs>(UpdateChat.Update)
+                .WithParsed<ChatRenderArgs>(RenderChat.Render)
+                .WithParsed<FfmpegArgs>(FfmpegHandler.ParseArgs)
+                .WithParsed<CacheArgs>(CacheHandler.ParseArgs)
+                .WithNotParsed(_ => Environment.Exit(1));
+        }
+
+        static void WriteNoArgHelpText(string[] args, string processFileName)
+        {
             if (args.Length == 0)
             {
                 if (Path.GetExtension(processFileName).Equals(".exe"))
@@ -29,27 +46,6 @@ namespace TwitchDownloaderCLI
                 }
                 Environment.Exit(1);
             }
-
-            string[] preParsedArgs;
-            if (args.Any(x => x is "-m" or "--mode" or "--embed-emotes"))
-            {
-                // A legacy syntax was used, convert to new syntax
-                preParsedArgs = PreParseArgs.Process(PreParseArgs.ConvertFromOldSyntax(args, processFileName));
-            }
-            else
-            {
-                preParsedArgs = PreParseArgs.Process(args);
-            }
-
-            Parser.Default.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, FfmpegArgs, CacheArgs>(preParsedArgs)
-                .WithParsed<VideoDownloadArgs>(DownloadVideo.Download)
-                .WithParsed<ClipDownloadArgs>(DownloadClip.Download)
-                .WithParsed<ChatDownloadArgs>(DownloadChat.Download)
-                .WithParsed<ChatUpdateArgs>(UpdateChat.Update)
-                .WithParsed<ChatRenderArgs>(RenderChat.Render)
-                .WithParsed<FfmpegArgs>(FfmpegHandler.ParseArgs)
-                .WithParsed<CacheArgs>(CacheHandler.ParseArgs)
-                .WithNotParsed(_ => Environment.Exit(1));
         }
     }
 }

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -220,6 +220,9 @@ Path to ffmpeg executable.
 **--temp-path**
 Path to temporary folder for cache.
 
+**--verbose-ffmpeg**
+Prints every message from ffmpeg.
+
 
 ## Arguments for mode ffmpeg
 <sup>Manage standalone ffmpeg</sup>

--- a/TwitchDownloaderCLI/Tools/PreParseArgs.cs
+++ b/TwitchDownloaderCLI/Tools/PreParseArgs.cs
@@ -6,11 +6,21 @@ namespace TwitchDownloaderCLI.Tools
 {
     internal static class PreParseArgs
     {
+        internal static string[] Parse(string[] args, string processFileName)
+        {
+            if (args.Any(x => x is "-m" or "--mode" or "--embed-emotes"))
+            {
+                // A legacy syntax was used, convert to new syntax
+                return Process(ConvertFromOldSyntax(args, processFileName));
+            }
+
+            return Process(args);
+        }
+
         internal static string[] Process(string[] args)
         {
-            string[] processedArgs = args;
-            processedArgs[0] = processedArgs[0].ToLower();
-            return processedArgs;
+            args[0] = args[0].ToLower();
+            return args;
         }
 
         /// <summary>

--- a/TwitchDownloaderCLI/Tools/ProgressHandler.cs
+++ b/TwitchDownloaderCLI/Tools/ProgressHandler.cs
@@ -10,46 +10,74 @@ namespace TwitchDownloaderCLI.Tools
 
         internal static void Progress_ProgressChanged(object sender, ProgressReport e)
         {
-            if (e.ReportType == ReportType.Status)
+            switch (e.ReportType)
             {
-                if (previousMessageWasStatusInfo)
-                {
-                    previousMessageWasStatusInfo = false;
-                    Console.WriteLine();
-                }
-
-                string currentStatus = "[STATUS] - " + e.Data;
-                if (currentStatus != previousMessage)
-                {
-                    previousMessage = currentStatus;
-                    Console.WriteLine(currentStatus);
-                }
+                case ReportType.Log:
+                    ReportLog(e);
+                    break;
+                case ReportType.Status:
+                    ReportStatus(e);
+                    break;
+                case ReportType.StatusInfo:
+                    ReportStatusInfo(e);
+                    break;
+                case ReportType.FfmpegLog:
+                    ReportFfmpegLog(e);
+                    break;
             }
-            else if (e.ReportType == ReportType.StatusInfo)
-            {
-                string currentStatus = "\r[STATUS] - " + e.Data;
-                if (currentStatus != previousMessage)
-                {
-                    previousMessageWasStatusInfo = true;
+        }
 
-                    // This ensures the previous message is fully overwritten
-                    currentStatus = currentStatus.PadRight(previousMessage.Length);
-                    
-                    previousMessage = currentStatus.TrimEnd();
-                    Console.Write(currentStatus);
-                }
-            }
-            else if (e.ReportType == ReportType.Log)
-            {
-                if (previousMessageWasStatusInfo)
-                {
-                    previousMessageWasStatusInfo = false;
-                    Console.WriteLine();
-                }
+        private static void ReportLog(ProgressReport e)
+        {
+            WasLastMessageStatusInfo();
 
-                string currentStatus = "[LOG] - " + e.Data;
+            string currentStatus = "[LOG] - " + e.Data;
+            previousMessage = currentStatus;
+            Console.WriteLine(currentStatus);
+        }
+
+        private static void ReportStatus(ProgressReport e)
+        {
+            WasLastMessageStatusInfo();
+
+            string currentStatus = "[STATUS] - " + e.Data;
+            if (currentStatus != previousMessage)
+            {
                 previousMessage = currentStatus;
                 Console.WriteLine(currentStatus);
+            }
+        }
+
+        private static void ReportStatusInfo(ProgressReport e)
+        {
+            string currentStatus = "\r[STATUS] - " + e.Data;
+            if (currentStatus != previousMessage)
+            {
+                previousMessageWasStatusInfo = true;
+
+                // This ensures the previous message is fully overwritten
+                currentStatus = currentStatus.PadRight(previousMessage.Length);
+
+                previousMessage = currentStatus.TrimEnd();
+                Console.Write(currentStatus);
+            }
+        }
+
+        private static void ReportFfmpegLog(ProgressReport e)
+        {
+            WasLastMessageStatusInfo();
+
+            string currentStatus = "<FFMEPG LOG> " + e.Data;
+            previousMessage = currentStatus;
+            Console.WriteLine(currentStatus);
+        }
+
+        private static void WasLastMessageStatusInfo()
+        {
+            if (previousMessageWasStatusInfo)
+            {
+                previousMessageWasStatusInfo = false;
+                Console.WriteLine();
             }
         }
     }

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -49,28 +49,7 @@ namespace TwitchDownloaderCore
         public async Task RenderVideoAsync(IProgress<ProgressReport> progress, CancellationToken cancellationToken)
         {
             progress.Report(new ProgressReport(ReportType.Status, "Fetching Images"));
-
-            Task<List<ChatBadge>> badgeTask = TwitchHelper.GetChatBadges(chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
-            Task<List<TwitchEmote>> emoteTask = TwitchHelper.GetEmotes(chatRoot.comments, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
-            Task<List<TwitchEmote>> emoteThirdTask = TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.BttvEmotes, renderOptions.FfzEmotes, renderOptions.StvEmotes, renderOptions.Offline, cancellationToken);
-            Task<List<CheerEmote>> cheerTask = TwitchHelper.GetBits(renderOptions.TempFolder, chatRoot.streamer.id.ToString(), chatRoot.embeddedData, renderOptions.Offline);
-            Task<Dictionary<string, SKBitmap>> emojiTask = TwitchHelper.GetTwitterEmojis(renderOptions.TempFolder);
-
-            await Task.WhenAll(badgeTask, emoteTask, emoteThirdTask, cheerTask, emojiTask);
-
-            badgeList = badgeTask.Result;
-            emoteList = emoteTask.Result;
-            emoteThirdList = emoteThirdTask.Result;
-            cheermotesList = cheerTask.Result;
-            emojiCache = emojiTask.Result;
-
-            // Dispose of the tasks to free up the memory now
-            // TODO: move the tasks to a dedicated function so they are disposed by the scope instead
-            badgeTask.Dispose();
-            emoteTask.Dispose();
-            emoteThirdTask.Dispose();
-            cheerTask.Dispose();
-            emojiTask.Dispose();
+            await FetchImages(cancellationToken);
 
             await Task.Run(ScaleImages, cancellationToken);
             FloorCommentOffsets(chatRoot.comments);
@@ -98,23 +77,18 @@ namespace TwitchDownloaderCore
             if (renderOptions.GenerateMask && File.Exists(renderOptions.MaskFile))
                 File.Delete(renderOptions.MaskFile);
 
+            FfmpegProcess ffmpegProcess = GetFfmpegProcess(0, false, renderOptions.LogFfmpegOutput ? progress : null);
+            FfmpegProcess maskProcess = renderOptions.GenerateMask ? GetFfmpegProcess(0, true, null) : null;
             progress.Report(new ProgressReport(ReportType.StatusInfo, "Rendering Video: 0%"));
-            (Process ffmpegProcess, string ffmpegSavePath) = GetFfmpegProcess(0, false, progress);
 
             try
             {
-                if (renderOptions.GenerateMask)
-                {
-                    (Process maskProcess, string maskSavePath) = GetFfmpegProcess(0, true);
-                    await Task.Run(() => RenderVideoSection(startTick, startTick + totalTicks, ffmpegProcess, maskProcess, progress, cancellationToken));
-                }
-                else
-                {
-                    await Task.Run(() => RenderVideoSection(startTick, startTick + totalTicks, ffmpegProcess, maskProcess: null, progress, cancellationToken));
-                }
+                await RenderVideoSection(startTick, startTick + totalTicks, ffmpegProcess, maskProcess, progress, cancellationToken);
             }
             catch (OperationCanceledException)
             {
+                ffmpegProcess.Process.Dispose();
+                maskProcess?.Process.Dispose();
                 GC.Collect();
                 throw;
             }
@@ -155,13 +129,15 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private void RenderVideoSection(int startTick, int endTick, Process ffmpegProcess, Process maskProcess = null, IProgress<ProgressReport> progress = null, CancellationToken cancellationToken = new())
+        private async Task RenderVideoSection(int startTick, int endTick, FfmpegProcess ffmpegProcess, FfmpegProcess maskProcess = null, IProgress<ProgressReport> progress = null, CancellationToken cancellationToken = new())
         {
             UpdateFrame latestUpdate = null;
-            BinaryWriter ffmpegStream = new BinaryWriter(ffmpegProcess.StandardInput.BaseStream);
+            BinaryWriter ffmpegStream = new BinaryWriter(ffmpegProcess.Process.StandardInput.BaseStream);
             BinaryWriter maskStream = null;
             if (maskProcess != null)
-                maskStream = new BinaryWriter(maskProcess.StandardInput.BaseStream);
+                maskStream = new BinaryWriter(maskProcess.Process.StandardInput.BaseStream);
+
+            DriveInfo outputDrive = DriveHelper.GetOutputDrive(ffmpegProcess);
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -181,10 +157,14 @@ namespace TwitchDownloaderCore
 
                 using (SKBitmap frame = GetFrameFromTick(currentTick, sampleTextBounds.Height, latestUpdate))
                 {
+                    await DriveHelper.WaitForDrive(outputDrive, progress, cancellationToken);
+
                     ffmpegStream.Write(frame.Bytes);
 
                     if (maskProcess != null)
                     {
+                        await DriveHelper.WaitForDrive(outputDrive, progress, cancellationToken);
+
                         SetFrameMask(frame);
                         maskStream.Write(frame.Bytes);
                     }
@@ -212,8 +192,8 @@ namespace TwitchDownloaderCore
             ffmpegStream.Dispose();
             maskStream?.Dispose();
 
-            ffmpegProcess.WaitForExit();
-            maskProcess?.WaitForExit();
+            ffmpegProcess.Process.WaitForExit(30_000);
+            maskProcess?.Process.WaitForExit(30_000);
         }
 
         private void SetFrameMask(SKBitmap frame)
@@ -238,7 +218,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private (Process process, string savePath) GetFfmpegProcess(int partNumber, bool isMask, IProgress<ProgressReport> progress = null)
+        private FfmpegProcess GetFfmpegProcess(int partNumber, bool isMask, IProgress<ProgressReport> progress = null)
         {
             string savePath;
             if (partNumber == 0)
@@ -280,7 +260,9 @@ namespace TwitchDownloaderCore
                 process.ErrorDataReceived += (s, e) =>
                 {
                     if (e.Data != null)
+                    {
                         progress.Report(new ProgressReport() { ReportType = ReportType.FfmpegLog, Data = e.Data });
+                    }
                 };
             }
 
@@ -288,7 +270,7 @@ namespace TwitchDownloaderCore
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
 
-            return (process, savePath);
+            return new FfmpegProcess(process, savePath);
         }
 
         private SKBitmap GetFrameFromTick(int currentTick, float sampleTextHeight, UpdateFrame currentFrame = null)
@@ -959,6 +941,23 @@ namespace TwitchDownloaderCore
             drawPos.X = defaultPos.X;
             drawPos.Y = defaultPos.Y;
             sectionImages.Add(new SKBitmap(renderOptions.ChatWidth, renderOptions.SectionHeight));
+        }
+
+        private async Task FetchImages(CancellationToken cancellationToken)
+        {
+            Task<List<ChatBadge>> badgeTask = TwitchHelper.GetChatBadges(chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
+            Task<List<TwitchEmote>> emoteTask = TwitchHelper.GetEmotes(chatRoot.comments, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
+            Task<List<TwitchEmote>> emoteThirdTask = TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.BttvEmotes, renderOptions.FfzEmotes, renderOptions.StvEmotes, renderOptions.Offline, cancellationToken);
+            Task<List<CheerEmote>> cheerTask = TwitchHelper.GetBits(renderOptions.TempFolder, chatRoot.streamer.id.ToString(), chatRoot.embeddedData, renderOptions.Offline);
+            Task<Dictionary<string, SKBitmap>> emojiTask = TwitchHelper.GetTwitterEmojis(renderOptions.TempFolder);
+
+            await Task.WhenAll(badgeTask, emoteTask, emoteThirdTask, cheerTask, emojiTask);
+
+            badgeList = badgeTask.Result;
+            emoteList = emoteTask.Result;
+            emoteThirdList = emoteThirdTask.Result;
+            cheermotesList = cheerTask.Result;
+            emojiCache = emojiTask.Result;
         }
 
         //Precompute scaled images so we don't have to scale every frame

--- a/TwitchDownloaderCore/Options/ChatRenderOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatRenderOptions.cs
@@ -69,5 +69,6 @@ namespace TwitchDownloaderCore.Options
         public int AscentStrokeWidth => (int)(12 * ReferenceScale);
         public int AscentIndentWidth => (int)(24 * ReferenceScale);
         public bool Offline { get; set; }
+        public bool LogFfmpegOutput { get; set; } = false;
     }
 }

--- a/TwitchDownloaderCore/Tools/DriveHelper.cs
+++ b/TwitchDownloaderCore/Tools/DriveHelper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TwitchDownloaderCore.Tools
+{
+    public static class DriveHelper
+    {
+        public static DriveInfo GetOutputDrive(FfmpegProcess ffmpegProcess)
+        {
+            // Cannot instantiate a null DriveInfo
+            DriveInfo outputDrive = DriveInfo.GetDrives()[0];
+
+            string outputPath = Path.GetFullPath(ffmpegProcess.SavePath);
+
+            // Get the name of the drive we are writing to
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                // If our output path starts with the drive name
+                if (outputPath.StartsWith(drive.Name))
+                {
+                    // In Linux, the root drive is '/' while mounted drives are located in '/mnt/' or '/run/media/'
+                    // So we need to do a length check to not misinterpret a mounted drive as the root drive
+                    if (drive.Name.Length < outputDrive.Name.Length)
+                    {
+                        continue;
+                    }
+
+                    outputDrive = drive;
+                }
+            }
+
+            return outputDrive;
+        }
+
+        public static async Task WaitForDrive(DriveInfo outputDrive, IProgress<ProgressReport> progress, CancellationToken cancellationToken)
+        {
+            if (outputDrive.IsReady)
+            {
+                return;
+            }
+
+            int driveNotReadyCount = 0;
+            while (!outputDrive.IsReady)
+            {
+                progress.Report(new ProgressReport(ReportType.StatusInfo, $"Waiting for output drive ({(driveNotReadyCount + 1) / 2f:F1}s)"));
+                await Task.Delay(500, cancellationToken);
+
+                if (++driveNotReadyCount >= 20)
+                {
+                    throw new DriveNotFoundException("The output drive disconnected for 10 or more consecutive seconds.");
+                }
+
+            }
+        }
+    }
+}

--- a/TwitchDownloaderCore/Tools/DriveHelper.cs
+++ b/TwitchDownloaderCore/Tools/DriveHelper.cs
@@ -8,11 +8,12 @@ namespace TwitchDownloaderCore.Tools
     public static class DriveHelper
     {
         public static DriveInfo GetOutputDrive(FfmpegProcess ffmpegProcess)
+            => GetOutputDrive(Path.GetFullPath(ffmpegProcess.SavePath));
+
+        public static DriveInfo GetOutputDrive(string outputPath)
         {
             // Cannot instantiate a null DriveInfo
             DriveInfo outputDrive = DriveInfo.GetDrives()[0];
-
-            string outputPath = Path.GetFullPath(ffmpegProcess.SavePath);
 
             // Get the name of the drive we are writing to
             foreach (var drive in DriveInfo.GetDrives())

--- a/TwitchDownloaderCore/Tools/FfmpegProcess.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegProcess.cs
@@ -4,10 +4,9 @@ namespace TwitchDownloaderCore.Tools
 {
     public class FfmpegProcess
     {
-        public Process Process { get; init; }
+        public Process Process { get; private set; }
         public string SavePath { get; private set; }
 
-        public FfmpegProcess() { }
         public FfmpegProcess(Process process, string savePath)
         {
             Process = process;

--- a/TwitchDownloaderCore/Tools/FfmpegProcess.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegProcess.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics;
+
+namespace TwitchDownloaderCore.Tools
+{
+    public class FfmpegProcess
+    {
+        public Process Process { get; init; }
+        public string SavePath { get; private set; }
+
+        public FfmpegProcess() { }
+        public FfmpegProcess(Process process, string savePath)
+        {
+            Process = process;
+            SavePath = savePath;
+        }
+
+        ~FfmpegProcess()
+        {
+            SavePath = null;
+            Process.Dispose();
+        }
+    }
+}

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCore
 {
@@ -196,31 +197,9 @@ namespace TwitchDownloaderCore
                 progress.Report(new ProgressReport() { ReportType = ReportType.Status, Data = "Combining Parts (2/3)" });
                 progress.Report(new ProgressReport() { ReportType = ReportType.Percent, Data = 0 });
 
-                await Task.Run(() =>
-                {
-                    string outputFile = Path.Combine(downloadFolder, "output.ts");
-                    using (FileStream outputStream = new FileStream(outputFile, FileMode.Create, FileAccess.Write))
-                    {
-                        foreach (var part in videoPartsList)
-                        {
-                            string file = Path.Combine(downloadFolder, RemoveQueryString(part));
-                            if (File.Exists(file))
-                            {
-                                byte[] writeBytes = File.ReadAllBytes(file);
-                                outputStream.Write(writeBytes, 0, writeBytes.Length);
+                await CombineVideoParts(progress, downloadFolder, videoPartsList, cancellationToken);
 
-                                try
-                                {
-                                    File.Delete(file);
-                                }
-                                catch { }
-                            }
-                            CheckCancelation(cancellationToken, downloadFolder);
-                        }
-                    }
-                });
-
-                progress.Report(new ProgressReport() { ReportType = ReportType.Status, Data = "Finalizing MP4 (3/3)" });
+                progress.Report(new ProgressReport() { ReportType = ReportType.Status, Data = $"Finalizing Video (3/3)" });
 
                 double startOffset = 0.0;
 
@@ -259,6 +238,34 @@ namespace TwitchDownloaderCore
             {
                 Cleanup(downloadFolder);
                 throw;
+            }
+        }
+
+        private async Task CombineVideoParts(IProgress<ProgressReport> progress, string downloadFolder, List<string> videoPartsList, CancellationToken cancellationToken)
+        {
+            DriveInfo outputDrive = DriveHelper.GetOutputDrive(downloadFolder);
+
+            string outputFile = Path.Combine(downloadFolder, "output.ts");
+            using (FileStream outputStream = new FileStream(outputFile, FileMode.Create, FileAccess.Write))
+            {
+                foreach (var part in videoPartsList)
+                {
+                    await DriveHelper.WaitForDrive(outputDrive, progress, cancellationToken);
+
+                    string file = Path.Combine(downloadFolder, RemoveQueryString(part));
+                    if (File.Exists(file))
+                    {
+                        byte[] writeBytes = File.ReadAllBytes(file);
+                        outputStream.Write(writeBytes, 0, writeBytes.Length);
+
+                        try
+                        {
+                            File.Delete(file);
+                        }
+                        catch { }
+                    }
+                    CheckCancelation(cancellationToken, downloadFolder);
+                }
             }
         }
 

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -7,33 +7,29 @@ namespace TwitchDownloaderWPF
     /// Interaction logic for App.xaml
     /// </summary>
     public partial class App : Application
-	{
-		public static ThemeService ThemeServiceSingleton { get; private set; }
-		public static App AppSingleton { get; private set; }
+    {
+        public static ThemeService ThemeServiceSingleton { get; private set; }
+        public static App AppSingleton { get; private set; }
 
-		public App()
-		{
-			AppSingleton = this;
-		}
+        public App()
+        {
+            AppSingleton = this;
+        }
 
-		private void Application_Startup(object sender, StartupEventArgs e)
-		{
-			WindowsThemeService windowsThemeService = new();
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            WindowsThemeService windowsThemeService = new();
 
-			ThemeServiceSingleton = new ThemeService(this, windowsThemeService);
+            ThemeServiceSingleton = new ThemeService(this, windowsThemeService);
 
-			MainWindow wnd = new();
-			wnd.Show();
-		}
+            MainWindow wnd = new();
+            wnd.Show();
+        }
 
-		public void RequestAppThemeChange()
-		{
-			ThemeServiceSingleton.ChangeAppTheme();
-		}
+        public void RequestAppThemeChange()
+            => ThemeServiceSingleton.ChangeAppTheme();
 
-		public void RequestTitleBarChange()
-		{
-			ThemeServiceSingleton.SetTitleBarTheme(this.Windows);
-		}
+        public void RequestTitleBarChange()
+            => ThemeServiceSingleton.SetTitleBarTheme(Windows);
     }
 }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -237,12 +237,18 @@ namespace TwitchDownloaderWPF
 
         private void OnProgressChanged(ProgressReport progress)
         {
-            if (progress.ReportType == ReportType.Percent)
-                statusProgressBar.Value = (int)progress.Data;
-            if (progress.ReportType is ReportType.Status or ReportType.StatusInfo)
-                statusMessage.Text = (string)progress.Data;
-            if (progress.ReportType == ReportType.Log)
-                AppendLog((string)progress.Data);
+            switch (progress.ReportType)
+            {
+                case ReportType.Percent:
+                    statusProgressBar.Value = (int)progress.Data;
+                    break;
+                case ReportType.Status or ReportType.StatusInfo:
+                    statusMessage.Text = (string)progress.Data;
+                    break;
+                case ReportType.Log:
+                    AppendLog((string)progress.Data);
+                    break;
+            }
         }
 
         public void SetImage(string imageUri, bool isGif)

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -77,7 +77,7 @@
                         <TextBlock Text="BTTV Emotes:" HorizontalAlignment="Right" Margin="0,0,0,0" Foreground="{DynamicResource AppText}"/>
                         <TextBlock Text="FFZ Emotes:" HorizontalAlignment="Right" Margin="0,6,0,0" Foreground="{DynamicResource AppText}"/>
                         <TextBlock Text="7TV Emotes:" HorizontalAlignment="Right" Margin="0,6,0,0" Foreground="{DynamicResource AppText}"/>
-                        <TextBlock HorizontalAlignment="Right" Margin="0,6,0,0"><Run Text="Offline " Foreground="{DynamicResource AppText}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>Render the chat using only resources embedded in the chat json file.</Hyperlink.ToolTip><Run Text="(?)"/></Hyperlink><Run Text=":"/></TextBlock>
+                        <TextBlock HorizontalAlignment="Right" Margin="0,6,0,0" Foreground="{DynamicResource AppText}">Offline <Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>Render the chat using only resources embedded in the chat json file.</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                     </StackPanel>
                     <StackPanel Orientation="Vertical" Margin="0,10,0,2">
                         <CheckBox x:Name="checkBTTV" HorizontalAlignment="Left" Margin="0,2,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
@@ -88,7 +88,7 @@
                     <StackPanel Orientation="Vertical" Margin="20,10,0,5">
                         <TextBlock Text="Chat Badge Filter:" Foreground="{DynamicResource AppText}"></TextBlock>
                         <hc:CheckComboBox x:Name="comboBadges" MinWidth="200" HorizontalAlignment="Left" Margin="0,4,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-                        <TextBlock Margin="0,10,0,0"><Run Text="Ignore users list " Foreground="{DynamicResource AppText}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>List of usernames - comma separated, spaces around commas ignored, NOT case-sensitive.</Hyperlink.ToolTip><Run Text="(?)"/></Hyperlink><Run Text=":"/></TextBlock>
+                        <TextBlock Margin="0,10,0,0" Foreground="{DynamicResource AppText}">Ignore users list <Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>List of usernames - comma separated, spaces around commas ignored, NOT case-sensitive.</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                         <TextBox x:Name="textIgnoreUsersList" Margin="0,4,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     </StackPanel>
                 </DockPanel>

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -110,6 +110,9 @@ namespace TwitchDownloaderWPF
                 case ReportType.Log:
                     AppendLog((string)progress.Data);
                     break;
+                case ReportType.FfmpegLog:
+                    ffmpegLog.Add((string)progress.Data);
+                    break;
             }
         }
 

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -86,7 +86,8 @@ namespace TwitchDownloaderWPF
                 TempFolder = Settings.Default.TempPath,
                 SubMessages = (bool)checkSub.IsChecked,
                 ChatBadges = (bool)checkBadge.IsChecked,
-                Offline = (bool)checkOffline.IsChecked
+                Offline = (bool)checkOffline.IsChecked,
+                LogFfmpegOutput = true
             };
             foreach (var item in comboBadges.SelectedItems)
             {
@@ -98,14 +99,18 @@ namespace TwitchDownloaderWPF
 
         private void OnProgressChanged(ProgressReport progress)
         {
-            if (progress.ReportType == ReportType.Percent)
-                statusProgressBar.Value = (int)progress.Data;
-            if (progress.ReportType is ReportType.Status or ReportType.StatusInfo)
-                statusMessage.Text = (string)progress.Data;
-            if (progress.ReportType == ReportType.FfmpegLog)
-                ffmpegLog.Add((string)progress.Data);
-            if (progress.ReportType == ReportType.Log)
-                AppendLog((string)progress.Data);
+            switch (progress.ReportType)
+            {
+                case ReportType.Percent:
+                    statusProgressBar.Value = (int)progress.Data;
+                    break;
+                case ReportType.Status or ReportType.StatusInfo:
+                    statusMessage.Text = (string)progress.Data;
+                    break;
+                case ReportType.Log:
+                    AppendLog((string)progress.Data);
+                    break;
+            }
         }
 
         private void LoadSettings()
@@ -513,16 +518,7 @@ namespace TwitchDownloaderWPF
                             AppendLog("ERROR: " + ex.Message);
                             if (Settings.Default.VerboseErrors)
                             {
-                                if (ex.Message.Contains("The pipe has been ended"))
-                                {
-                                    string errorLog = String.Join('\n', ffmpegLog.ToArray());
-                                    Clipboard.SetText(errorLog);
-                                    MessageBox.Show(errorLog, "Verbose error output", MessageBoxButton.OK, MessageBoxImage.Error);
-                                }
-                                else
-                                {
-                                    MessageBox.Show(ex.ToString(), "Verbose error output", MessageBoxButton.OK, MessageBoxImage.Error);
-                                }
+                                MessageBox.Show(ex.ToString(), "Verbose error output", MessageBoxButton.OK, MessageBoxImage.Error);
                             }
                         }
                         statusProgressBar.Value = 0;

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -232,12 +232,18 @@ namespace TwitchDownloaderWPF
 
         private void OnProgressChanged(ProgressReport progress)
         {
-            if (progress.ReportType == ReportType.Percent)
-                statusProgressBar.Value = (int)progress.Data;
-            if (progress.ReportType is ReportType.Status or ReportType.StatusInfo)
-                statusMessage.Text = (string)progress.Data;
-            if (progress.ReportType == ReportType.Log)
-                AppendLog((string)progress.Data);
+            switch (progress.ReportType)
+            {
+                case ReportType.Percent:
+                    statusProgressBar.Value = (int)progress.Data;
+                    break;
+                case ReportType.Status or ReportType.StatusInfo:
+                    statusMessage.Text = (string)progress.Data;
+                    break;
+                case ReportType.Log:
+                    AppendLog((string)progress.Data);
+                    break;
+            }
         }
 
         public void SetImage(string imageUri, bool isGif)

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -109,9 +109,9 @@ namespace TwitchDownloaderWPF
 
         private void AppendLog(string message)
         {
-            textLog.Dispatcher.BeginInvoke((Action)(() =>
+            textLog.Dispatcher.BeginInvoke(() =>
                 textLog.AppendText(message + Environment.NewLine)
-            ));
+            );
         }
 
         private void Page_Initialized(object sender, EventArgs e)
@@ -138,7 +138,7 @@ namespace TwitchDownloaderWPF
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)
         {
-            System.Diagnostics.Process.Start(new ProcessStartInfo("https://www.buymeacoffee.com/lay295") { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo("https://www.buymeacoffee.com/lay295") { UseShellExecute = true });
         }
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -60,7 +60,7 @@
                 <TextBlock Text="Quality:" HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="Crop Video:" HorizontalAlignment="Right" Margin="0,20,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="Download Threads:" HorizontalAlignment="Right" Margin="0,50,0,0" Foreground="{DynamicResource AppText}" />
-                <TextBlock HorizontalAlignment="Right" Margin="0,22,0,0"><Run Text="OAuth (optional) " Foreground="{DynamicResource AppText}" /><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>Only required for sub only VODs. All 3rd party OAuth tokens will not work. Click to see YouTube video on how to get OAuth token.</Hyperlink.ToolTip><Run Text="(?)"/></Hyperlink><Run Text=":"/></TextBlock>
+                <TextBlock HorizontalAlignment="Right" Margin="0,22,0,0" Foreground="{DynamicResource AppText}">OAuth (optional) <Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>Only required for sub only VODs. All 3rd party OAuth tokens will not work. Click to see YouTube video on how to get OAuth token.</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
             </StackPanel>
             <StackPanel>
                 <TextBlock x:Name="labelLength" Text="0:0:0" Margin="5,0,0,0" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -174,12 +174,18 @@ namespace TwitchDownloaderWPF
 
         private void OnProgressChanged(ProgressReport progress)
         {
-            if (progress.ReportType == ReportType.Percent)
-                statusProgressBar.Value = (int)progress.Data;
-            if (progress.ReportType is ReportType.Status or ReportType.StatusInfo)
-                statusMessage.Text = (string)progress.Data;
-            if (progress.ReportType == ReportType.Log)
-                AppendLog((string)progress.Data);
+            switch (progress.ReportType)
+            {
+                case ReportType.Percent:
+                    statusProgressBar.Value = (int)progress.Data;
+                    break;
+                case ReportType.Status or ReportType.StatusInfo:
+                    statusMessage.Text = (string)progress.Data;
+                    break;
+                case ReportType.Log:
+                    AppendLog((string)progress.Data);
+                    break;
+            }
         }
 
         public void SetImage(string imageUri, bool isGif)
@@ -268,11 +274,11 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        public void AppendLog(string message)
+        private void AppendLog(string message)
         {
-            textLog.Dispatcher.BeginInvoke((Action)(() =>
+            textLog.Dispatcher.BeginInvoke(() =>
                 textLog.AppendText(message + Environment.NewLine)
-            ));
+            );
         }
 
         private void Page_Initialized(object sender, EventArgs e)

--- a/TwitchDownloaderWPF/SettingsPage.xaml
+++ b/TwitchDownloaderWPF/SettingsPage.xaml
@@ -36,10 +36,11 @@
                 <CheckBox x:Name="checkVerboseErrors" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" BorderBrush="{DynamicResource AppElementBorder}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
-				<TextBlock Margin="3,8,3,3" Text="Theme:" Foreground="{DynamicResource AppText}" />
+                <!--TODO: Add theme creation window instead of just opening the theme folder-->
+                <TextBlock Margin="3,7,3,3" Foreground="{DynamicResource AppText}">Theme <Hyperlink ToolTipService.ShowDuration="30000" NavigateUri="Themes" RequestNavigate="Hyperlink_RequestNavigate" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip>Click to learn how to make your own theme!</Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                 <ComboBox x:Name="comboTheme" MinWidth="100" MaxWidth="345" HorizontalAlignment="Left" SelectionChanged="comboTheme_SelectionChanged" Margin="3,0,3,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
-			</StackPanel>
-			<TextBlock Margin="3,5,3,3" Text="Download Filename Templates:" Foreground="{DynamicResource AppText}" />
+            </StackPanel>
+            <TextBlock Margin="3,5,3,3" Text="Download Filename Templates:" Foreground="{DynamicResource AppText}" />
             <StackPanel Margin="0" Orientation="Horizontal">
                 <StackPanel Orientation="Vertical">
                     <TextBlock Margin="3,10,3,3" Text="VODs:" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/SettingsPage.xaml.cs
+++ b/TwitchDownloaderWPF/SettingsPage.xaml.cs
@@ -99,7 +99,14 @@ namespace TwitchDownloader
 
         private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
         {
-            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+            Uri uri = e.Uri;
+            if (!uri.IsAbsoluteUri)
+            {
+                string destinationPath = Path.Combine(Environment.CurrentDirectory, uri.OriginalString);
+                uri = new Uri(destinationPath);
+            }
+
+            Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
             e.Handled = true;
         }
 


### PR DESCRIPTION
- Fix pipe end errors when rendering to a drive that disconnects during high loads[^1] (Fixes #465)
- Cleanup CLI runmodes
- Cleanup CLI ProgressHandler
- Cleanup progress report handling in GUI

[^1]: Because of the constant drive checks, I noticed a *very* slight performance dip when rendering from 201s -> 203s (41.2x -> 40.9x) 