### PR TITLE
Populate Message.bits_spent in newly downloaded chats

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using TwitchDownloaderCore.Options;
@@ -18,6 +19,7 @@ namespace TwitchDownloaderCore
     {
         private readonly ChatDownloadOptions downloadOptions;
         private static HttpClient httpClient = new HttpClient();
+        private static readonly Regex _bitsRegex = new(@"(?:Cheer|BibleThump|cheerwhal|Corgo|Scoops|uni|ShowLove|Party|SeemsGood|Pride|Kappa|FrankerZ|HeyGuys|DansGame|EleGiggle|TriHard|Kreygasm|4Head|SwiftRage|NotLikeThis|FailFish|VoHiYo|PJSalt|MrDestructoid|bday|RIPCheer|Shamrock|DoodleCheer|BitBoss|Streamlabs|Muxy|HolidayCheer|Goal|Anon|Charity)(\d+)(?:\s|$)", RegexOptions.Compiled);
         private enum DownloadType { Clip, Video }
 
         public ChatDownloader(ChatDownloadOptions DownloadOptions)
@@ -173,6 +175,11 @@ namespace TwitchDownloaderCore
                 message.user_badges = badges;
                 message.user_color = oldComment.message.userColor;
                 message.emoticons = emoticons;
+                var bitMatch = _bitsRegex.Match(message.body);
+                if (bitMatch.Success)
+                {
+                    message.bits_spent = int.Parse(bitMatch.Groups[1].Value);
+                }
                 newComment.message = message;
 
                 returnList.Add(newComment);


### PR DESCRIPTION
GQL doesn't return it and also combines all the cheers into a single Cheer### word making emulating old behaviour harder.
- Fixes #519 

I'm a bit torn on if and how we should go about emulating old behaviour in the render.

1. Splitting the total into highest bit quantities is an option.
2. So is just drawing the highest quantity cheermote + the total amount cheered to partially emulate Twitch.[^1]
![image](https://user-images.githubusercontent.com/72096833/213906273-ecccd988-022a-45c0-8d7b-1cfbdd2aedad.png)
We would want to do a date/chatrootversion check though to preserve old behaviour with chats from v5.

3. Or we could just do nothing and let it print the highest quantity cheermote as it does right now.

No matter what we choose users will probably complain :P

A bit total of 5100 was probably a Cheer5000 + Cheer100, but only a Cheer5000 is rendered because there is only one 'Cheer###' in the fragment.
![image](https://user-images.githubusercontent.com/72096833/213906008-9b0de66e-d5b7-4b5a-a0eb-fe18143b0ac8.png)
![image](https://user-images.githubusercontent.com/72096833/213905996-f0a2aaef-928b-46c3-9c8c-400c2338b849.png)

[^1]: This would be my goto if I had to choose between the two options.