### PR TITLE
Fix renders crashing when user colors are blank and not null

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -934,7 +934,15 @@ namespace TwitchDownloaderCore
         private void DrawUsername(Comment comment, List<SKBitmap> sectionImages, ref Point drawPos, IProgress<ProgressReport> progress)
         {
             using SKCanvas sectionImageCanvas = new SKCanvas(sectionImages.Last());
-            SKColor userColor = SKColor.Parse(comment.message.user_color ?? defaultColors[Math.Abs(comment.commenter.display_name.GetHashCode()) % defaultColors.Length]);
+            SKColor userColor;
+            if (!string.IsNullOrWhiteSpace(comment.message.user_color))
+            {
+                userColor = SKColor.Parse(comment.message.user_color);
+            }
+            else
+            {
+                userColor = SKColor.Parse(defaultColors[Math.Abs(comment.commenter.display_name.GetHashCode()) % defaultColors.Length]);
+            }
             userColor = GenerateUserColor(userColor, renderOptions.BackgroundColor, renderOptions);
 
             SKPaint userPaint = comment.commenter.display_name.Any(IsNotAscii)

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -90,7 +90,7 @@ namespace TwitchDownloader
                 textFolder.Text = queueFolder;
         }
 
-        private void btnQueue_Click(object sender, RoutedEventArgs e)
+        private async void btnQueue_Click(object sender, RoutedEventArgs e)
         {
             if (parentPage != null)
             {
@@ -343,7 +343,7 @@ namespace TwitchDownloader
                         ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
                         renderTask.DownloadOptions = renderOptions;
                         renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
-                        renderTask.Info.Thumbnail = InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl).Result;
+                        renderTask.Info.Thumbnail = await InfoHelper.GetThumb(InfoHelper.thumbnailMissingUrl);
                         renderTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)


### PR DESCRIPTION
Fixes #500 

Also there's a severe memory leak somewhere that this chat exposes. All emotes/badges are disabled. Seems like it's stuck in a recursion loop or something.
![image](https://user-images.githubusercontent.com/72096833/211177476-e164fd1f-402d-4380-8542-e8d3726baed3.png)
