### PR TITLE
Add 'unsure' and default 'select an option' to bug report edition dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,6 +22,7 @@ body:
     label: Edition
     description: Which edition of the program are you using?
     options:
+      - Unsure
       - Windows GUI Application
       - Command Line Interface
       - Both

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,10 +22,11 @@ body:
     label: Edition
     description: Which edition of the program are you using?
     options:
-      - Unsure
+      - Select an Option
       - Windows GUI Application
       - Command Line Interface
       - Both
+      - Unsure
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Some users have neglected the edition dropdown, so making GUI the default was not a great idea.