### PR TITLE
Support URLs in video, clip, chat downloading in CLI

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -7,7 +7,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
     [Verb("chatdownload", HelpText = "Downloads the chat from a VOD or clip")]
     public class ChatDownloadArgs
     {
-        [Option('u', "id", Required = true, HelpText = "The ID of the VOD or clip to download that chat of.")]
+        [Option('u', "id", Required = true, HelpText = "The ID or URL of the VOD or clip to download that chat of.")]
         public string Id { get; set; }
 
         [Option('o', "output", Required = true, HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: json, html, and txt.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ClipDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ClipDownloadArgs.cs
@@ -6,7 +6,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
     [Verb("clipdownload", HelpText = "Downloads a clip from Twitch")]
     public class ClipDownloadArgs
     {
-        [Option('u', "id", Required = true, HelpText = "The ID of the clip to download.")]
+        [Option('u', "id", Required = true, HelpText = "The ID or URL of the clip to download.")]
         public string Id { get; set; }
 
         [Option('o', "output", Required = true, HelpText = "Path to output file.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -6,7 +6,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
     [Verb("videodownload", HelpText = "Downloads a stream VOD from Twitch")]
     public class VideoDownloadArgs
     {
-        [Option('u', "id", Required = true, HelpText = "The ID of the VOD to download.")]
+        [Option('u', "id", Required = true, HelpText = "The ID or URL of the VOD to download.")]
         public string Id { get; set; }
 
         [Option('o', "output", Required = true, HelpText = "Path to output file.")]

--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
@@ -22,9 +23,17 @@ namespace TwitchDownloaderCLI.Modes
 
         private static ChatDownloadOptions GetDownloadOptions(ChatDownloadArgs inputOptions)
         {
-            if (string.IsNullOrWhiteSpace(inputOptions.Id))
+            if (inputOptions.Id is null)
             {
-                Console.WriteLine("[ERROR] - Invalid ID, unable to parse.");
+                Console.WriteLine("[ERROR] - Vod/Clip ID/URL cannot be null!");
+                Environment.Exit(1);
+            }
+
+            var vodClipIdRegex = new Regex(@"(?:^|(?:twitch.tv\/(?:videos|\w+\/clip)\/))(\w+(?:-\w+)?)(?:$|\?)");
+            var vodClipIdMatch = vodClipIdRegex.Match(inputOptions.Id);
+            if (!vodClipIdMatch.Success)
+            {
+                Console.WriteLine("[ERROR] - Unable to parse Vod/Clip ID/URL.");
                 Environment.Exit(1);
             }
 
@@ -36,7 +45,7 @@ namespace TwitchDownloaderCLI.Modes
                     ".json" => ChatFormat.Json,
                     _ => ChatFormat.Text
                 },
-                Id = inputOptions.Id,
+                Id = vodClipIdMatch.Groups[1].ToString(),
                 CropBeginning = inputOptions.CropBeginningTime > 0.0,
                 CropBeginningTime = inputOptions.CropBeginningTime,
                 CropEnding = inputOptions.CropEndingTime > 0.0,

--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using System.Text.RegularExpressions;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
@@ -18,15 +18,23 @@ namespace TwitchDownloaderCLI.Modes
 
         private static ClipDownloadOptions GetDownloadOptions(ClipDownloadArgs inputOptions)
         {
-            if (string.IsNullOrWhiteSpace(inputOptions.Id) || inputOptions.Id.All(char.IsDigit))
+            if (inputOptions.Id is null)
             {
-                Console.WriteLine("[ERROR] - Invalid Clip ID, unable to parse.");
+                Console.WriteLine("[ERROR] - Clip ID/URL cannot be null!");
+                Environment.Exit(1);
+            }
+
+            var clipIdRegex = new Regex(@"(?:^|(?:twitch.tv\/\w+\/clip\/))(\D\w+(?:-\w+)?)(?:$|\?)");
+            var clipIdMatch = clipIdRegex.Match(inputOptions.Id);
+            if (!clipIdMatch.Success)
+            {
+                Console.WriteLine("[ERROR] - Unable to parse Clip ID/URL.");
                 Environment.Exit(1);
             }
 
             ClipDownloadOptions downloadOptions = new()
             {
-                Id = inputOptions.Id,
+                Id = clipIdMatch.Groups[1].ToString(),
                 Filename = inputOptions.OutputFile,
                 Quality = inputOptions.Quality
             };

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
@@ -25,16 +25,24 @@ namespace TwitchDownloaderCLI.Modes
 
         private static VideoDownloadOptions GetDownloadOptions(VideoDownloadArgs inputOptions)
         {
-            if (string.IsNullOrWhiteSpace(inputOptions.Id) || !inputOptions.Id.All(char.IsDigit))
+            if (inputOptions.Id is null)
             {
-                Console.WriteLine("[ERROR] - Invalid VOD ID, unable to parse. Must be only numbers.");
+                Console.WriteLine("[ERROR] - Vod ID/URL cannot be null!");
+                Environment.Exit(1);
+            }
+
+            var vodIdRegex = new Regex(@"(?:^|(?:twitch.tv\/videos\/))(\d+)(?:$|\?)");
+            var vodIdMatch = vodIdRegex.Match(inputOptions.Id);
+            if (!vodIdMatch.Success)
+            {
+                Console.WriteLine("[ERROR] - Unable to parse Vod ID/URL.");
                 Environment.Exit(1);
             }
 
             VideoDownloadOptions downloadOptions = new()
             {
                 DownloadThreads = inputOptions.DownloadThreads,
-                Id = int.Parse(inputOptions.Id),
+                Id = int.Parse(vodIdMatch.Groups[1].ToString()),
                 Oauth = inputOptions.Oauth,
                 Filename = inputOptions.OutputFile,
                 Quality = inputOptions.Quality,

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -18,7 +18,7 @@ A cross platform command line tool that can do the main functions of the GUI pro
 <sup>Downloads a stream VOD or highlight from Twitch</sup>
 
 **-u / --id (REQUIRED)**
-The ID of the VOD to download, currently only accepts Integer IDs and will accept URLs in the future.
+The ID or URL of the VOD to download.
 
 **-o / --output (REQUIRED)**
 File the program will output to.
@@ -51,7 +51,7 @@ Path to temporary folder for cache.
 <sup>Downloads a clip from Twitch</sup>
 
 **-u / --id (REQUIRED)**
-The ID of the Clip to download, currently only accepts the string identifier and will accept URLs in the future.
+The ID or URL of the Clip to download.
 
 **-o / --output (REQUIRED)**
 File the program will output to.
@@ -64,7 +64,7 @@ The quality the program will attempt to download, for example "1080p60", if not 
 <sup>Downloads the chat of a VOD, highlight, or clip</sup>
 
 **-u / --id (REQUIRED)**
-The ID of the VOD or clip to download. Does not currently accept URLs.
+The ID or URL of the VOD or clip to download.
 
 **-o / --output (REQUIRED)**
 File the program will output to. File extension will be used to determine download type. Valid extensions are: `json`, `html`, and `txt`.


### PR DESCRIPTION
Supersedes #506 in order to not break backwards compatibility and to support all 3 downloaders.

Technically co-authored by @Teknoist