### PR TITLE
Fix storing the HttpResponseMessage Content in memory

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -372,7 +372,7 @@ namespace TwitchDownloaderCore
                     catch { failedInfo = true; }
                 }
 
-                if (!failedInfo)
+                if (failedInfo)
                 {
                     progress.Report(new ProgressReport() { ReportType = ReportType.Log, Data = "Failed to backfill some commenter info" });
                 }

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -85,7 +85,7 @@ namespace TwitchDownloaderCore
             {
                 await RenderVideoSection(startTick, startTick + totalTicks, ffmpegProcess, maskProcess, progress, cancellationToken);
             }
-            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
+            catch
             {
                 ffmpegProcess.Process.Dispose();
                 maskProcess?.Process.Dispose();

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -85,7 +85,7 @@ namespace TwitchDownloaderCore
             {
                 await RenderVideoSection(startTick, startTick + totalTicks, ffmpegProcess, maskProcess, progress, cancellationToken);
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ffmpegProcess.Process.Dispose();
                 maskProcess?.Process.Dispose();

--- a/TwitchDownloaderCore/ProgressReport.cs
+++ b/TwitchDownloaderCore/ProgressReport.cs
@@ -11,6 +11,9 @@
 
     public class ProgressReport
     {
+        public ReportType ReportType { get; set; }
+        public object Data { get; set; }
+
         public ProgressReport() { }
 
         public ProgressReport(int percent)
@@ -25,7 +28,9 @@
             Data = message;
         }
 
-        public ReportType ReportType { get; set; }
-        public object Data { get; set; }
+        ~ProgressReport()
+        {
+            Data = null;
+        }
     }
 }

--- a/TwitchDownloaderCore/TwitchDownloaderCore.csproj
+++ b/TwitchDownloaderCore/TwitchDownloaderCore.csproj
@@ -10,7 +10,6 @@
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>default</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	<NoWarn>SYSLIB0014</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchDownloaderWPF/TwitchTasks/ChatDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatDownloadTask.cs
@@ -64,7 +64,7 @@ namespace TwitchDownloader.TwitchTasks
                     ChangeStatus(TwitchTaskStatus.Finished);
                 }
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ChangeStatus(TwitchTaskStatus.Cancelled);
             }

--- a/TwitchDownloaderWPF/TwitchTasks/ChatRenderTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatRenderTask.cs
@@ -84,7 +84,7 @@ namespace TwitchDownloader.TwitchTasks
                     OnPropertyChanged(nameof(Progress));
                 }
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ChangeStatus(TwitchTaskStatus.Cancelled);
             }

--- a/TwitchDownloaderWPF/TwitchTasks/ChatUpdateTask .cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatUpdateTask .cs
@@ -66,7 +66,7 @@ namespace TwitchDownloader.TwitchTasks
                     ChangeStatus(TwitchTaskStatus.Finished);
                 }
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ChangeStatus(TwitchTaskStatus.Cancelled);
             }

--- a/TwitchDownloaderWPF/TwitchTasks/ClipDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ClipDownloadTask.cs
@@ -65,7 +65,7 @@ namespace TwitchDownloader.TwitchTasks
                     ChangeStatus(TwitchTaskStatus.Finished);
                 }
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ChangeStatus(TwitchTaskStatus.Cancelled);
             }

--- a/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
@@ -65,7 +65,7 @@ namespace TwitchDownloader.TwitchTasks
                     ChangeStatus(TwitchTaskStatus.Finished);
                 }
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
             {
                 ChangeStatus(TwitchTaskStatus.Cancelled);
             }


### PR DESCRIPTION
- Don't store the response content in memory!!
- Fix backwards progress report when backfilling
- Add TaskCanceledException to cancel checks
- Add ProgressReport finalizer (probably unneeded anyways)
- Remove webclient warn suppression