### PR TITLE
Print unhandled gui exceptions before exiting

### DIFF
--- a/TwitchDownloaderWPF/App.xaml
+++ b/TwitchDownloaderWPF/App.xaml
@@ -2,7 +2,6 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:TwitchDownloaderWPF"
-             Startup="Application_Startup"
              xmlns:hc="https://handyorg.github.io/handycontrol">
 	<Application.Resources>
 		<ResourceDictionary>

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -18,8 +18,9 @@ namespace TwitchDownloaderWPF
             AppSingleton = this;
         }
 
-        private void Application_Startup(object sender, StartupEventArgs e)
+        protected override void OnStartup(StartupEventArgs e)
         {
+            base.OnStartup(e);
             WindowsThemeService windowsThemeService = new();
 
             ThemeServiceSingleton = new ThemeService(this, windowsThemeService);

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
+using System.Windows.Threading;
 using TwitchDownloader.Tools;
 
 namespace TwitchDownloaderWPF
@@ -22,8 +24,27 @@ namespace TwitchDownloaderWPF
 
             ThemeServiceSingleton = new ThemeService(this, windowsThemeService);
 
-            MainWindow wnd = new();
-            wnd.Show();
+            Current.DispatcherUnhandledException += Current_DispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+
+            MainWindow mainWindow = new();
+            mainWindow.Show();
+        }
+
+        private void Current_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            Exception ex = e.Exception;
+            MessageBox.Show(ex.ToString(), "Fatal Error", MessageBoxButton.OK, MessageBoxImage.Error);
+
+            Current?.Shutdown();
+        }
+
+        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Exception ex = (Exception)e.ExceptionObject;
+            MessageBox.Show(ex.ToString(), "Fatal Error", MessageBoxButton.OK, MessageBoxImage.Error);
+
+            Current?.Shutdown();
         }
 
         public void RequestAppThemeChange()

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -27,8 +27,8 @@ namespace TwitchDownloaderWPF
             Current.DispatcherUnhandledException += Current_DispatcherUnhandledException;
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 
-            MainWindow mainWindow = new();
-            mainWindow.Show();
+            MainWindow = new MainWindow();
+            MainWindow.Show();
         }
 
         private void Current_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -90,7 +90,7 @@ namespace TwitchDownloader
                 textFolder.Text = queueFolder;
         }
 
-        private void btnQueue_Click(object sender, RoutedEventArgs e)
+        private async void btnQueue_Click(object sender, RoutedEventArgs e)
         {
             if (parentPage != null)
             {
@@ -343,7 +343,7 @@ namespace TwitchDownloader
                         ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
                         renderTask.DownloadOptions = renderOptions;
                         renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
-                        renderTask.Info.Thumbnail = InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl).Result;
+                        renderTask.Info.Thumbnail = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         renderTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)


### PR DESCRIPTION
Just reading about some better practices is all. I'll likely also switch to `IHttpClientFactory` in a later PR to fix the issues with using a static `HttpClient`.