### PR TITLE
Minor refactoring

### DIFF
--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchDownloaderCore.Options
+﻿namespace TwitchDownloaderCore.Options
 {
     public class VideoDownloadOptions
     {
         public int Id { get; set; }
-        public string PlaylistUrl { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
         public bool CropBeginning { get; set; }

--- a/TwitchDownloaderWPF/InfoHelper.cs
+++ b/TwitchDownloaderWPF/InfoHelper.cs
@@ -6,6 +6,8 @@ namespace TwitchDownloader
 {
     class InfoHelper
     {
+        public const string thumbnailMissingUrl = @"https://vod-secure.twitch.tv/_404/404_processing_320x180.png";
+
         public static async Task<BitmapImage> GetThumb(string thumbUrl)
         {
             using (HttpClient client = new HttpClient())

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -78,8 +78,8 @@ namespace TwitchDownloaderWPF
 
             Version currentVersion = new Version("1.51.1");
             Title = string.Format("Twitch Downloader v{0}", currentVersion);
-#if !DEBUG
             AutoUpdater.InstalledVersion = currentVersion;
+#if !DEBUG
             AutoUpdater.Start("https://downloader-update.twitcharchives.workers.dev");
 #endif
         }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -18,11 +18,11 @@ using WpfAnimatedGif;
 namespace TwitchDownloaderWPF
 {
     public enum DownloadType { Clip, Video }
-	/// <summary>
-	/// Interaction logic for PageChatDownload.xaml
-	/// </summary>
-	public partial class PageChatDownload : Page
-	{
+    /// <summary>
+    /// Interaction logic for PageChatDownload.xaml
+    /// </summary>
+    public partial class PageChatDownload : Page
+    {
 
         public DownloadType downloadType;
         public string downloadId;
@@ -102,19 +102,17 @@ namespace TwitchDownloaderWPF
                     {
                         Task<GqlVideoResponse> taskVideoInfo = TwitchHelper.GetVideoInfo(int.Parse(downloadId));
                         await Task.WhenAll(taskVideoInfo);
-                        string thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
-                        Task<BitmapImage> taskThumb = InfoHelper.GetThumb(thumbUrl);
 
                         try
                         {
-                            await taskThumb;
+                            string thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
+                            imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                         }
                         catch
                         {
                             AppendLog("ERROR: Unable to find thumbnail");
+                            imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         }
-                        if (!taskThumb.IsFaulted)
-                            imgThumbnail.Source = taskThumb.Result;
                         TimeSpan vodLength = TimeSpan.FromSeconds(taskVideoInfo.Result.data.video.lengthSeconds);
                         textTitle.Text = taskVideoInfo.Result.data.video.title;
                         textStreamer.Text = taskVideoInfo.Result.data.video.owner.displayName;
@@ -141,19 +139,17 @@ namespace TwitchDownloaderWPF
                         string clipId = downloadId;
                         Task<GqlClipResponse> taskClipInfo = TwitchHelper.GetClipInfo(clipId);
                         await Task.WhenAll(taskClipInfo);
-                        string thumbUrl = taskClipInfo.Result.data.clip.thumbnailURL;
-                        Task<BitmapImage> taskThumb = InfoHelper.GetThumb(thumbUrl);
 
                         try
                         {
-                            await taskThumb;
+                            string thumbUrl = taskClipInfo.Result.data.clip.thumbnailURL;
+                            imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                         }
                         catch
                         {
                             AppendLog("ERROR: Unable to find thumbnail");
+                            imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         }
-                        if (!taskThumb.IsFaulted)
-                            imgThumbnail.Source = taskThumb.Result;
                         TimeSpan clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
                         textStreamer.Text = taskClipInfo.Result.data.clip.broadcaster.displayName;
                         textCreatedAt.Text = taskClipInfo.Result.data.clip.createdAt.ToString();
@@ -225,7 +221,7 @@ namespace TwitchDownloaderWPF
                 options.DownloadFormat = ChatFormat.Html;
             else if (radioText.IsChecked == true)
                 options.DownloadFormat = ChatFormat.Text;
-            
+
             options.EmbedData = (bool)checkEmbed.IsChecked;
             options.BttvEmotes = (bool)checkBttvEmbed.IsChecked;
             options.FfzEmotes = (bool)checkFfzEmbed.IsChecked;

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -79,20 +79,22 @@ namespace TwitchDownloaderWPF
                         if (videoInfo.data.video == null)
                         {
                             AppendLog("ERROR: Unable to find thumbnail: VOD is expired or embedded ID is corrupt");
+                            imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         }
                         else
                         {
                             videoLength = TimeSpan.FromSeconds(videoInfo.data.video.lengthSeconds);
                             labelLength.Text = string.Format("{0:00}:{1:00}:{2:00}", (int)videoLength.TotalHours, videoLength.Minutes, videoLength.Seconds);
 
-                            Task<BitmapImage> taskThumb = InfoHelper.GetThumb(videoInfo.data.video.thumbnailURLs.FirstOrDefault());
                             try
                             {
-                                imgThumbnail.Source = await taskThumb;
+                                string thumbUrl = videoInfo.data.video.thumbnailURLs.FirstOrDefault();
+                                imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                             }
                             catch
                             {
                                 AppendLog("ERROR: Unable to find thumbnail");
+                                imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                             }
                         }
                     }
@@ -102,20 +104,22 @@ namespace TwitchDownloaderWPF
                         if (videoInfo.data.clip.video == null)
                         {
                             AppendLog("ERROR: Unable to find thumbnail: VOD is expired or embedded ID is corrupt");
+                            imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         }
                         else
                         {
                             videoLength = TimeSpan.FromSeconds(videoInfo.data.clip.durationSeconds);
                             labelLength.Text = string.Format("{0:00}:{1:00}:{2:00}", (int)videoLength.TotalHours, videoLength.Minutes, videoLength.Seconds);
 
-                            Task<BitmapImage> taskThumb = InfoHelper.GetThumb(videoInfo.data.clip.thumbnailURL);
                             try
                             {
-                                imgThumbnail.Source = await taskThumb;
+                                string thumbUrl = videoInfo.data.clip.thumbnailURL;
+                                imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                             }
                             catch
                             {
                                 AppendLog("ERROR: Unable to find thumbnail");
+                                imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                             }
                         }
                     }

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -48,19 +48,17 @@ namespace TwitchDownloaderWPF
                     await Task.WhenAll(taskClipInfo, taskLinks);
 
                     GqlClipResponse clipData = taskClipInfo.Result;
-                    string thumbUrl = clipData.data.clip.thumbnailURL;
-                    Task<BitmapImage> taskThumb = InfoHelper.GetThumb(thumbUrl);
 
                     try
                     {
-                        await taskThumb;
+                        string thumbUrl = clipData.data.clip.thumbnailURL;
+                        imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                     }
                     catch
                     {
                         AppendLog("ERROR: Unable to find thumbnail");
+                        imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                     }
-                    if (!taskThumb.IsFaulted)
-                        imgThumbnail.Source = taskThumb.Result;
                     TimeSpan clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
                     textStreamer.Text = clipData.data.clip.broadcaster.displayName;
                     textCreatedAt.Text = clipData.data.clip.createdAt.ToString();

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -75,17 +75,17 @@ namespace TwitchDownloaderWPF
                     Task<GqlVideoResponse> taskVideoInfo = TwitchHelper.GetVideoInfo(videoId);
                     Task<GqlVideoTokenResponse> taskAccessToken = TwitchHelper.GetVideoToken(videoId, textOauth.Text);
                     await Task.WhenAll(taskVideoInfo, taskAccessToken);
-                    string thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
-                    Task<BitmapImage> thumbImage = InfoHelper.GetThumb(thumbUrl);
                     Task<string[]> taskPlaylist = TwitchHelper.GetVideoPlaylist(videoId, taskAccessToken.Result.data.videoPlaybackAccessToken.value, taskAccessToken.Result.data.videoPlaybackAccessToken.signature);
                     await taskPlaylist;
                     try
                     {
-                        await thumbImage;
+                        string thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
+                        imgThumbnail.Source = await InfoHelper.GetThumb(thumbUrl);
                     }
                     catch
                     {
                         AppendLog("ERROR: Unable to find thumbnail");
+                        imgThumbnail.Source = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                     }
 
                     comboQuality.Items.Clear();
@@ -107,8 +107,6 @@ namespace TwitchDownloaderWPF
                     }
                     comboQuality.SelectedIndex = 0;
 
-                    if (!thumbImage.IsFaulted)
-                        imgThumbnail.Source = thumbImage.Result;
                     TimeSpan vodLength = TimeSpan.FromSeconds(taskVideoInfo.Result.data.video.lengthSeconds);
                     textStreamer.Text = taskVideoInfo.Result.data.video.owner.displayName;
                     textTitle.Text = taskVideoInfo.Result.data.video.title;

--- a/TwitchDownloaderWPF/TwitchTasks/ChatDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatDownloadTask.cs
@@ -16,14 +16,17 @@ namespace TwitchDownloader.TwitchTasks
         public CancellationTokenSource TokenSource { get; set; } = new CancellationTokenSource();
         public ITwitchTask DependantTask { get; set; }
         public string TaskType { get; } = "Chat Download";
-        public Exception TaskException { get; private set; }
         public TwitchTaskException Exception { get; private set; } = new();
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public void Cancel()
         {
-            TokenSource.Cancel();
+            try
+            {
+                TokenSource.Cancel();
+            }
+            catch (ObjectDisposedException) { }
 
             if (Status == TwitchTaskStatus.Running)
             {
@@ -75,6 +78,7 @@ namespace TwitchDownloader.TwitchTasks
                 OnPropertyChanged(nameof(Exception));
             }
             downloader = null;
+            TokenSource.Dispose();
             GC.Collect();
             GC.WaitForPendingFinalizers();
         }

--- a/TwitchDownloaderWPF/TwitchTasks/ChatRenderTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatRenderTask.cs
@@ -22,7 +22,11 @@ namespace TwitchDownloader.TwitchTasks
 
         public void Cancel()
         {
-            TokenSource.Cancel();
+            try
+            {
+                TokenSource.Cancel();
+            }
+            catch (ObjectDisposedException) { }
 
             if (Status == TwitchTaskStatus.Running)
             {
@@ -95,6 +99,7 @@ namespace TwitchDownloader.TwitchTasks
                 OnPropertyChanged(nameof(Exception));
             }
             renderer = null;
+            TokenSource.Dispose();
             GC.Collect();
             GC.WaitForPendingFinalizers();
         }

--- a/TwitchDownloaderWPF/TwitchTasks/ChatUpdateTask .cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ChatUpdateTask .cs
@@ -16,14 +16,17 @@ namespace TwitchDownloader.TwitchTasks
         public CancellationTokenSource TokenSource { get; set; } = new CancellationTokenSource();
         public ITwitchTask DependantTask { get; set; }
         public string TaskType { get; } = "Chat Update";
-        public Exception TaskException { get; private set; }
         public TwitchTaskException Exception { get; private set; } = new();
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public void Cancel()
         {
-            TokenSource.Cancel();
+            try
+            {
+                TokenSource.Cancel();
+            }
+            catch (ObjectDisposedException) { }
 
             if (Status == TwitchTaskStatus.Running)
             {
@@ -77,6 +80,7 @@ namespace TwitchDownloader.TwitchTasks
                 OnPropertyChanged(nameof(Exception));
             }
             updater = null;
+            TokenSource.Dispose();
             GC.Collect();
             GC.WaitForPendingFinalizers();
         }

--- a/TwitchDownloaderWPF/TwitchTasks/ClipDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ClipDownloadTask.cs
@@ -16,14 +16,17 @@ namespace TwitchDownloader.TwitchTasks
         public CancellationTokenSource TokenSource { get; set; } = new CancellationTokenSource();
         public ITwitchTask DependantTask { get; set; }
         public string TaskType { get; } = "Clip Download";
-        public Exception TaskException { get; private set; }
         public TwitchTaskException Exception { get; private set; } = new();
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public void Cancel()
         {
-            TokenSource.Cancel();
+            try
+            {
+                TokenSource.Cancel();
+            }
+            catch (ObjectDisposedException) { }
 
             if (Status == TwitchTaskStatus.Running)
             {
@@ -76,6 +79,7 @@ namespace TwitchDownloader.TwitchTasks
                 OnPropertyChanged(nameof(Exception));
             }
             downloader = null;
+            TokenSource.Dispose();
             GC.Collect();
             GC.WaitForPendingFinalizers();
         }

--- a/TwitchDownloaderWPF/TwitchTasks/ITwitchTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/ITwitchTask.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
@@ -16,14 +16,17 @@ namespace TwitchDownloader.TwitchTasks
         public CancellationTokenSource TokenSource { get; set; } = new CancellationTokenSource();
         public ITwitchTask DependantTask { get; set; }
         public string TaskType { get; } = "VOD Download";
-        public Exception TaskException { get; private set; }
         public TwitchTaskException Exception { get; private set; } = new();
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public void Cancel()
         {
-            TokenSource.Cancel();
+            try
+            {
+                TokenSource.Cancel();
+            }
+            catch (ObjectDisposedException) { }
 
             if (Status == TwitchTaskStatus.Running)
             {
@@ -76,6 +79,7 @@ namespace TwitchDownloader.TwitchTasks
                 OnPropertyChanged(nameof(Exception));
             }
             downloader = null;
+            TokenSource.Dispose();
             GC.Collect();
             GC.WaitForPendingFinalizers();
         }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -343,6 +343,7 @@ namespace TwitchDownloader
                         ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
                         renderTask.DownloadOptions = renderOptions;
                         renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
+                        renderTask.Info.Thumbnail = InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl).Result;
                         renderTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)


### PR DESCRIPTION
### VideoDownloader.cs
- Extract some code into methods for easier management and cleaner stack traces[^1]
- Catch IOException when cleaning up
- Make some methods static
- Remove some redundant code

### GUI
- Dispose of TwitchTask token sources once completed/canceled
- Add 404 thumbnail
- Move the autoupdate preprocessor so the import isn't imcorrectly marked as unnecessary; intellisense is stupid.

[^1]: Hopefully this let's us catch the cause of #401 so we can throw a custom exception message instead or wait and retry.