### PR TITLE
Multiselect chat rendering

### DIFF
--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -181,8 +181,8 @@
             <hc:SplitButton x:Name="btnRender" Height="40" Width="120" Margin="0,6,0,0" Content="Render Chat" Click="SplitButton_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
                 <hc:SplitButton.DropDownContent>
                     <StackPanel>
-                        <MenuItem Header="Partial Render" Click="MenuItem_Click_1"/>
-                        <MenuItem Header="Enqueue Render" Click="MenuItem_Click"/>
+                        <MenuItem Name="MenuItemPartialRender" Header="Partial Render" Click="MenuItemPartialRender_Click"/>
+                        <MenuItem Name="MenuItemEnqueueRender" Header="Enqueue Render" Click="MenuItemEnqueueRender_Click"/>
                     </StackPanel>
                 </hc:SplitButton.DropDownContent>
             </hc:SplitButton>

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -178,7 +178,7 @@
             <Button x:Name="btnBrowse" Margin="3" MinWidth="50" Content="Browse" Click="btnBrowse_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </WrapPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,10">
-            <hc:SplitButton x:Name="SplitBtnRender" Height="40" Width="120" Margin="0,6,0,0" Content="Render Chat" Click="SplitBtnRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
+            <hc:SplitButton x:Name="SplitBtnRender" Height="40" MinWidth="120" Margin="0,6,0,0" Content="Render Chat" Click="SplitBtnRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
                 <hc:SplitButton.DropDownContent>
                     <StackPanel>
                         <MenuItem Name="MenuItemPartialRender" Header="Partial Render" Click="MenuItemPartialRender_Click"/>

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -174,11 +174,11 @@
 
         <WrapPanel Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Margin="0,0,0,10" Orientation="Horizontal" HorizontalAlignment="Center">
             <TextBlock Margin="3,8,3,3" Text="JSON File:" Foreground="{DynamicResource AppText}"/>
-            <TextBox x:Name="textJson" Margin="3" MinWidth="200" MaxWidth="400" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <TextBox x:Name="textJson" Margin="3" MinWidth="200" MaxWidth="400" TextChanged="TextJson_TextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <Button x:Name="btnBrowse" Margin="3" MinWidth="50" Content="Browse" Click="btnBrowse_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </WrapPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,10">
-            <hc:SplitButton x:Name="btnRender" Height="40" Width="120" Margin="0,6,0,0" Content="Render Chat" Click="SplitButton_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
+            <hc:SplitButton x:Name="SplitBtnRender" Height="40" Width="120" Margin="0,6,0,0" Content="Render Chat" Click="SplitBtnRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
                 <hc:SplitButton.DropDownContent>
                     <StackPanel>
                         <MenuItem Name="MenuItemPartialRender" Header="Partial Render" Click="MenuItemPartialRender_Click"/>

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -14,7 +14,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using HandyControl.Data.Enum;
 using TwitchDownloader;
 using TwitchDownloader.Properties;
 using TwitchDownloaderCore;
@@ -35,7 +34,7 @@ namespace TwitchDownloaderWPF
         public List<string> ffmpegLog = new List<string>();
         public SKFontManager fontManager = SKFontManager.CreateDefault();
         public ConcurrentDictionary<char, SKPaint> fallbackCache = new ConcurrentDictionary<char, SKPaint>();
-        public string[] fileNames = { };
+        public string[] FileNames;
         public PageChatRender()
         {
             InitializeComponent();
@@ -52,15 +51,15 @@ namespace TwitchDownloaderWPF
                 return;
             }
 
-            fileNames = openFileDialog.FileNames;
-            textJson.Text = string.Join("&&", fileNames);
+            FileNames = openFileDialog.FileNames;
+            textJson.Text = string.Join("&&", FileNames);
 
             UpdateRenderButtonOptions();
         }
 
         private void UpdateRenderButtonOptions()
         {
-            if (fileNames.Length > 1)
+            if (FileNames.Length > 1)
             {
                 SplitBtnRender.Content = "Enqueue Render";
                 SplitBtnRender.MaxDropDownHeight = 0;
@@ -318,12 +317,12 @@ namespace TwitchDownloaderWPF
 
         private bool ValidateInputs()
         {
-            if (fileNames.Length == 0)
+            if (FileNames.Length == 0)
             {
                 AppendLog("ERROR: No JSON Files Were Selected");
                 return false;
             }
-            foreach (string fileName in fileNames)
+            foreach (string fileName in FileNames)
             {
                 if (!File.Exists(fileName))
                 {
@@ -543,7 +542,7 @@ namespace TwitchDownloaderWPF
                 }
 
                 // Force "enqueue render" if multiple files are selected
-                if (fileNames.Length > 1)
+                if (FileNames.Length > 1)
                 {
                     MenuItemEnqueueRender_Click(sender, e);
                     return;
@@ -641,7 +640,7 @@ namespace TwitchDownloaderWPF
 
         private void TextJson_TextChanged(object sender, TextChangedEventArgs e)
         {
-            fileNames = textJson.Text.Split("&&", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            FileNames = textJson.Text.Split("&&", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             UpdateRenderButtonOptions();
         }
     }

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -34,6 +34,7 @@ namespace TwitchDownloaderWPF
         public List<string> ffmpegLog = new List<string>();
         public SKFontManager fontManager = SKFontManager.CreateDefault();
         public ConcurrentDictionary<char, SKPaint> fallbackCache = new ConcurrentDictionary<char, SKPaint>();
+        public string[] fileNames = { };
         public PageChatRender()
         {
             InitializeComponent();
@@ -43,10 +44,12 @@ namespace TwitchDownloaderWPF
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();
             openFileDialog.Filter = "JSON Files | *.json;*.json.gz";
+            openFileDialog.Multiselect = true;
 
             if (openFileDialog.ShowDialog() == true)
             {
-                textJson.Text = openFileDialog.FileName;
+                fileNames = openFileDialog.FileNames;
+                textJson.Text = String.Join(",", fileNames);
             }
         }
 
@@ -295,10 +298,18 @@ namespace TwitchDownloaderWPF
 
         private bool ValidateInputs()
         {
-            if (!File.Exists(textJson.Text))
+            if (fileNames.Length == 0)
             {
-                AppendLog("ERROR: JSON File Not Found");
+                AppendLog("ERROR: no JSON Files selected");
                 return false;
+            }
+            foreach (string fileName in fileNames)
+            {
+                if (!File.Exists(fileName))
+                {
+                    AppendLog("ERROR: JSON File Not Found");
+                    return false;
+                }
             }
 
             try
@@ -508,6 +519,13 @@ namespace TwitchDownloaderWPF
                 if (!ValidateInputs())
                 {
                     MessageBox.Show("Please double check your inputs are valid", "Unable to parse inputs", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                // Force "enqueue render" if multiple files are selected
+                if (fileNames.Length > 1)
+                {
+                    MenuItem_Click(sender, e);
                     return;
                 }
 

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -34,7 +34,7 @@ namespace TwitchDownloaderWPF
         public List<string> ffmpegLog = new List<string>();
         public SKFontManager fontManager = SKFontManager.CreateDefault();
         public ConcurrentDictionary<char, SKPaint> fallbackCache = new ConcurrentDictionary<char, SKPaint>();
-        public string[] FileNames;
+        public string[] FileNames = Array.Empty<string>();
         public PageChatRender()
         {
             InitializeComponent();
@@ -53,7 +53,6 @@ namespace TwitchDownloaderWPF
 
             FileNames = openFileDialog.FileNames;
             textJson.Text = string.Join("&&", FileNames);
-
             UpdateRenderButtonOptions();
         }
 
@@ -319,7 +318,7 @@ namespace TwitchDownloaderWPF
         {
             if (FileNames.Length == 0)
             {
-                AppendLog("ERROR: No JSON Files Were Selected");
+                AppendLog("ERROR: No JSON Files Are Selected");
                 return false;
             }
             foreach (string fileName in FileNames)

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -525,7 +525,7 @@ namespace TwitchDownloaderWPF
                 // Force "enqueue render" if multiple files are selected
                 if (fileNames.Length > 1)
                 {
-                    MenuItem_Click(sender, e);
+                    MenuItemEnqueueRender_Click(sender, e);
                     return;
                 }
 
@@ -606,7 +606,7 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void MenuItem_Click(object sender, RoutedEventArgs e)
+        private void MenuItemEnqueueRender_Click(object sender, RoutedEventArgs e)
         {
             if (ValidateInputs())
             {
@@ -615,7 +615,7 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void MenuItem_Click_1(object sender, RoutedEventArgs e)
+        private void MenuItemPartialRender_Click(object sender, RoutedEventArgs e)
         {
             SplitButton_Click(null, null);
         }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -99,178 +99,53 @@ namespace TwitchDownloader
                 {
                     PageVodDownload vodPage = (PageVodDownload)parentPage;
                     string folderPath = textFolder.Text;
-                    if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
-                    {
-                        VodDownloadTask downloadTask = new VodDownloadTask();
-                        VideoDownloadOptions downloadOptions = vodPage.GetOptions(null, textFolder.Text);
-                        downloadTask.DownloadOptions = downloadOptions;
-                        downloadTask.Info.Title = vodPage.textTitle.Text;
-                        downloadTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
-                        downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                        lock (PageQueue.taskLock)
-                        {
-                            PageQueue.taskList.Add(downloadTask);
-                        }
-
-                        if ((bool)checkChat.IsChecked)
-                        {
-                            ChatDownloadTask chatTask = new ChatDownloadTask();
-                            ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
-                            chatOptions.Id = downloadOptions.Id.ToString();
-                            if (radioJson.IsChecked == true)
-                                chatOptions.DownloadFormat = ChatFormat.Json;
-                            else if (radioHTML.IsChecked == true)
-                                chatOptions.DownloadFormat = ChatFormat.Html;
-                            else
-                                chatOptions.DownloadFormat = ChatFormat.Text;
-                            chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                            chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, vodPage.currentVideoTime.ToLocalTime(), vodPage.textStreamer.Text) + "." + chatOptions.DownloadFormat);
-
-                            if (downloadOptions.CropBeginning)
-                            {
-                                chatOptions.CropBeginning = true;
-                                chatOptions.CropBeginningTime = downloadOptions.CropBeginningTime;
-                            }
-
-                            if (downloadOptions.CropEnding)
-                            {
-                                chatOptions.CropEnding = true;
-                                chatOptions.CropEndingTime = downloadOptions.CropEndingTime;
-                            }
-
-                            chatTask.DownloadOptions = chatOptions;
-                            chatTask.Info.Title = vodPage.textTitle.Text;
-                            chatTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
-                            chatTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                            lock (PageQueue.taskLock)
-                            {
-                                PageQueue.taskList.Add(chatTask);
-                            }
-
-                            if ((bool)checkRender.IsChecked && chatOptions.DownloadFormat == ChatFormat.Json)
-                            {
-                                ChatRenderTask renderTask = new ChatRenderTask();
-                                ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), ".mp4"));
-                                if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
-                                {
-                                    //Just in case VOD and chat paths are the same. Like the previous defaults
-                                    renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
-                                }
-                                renderOptions.InputFile = chatOptions.Filename;
-                                renderTask.DownloadOptions = renderOptions;
-                                renderTask.Info.Title = vodPage.textTitle.Text;
-                                renderTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
-                                renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                                renderTask.DependantTask = chatTask;
-
-                                lock (PageQueue.taskLock)
-                                {
-                                    PageQueue.taskList.Add(renderTask);
-                                }
-                            }
-                        }
-
-                        this.Close();
-                    }
-                    else
+                    if (!Directory.Exists(folderPath))
                     {
                         MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
                     }
-                }
 
-                if (parentPage is PageClipDownload)
-                {
-                    PageClipDownload clipPage = (PageClipDownload)parentPage;
-                    string folderPath = textFolder.Text;
-                    if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
+                    VodDownloadTask downloadTask = new VodDownloadTask();
+                    VideoDownloadOptions downloadOptions = vodPage.GetOptions(null, textFolder.Text);
+                    downloadTask.DownloadOptions = downloadOptions;
+                    downloadTask.Info.Title = vodPage.textTitle.Text;
+                    downloadTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
+                    downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                    lock (PageQueue.taskLock)
                     {
-                        ClipDownloadTask downloadTask = new ClipDownloadTask();
-                        ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                        downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + ".mp4");
-                        downloadOptions.Id = clipPage.clipId;
-                        downloadOptions.Quality = clipPage.comboQuality.Text;
-                        downloadTask.DownloadOptions = downloadOptions;
-                        downloadTask.Info.Title = clipPage.textTitle.Text;
-                        downloadTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
-                        downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                        lock (PageQueue.taskLock)
-                        {
-                            PageQueue.taskList.Add(downloadTask);
-                        }
-
-                        if ((bool)checkChat.IsChecked)
-                        {
-                            ChatDownloadTask chatTask = new ChatDownloadTask();
-                            ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
-                            chatOptions.Id = downloadOptions.Id.ToString();
-                            if (radioJson.IsChecked == true)
-                                chatOptions.DownloadFormat = ChatFormat.Json;
-                            else if (radioHTML.IsChecked == true)
-                                chatOptions.DownloadFormat = ChatFormat.Html;
-                            else
-                                chatOptions.DownloadFormat = ChatFormat.Text;
-                            chatOptions.TimeFormat = TimestampFormat.Relative;
-                            chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                            chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + "." + chatOptions.FileExtension);
-
-                            chatTask.DownloadOptions = chatOptions;
-                            chatTask.Info.Title = clipPage.textTitle.Text;
-                            chatTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
-                            chatTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                            lock (PageQueue.taskLock)
-                            {
-                                PageQueue.taskList.Add(chatTask);
-                            }
-
-                            if ((bool)checkRender.IsChecked && chatOptions.DownloadFormat == ChatFormat.Json)
-                            {
-                                ChatRenderTask renderTask = new ChatRenderTask();
-                                ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), ".mp4"));
-                                if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
-                                {
-                                    //Just in case VOD and chat paths are the same. Like the previous defaults
-                                    renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
-                                }
-                                renderOptions.InputFile = chatOptions.Filename;
-                                renderTask.DownloadOptions = renderOptions;
-                                renderTask.Info.Title = clipPage.textTitle.Text;
-                                renderTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
-                                renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                                renderTask.DependantTask = chatTask;
-
-                                lock (PageQueue.taskLock)
-                                {
-                                    PageQueue.taskList.Add(renderTask);
-                                }
-                            }
-                        }
-
-                        this.Close();
+                        PageQueue.taskList.Add(downloadTask);
                     }
-                    else
-                    {
-                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
-                }
 
-                if (parentPage is PageChatDownload)
-                {
-                    PageChatDownload chatPage = (PageChatDownload)parentPage;
-                    string folderPath = textFolder.Text;
-                    if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
+                    if ((bool)checkChat.IsChecked)
                     {
                         ChatDownloadTask chatTask = new ChatDownloadTask();
                         ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
-                        chatOptions.Id = chatPage.downloadId;
-                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatOptions.Id, chatPage.currentVideoTime.ToLocalTime(), chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+                        chatOptions.Id = downloadOptions.Id.ToString();
+                        if (radioJson.IsChecked == true)
+                            chatOptions.DownloadFormat = ChatFormat.Json;
+                        else if (radioHTML.IsChecked == true)
+                            chatOptions.DownloadFormat = ChatFormat.Html;
+                        else
+                            chatOptions.DownloadFormat = ChatFormat.Text;
+                        chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
+                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, vodPage.currentVideoTime.ToLocalTime(), vodPage.textStreamer.Text) + "." + chatOptions.DownloadFormat);
+
+                        if (downloadOptions.CropBeginning)
+                        {
+                            chatOptions.CropBeginning = true;
+                            chatOptions.CropBeginningTime = downloadOptions.CropBeginningTime;
+                        }
+
+                        if (downloadOptions.CropEnding)
+                        {
+                            chatOptions.CropEnding = true;
+                            chatOptions.CropEndingTime = downloadOptions.CropEndingTime;
+                        }
 
                         chatTask.DownloadOptions = chatOptions;
-                        chatTask.Info.Title = chatPage.textTitle.Text;
-                        chatTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                        chatTask.Info.Title = vodPage.textTitle.Text;
+                        chatTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
                         chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)
@@ -282,10 +157,15 @@ namespace TwitchDownloader
                         {
                             ChatRenderTask renderTask = new ChatRenderTask();
                             ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), ".mp4"));
+                            if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
+                            {
+                                //Just in case VOD and chat paths are the same. Like the previous defaults
+                                renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
+                            }
                             renderOptions.InputFile = chatOptions.Filename;
                             renderTask.DownloadOptions = renderOptions;
-                            renderTask.Info.Title = chatPage.textTitle.Text;
-                            renderTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                            renderTask.Info.Title = vodPage.textTitle.Text;
+                            renderTask.Info.Thumbnail = vodPage.imgThumbnail.Source;
                             renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
                             renderTask.DependantTask = chatTask;
 
@@ -294,29 +174,54 @@ namespace TwitchDownloader
                                 PageQueue.taskList.Add(renderTask);
                             }
                         }
+                    }
 
-                        this.Close();
-                    }
-                    else
-                    {
-                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
+                    this.Close();
                 }
 
-                if (parentPage is PageChatUpdate)
+                if (parentPage is PageClipDownload)
                 {
-                    PageChatUpdate chatPage = (PageChatUpdate)parentPage;
+                    PageClipDownload clipPage = (PageClipDownload)parentPage;
                     string folderPath = textFolder.Text;
-                    if (!string.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
+                    if (!Directory.Exists(folderPath))
                     {
-                        ChatUpdateTask chatTask = new ChatUpdateTask();
-                        ChatUpdateOptions chatOptions = MainWindow.pageChatUpdate.GetOptions(null);
-                        chatOptions.InputFile = chatPage.InputFile;
-                        chatOptions.OutputFile = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatPage.VideoId, chatPage.VideoCreatedAt, chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
 
-                        chatTask.UpdateOptions = chatOptions;
-                        chatTask.Info.Title = chatPage.textTitle.Text;
-                        chatTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                    ClipDownloadTask downloadTask = new ClipDownloadTask();
+                    ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
+                    downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + ".mp4");
+                    downloadOptions.Id = clipPage.clipId;
+                    downloadOptions.Quality = clipPage.comboQuality.Text;
+                    downloadTask.DownloadOptions = downloadOptions;
+                    downloadTask.Info.Title = clipPage.textTitle.Text;
+                    downloadTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
+                    downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                    lock (PageQueue.taskLock)
+                    {
+                        PageQueue.taskList.Add(downloadTask);
+                    }
+
+                    if ((bool)checkChat.IsChecked)
+                    {
+                        ChatDownloadTask chatTask = new ChatDownloadTask();
+                        ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
+                        chatOptions.Id = downloadOptions.Id.ToString();
+                        if (radioJson.IsChecked == true)
+                            chatOptions.DownloadFormat = ChatFormat.Json;
+                        else if (radioHTML.IsChecked == true)
+                            chatOptions.DownloadFormat = ChatFormat.Html;
+                        else
+                            chatOptions.DownloadFormat = ChatFormat.Text;
+                        chatOptions.TimeFormat = TimestampFormat.Relative;
+                        chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
+                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+
+                        chatTask.DownloadOptions = chatOptions;
+                        chatTask.Info.Title = clipPage.textTitle.Text;
+                        chatTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
                         chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)
@@ -324,12 +229,103 @@ namespace TwitchDownloader
                             PageQueue.taskList.Add(chatTask);
                         }
 
-                        this.Close();
+                        if ((bool)checkRender.IsChecked && chatOptions.DownloadFormat == ChatFormat.Json)
+                        {
+                            ChatRenderTask renderTask = new ChatRenderTask();
+                            ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), ".mp4"));
+                            if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
+                            {
+                                //Just in case VOD and chat paths are the same. Like the previous defaults
+                                renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
+                            }
+                            renderOptions.InputFile = chatOptions.Filename;
+                            renderTask.DownloadOptions = renderOptions;
+                            renderTask.Info.Title = clipPage.textTitle.Text;
+                            renderTask.Info.Thumbnail = clipPage.imgThumbnail.Source;
+                            renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
+                            renderTask.DependantTask = chatTask;
+
+                            lock (PageQueue.taskLock)
+                            {
+                                PageQueue.taskList.Add(renderTask);
+                            }
+                        }
                     }
-                    else
+
+                    this.Close();
+                }
+
+                if (parentPage is PageChatDownload)
+                {
+                    PageChatDownload chatPage = (PageChatDownload)parentPage;
+                    string folderPath = textFolder.Text;
+                    if (!Directory.Exists(folderPath))
                     {
                         MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
                     }
+
+                    ChatDownloadTask chatTask = new ChatDownloadTask();
+                    ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
+                    chatOptions.Id = chatPage.downloadId;
+                    chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatOptions.Id, chatPage.currentVideoTime.ToLocalTime(), chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+
+                    chatTask.DownloadOptions = chatOptions;
+                    chatTask.Info.Title = chatPage.textTitle.Text;
+                    chatTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                    chatTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                    lock (PageQueue.taskLock)
+                    {
+                        PageQueue.taskList.Add(chatTask);
+                    }
+
+                    if ((bool)checkRender.IsChecked && chatOptions.DownloadFormat == ChatFormat.Json)
+                    {
+                        ChatRenderTask renderTask = new ChatRenderTask();
+                        ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), ".mp4"));
+                        renderOptions.InputFile = chatOptions.Filename;
+                        renderTask.DownloadOptions = renderOptions;
+                        renderTask.Info.Title = chatPage.textTitle.Text;
+                        renderTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                        renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
+                        renderTask.DependantTask = chatTask;
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(renderTask);
+                        }
+                    }
+
+                    this.Close();
+                }
+
+                if (parentPage is PageChatUpdate)
+                {
+                    PageChatUpdate chatPage = (PageChatUpdate)parentPage;
+                    string folderPath = textFolder.Text;
+                    if (!Directory.Exists(folderPath))
+                    {
+                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    ChatUpdateTask chatTask = new ChatUpdateTask();
+                    ChatUpdateOptions chatOptions = MainWindow.pageChatUpdate.GetOptions(null);
+                    chatOptions.InputFile = chatPage.InputFile;
+                    chatOptions.OutputFile = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatPage.VideoId, chatPage.VideoCreatedAt, chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+
+                    chatTask.UpdateOptions = chatOptions;
+                    chatTask.Info.Title = chatPage.textTitle.Text;
+                    chatTask.Info.Thumbnail = chatPage.imgThumbnail.Source;
+                    chatTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                    lock (PageQueue.taskLock)
+                    {
+                        PageQueue.taskList.Add(chatTask);
+                    }
+
+                    this.Close();
                 }
 
                 if (parentPage is PageChatRender)
@@ -338,33 +334,32 @@ namespace TwitchDownloader
                     string folderPath = textFolder.Text;
                     foreach (string fileName in renderPage.fileNames)
                     {
-                        if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
-                        {
-                            ChatRenderTask renderTask = new ChatRenderTask();
-                            string fileFormat = renderPage.comboFormat.SelectedItem.ToString();
-                            string filePath = Path.Combine(folderPath, Path.GetFileNameWithoutExtension(fileName) + "." + fileFormat.ToLower());
-                            ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
-                            renderOptions.InputFile = fileName;
-                            renderTask.DownloadOptions = renderOptions;
-                            renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
-                            var (success, image) = await InfoHelper.TryGetThumb(InfoHelper.THUMBNAIL_MISSING_URL);
-                            if (success)
-                            {
-                                renderTask.Info.Thumbnail = image;
-                            }
-                            renderTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                            lock (PageQueue.taskLock)
-                            {
-                                PageQueue.taskList.Add(renderTask);
-                            }
-
-                            this.Close();
-                        }
-                        else
+                        if (!Directory.Exists(folderPath))
                         {
                             MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                            return;
                         }
+
+                        ChatRenderTask renderTask = new ChatRenderTask();
+                        string fileFormat = renderPage.comboFormat.SelectedItem.ToString();
+                        string filePath = Path.Combine(folderPath, Path.GetFileNameWithoutExtension(fileName) + "." + fileFormat.ToLower());
+                        ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
+                        renderOptions.InputFile = fileName;
+                        renderTask.DownloadOptions = renderOptions;
+                        renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
+                        var (success, image) = await InfoHelper.TryGetThumb(InfoHelper.THUMBNAIL_MISSING_URL);
+                        if (success)
+                        {
+                            renderTask.Info.Thumbnail = image;
+                        }
+                        renderTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(renderTask);
+                        }
+
+                        this.Close();
                     }
                 }
             }
@@ -373,68 +368,28 @@ namespace TwitchDownloader
                 if (dataList.Count > 0)
                 {
                     string folderPath = textFolder.Text;
-                    if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
+                    if (!Directory.Exists(folderPath))
                     {
-                        for (int i = 0; i < dataList.Count; i++)
+                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    for (int i = 0; i < dataList.Count; i++)
+                    {
+                        if ((bool)checkVideo.IsChecked)
                         {
-                            if ((bool)checkVideo.IsChecked)
+                            if (dataList[i].Id.All(Char.IsDigit))
                             {
-                                if (dataList[i].Id.All(Char.IsDigit))
-                                {
-                                    VodDownloadTask downloadTask = new VodDownloadTask();
-                                    VideoDownloadOptions downloadOptions = new VideoDownloadOptions();
-                                    downloadOptions.Oauth = Settings.Default.OAuth;
-                                    downloadOptions.TempFolder = Settings.Default.TempPath;
-                                    downloadOptions.Id = int.Parse(dataList[i].Id);
-                                    downloadOptions.FfmpegPath = "ffmpeg";
-                                    downloadOptions.CropBeginning = false;
-                                    downloadOptions.CropEnding = false;
-                                    downloadOptions.DownloadThreads = Settings.Default.VodDownloadThreads;
-                                    downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateVod, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + ".mp4");
-                                    downloadTask.DownloadOptions = downloadOptions;
-                                    downloadTask.Info.Title = dataList[i].Title;
-                                    downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
-                                    downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                                    lock (PageQueue.taskLock)
-                                    {
-                                        PageQueue.taskList.Add(downloadTask);
-                                    }
-                                }
-                                else
-                                {
-                                    ClipDownloadTask downloadTask = new ClipDownloadTask();
-                                    ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                                    downloadOptions.Id = dataList[i].Id;
-                                    downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + ".mp4");
-                                    downloadTask.DownloadOptions = downloadOptions;
-                                    downloadTask.Info.Title = dataList[i].Title;
-                                    downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
-                                    downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                                    lock (PageQueue.taskLock)
-                                    {
-                                        PageQueue.taskList.Add(downloadTask);
-                                    }
-                                }
-                            }
-
-                            if ((bool)checkChat.IsChecked)
-                            {
-                                ChatDownloadTask downloadTask = new ChatDownloadTask();
-                                ChatDownloadOptions downloadOptions = new ChatDownloadOptions();
-                                if (radioJson.IsChecked == true)
-                                    downloadOptions.DownloadFormat = ChatFormat.Json;
-                                else if (radioHTML.IsChecked == true)
-                                    downloadOptions.DownloadFormat = ChatFormat.Html;
-                                else
-                                    downloadOptions.DownloadFormat = ChatFormat.Text;
-                                downloadOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                                downloadOptions.TimeFormat = TimestampFormat.Relative;
-                                downloadOptions.Id = dataList[i].Id;
+                                VodDownloadTask downloadTask = new VodDownloadTask();
+                                VideoDownloadOptions downloadOptions = new VideoDownloadOptions();
+                                downloadOptions.Oauth = Settings.Default.OAuth;
+                                downloadOptions.TempFolder = Settings.Default.TempPath;
+                                downloadOptions.Id = int.Parse(dataList[i].Id);
+                                downloadOptions.FfmpegPath = "ffmpeg";
                                 downloadOptions.CropBeginning = false;
                                 downloadOptions.CropEnding = false;
-                                downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + "." + downloadOptions.FileExtension);
+                                downloadOptions.DownloadThreads = Settings.Default.VodDownloadThreads;
+                                downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateVod, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + ".mp4");
                                 downloadTask.DownloadOptions = downloadOptions;
                                 downloadTask.Info.Title = dataList[i].Title;
                                 downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
@@ -444,38 +399,77 @@ namespace TwitchDownloader
                                 {
                                     PageQueue.taskList.Add(downloadTask);
                                 }
+                            }
+                            else
+                            {
+                                ClipDownloadTask downloadTask = new ClipDownloadTask();
+                                ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
+                                downloadOptions.Id = dataList[i].Id;
+                                downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + ".mp4");
+                                downloadTask.DownloadOptions = downloadOptions;
+                                downloadTask.Info.Title = dataList[i].Title;
+                                downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
+                                downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
-                                if ((bool)checkRender.IsChecked && downloadOptions.DownloadFormat == ChatFormat.Json)
+                                lock (PageQueue.taskLock)
                                 {
-                                    ChatRenderTask renderTask = new ChatRenderTask();
-                                    ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), ".mp4"));
-                                    if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
-                                    {
-                                        //Just in case VOD and chat paths are the same. Like the previous defaults
-                                        renderOptions.OutputFile = Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
-                                    }
-                                    renderOptions.InputFile = downloadOptions.Filename;
-                                    renderTask.DownloadOptions = renderOptions;
-                                    renderTask.Info.Title = dataList[i].Title;
-                                    renderTask.Info.Thumbnail = dataList[i].Thumbnail;
-                                    renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                                    renderTask.DependantTask = downloadTask;
-
-                                    lock (PageQueue.taskLock)
-                                    {
-                                        PageQueue.taskList.Add(renderTask);
-                                    }
+                                    PageQueue.taskList.Add(downloadTask);
                                 }
                             }
                         }
 
-                        this.DialogResult = true;
-                        this.Close();
+                        if ((bool)checkChat.IsChecked)
+                        {
+                            ChatDownloadTask downloadTask = new ChatDownloadTask();
+                            ChatDownloadOptions downloadOptions = new ChatDownloadOptions();
+                            if (radioJson.IsChecked == true)
+                                downloadOptions.DownloadFormat = ChatFormat.Json;
+                            else if (radioHTML.IsChecked == true)
+                                downloadOptions.DownloadFormat = ChatFormat.Html;
+                            else
+                                downloadOptions.DownloadFormat = ChatFormat.Text;
+                            downloadOptions.EmbedData = (bool)checkEmbed.IsChecked;
+                            downloadOptions.TimeFormat = TimestampFormat.Relative;
+                            downloadOptions.Id = dataList[i].Id;
+                            downloadOptions.CropBeginning = false;
+                            downloadOptions.CropEnding = false;
+                            downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer) + "." + downloadOptions.FileExtension);
+                            downloadTask.DownloadOptions = downloadOptions;
+                            downloadTask.Info.Title = dataList[i].Title;
+                            downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
+                            downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                            lock (PageQueue.taskLock)
+                            {
+                                PageQueue.taskList.Add(downloadTask);
+                            }
+
+                            if ((bool)checkRender.IsChecked && downloadOptions.DownloadFormat == ChatFormat.Json)
+                            {
+                                ChatRenderTask renderTask = new ChatRenderTask();
+                                ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), ".mp4"));
+                                if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
+                                {
+                                    //Just in case VOD and chat paths are the same. Like the previous defaults
+                                    renderOptions.OutputFile = Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), " - CHAT.mp4");
+                                }
+                                renderOptions.InputFile = downloadOptions.Filename;
+                                renderTask.DownloadOptions = renderOptions;
+                                renderTask.Info.Title = dataList[i].Title;
+                                renderTask.Info.Thumbnail = dataList[i].Thumbnail;
+                                renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
+                                renderTask.DependantTask = downloadTask;
+
+                                lock (PageQueue.taskLock)
+                                {
+                                    PageQueue.taskList.Add(renderTask);
+                                }
+                            }
+                        }
                     }
-                    else
-                    {
-                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
+
+                    this.DialogResult = true;
+                    this.Close();
                 }
             }
         }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -336,31 +336,35 @@ namespace TwitchDownloader
                 {
                     PageChatRender renderPage = (PageChatRender)parentPage;
                     string folderPath = textFolder.Text;
-                    if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
+                    foreach (string fileName in renderPage.fileNames)
                     {
-                        ChatRenderTask renderTask = new ChatRenderTask();
-                        string fileFormat = renderPage.comboFormat.SelectedItem.ToString();
-                        string filePath = Path.Combine(folderPath, Path.GetFileNameWithoutExtension(renderPage.textJson.Text) + "." + fileFormat.ToLower());
-                        ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
-                        renderTask.DownloadOptions = renderOptions;
-                        renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
-                        var (success, image) = await InfoHelper.TryGetThumb(InfoHelper.THUMBNAIL_MISSING_URL);
-                        if (success)
+                        if (!String.IsNullOrWhiteSpace(folderPath) && Directory.Exists(folderPath))
                         {
-                            renderTask.Info.Thumbnail = image;
-                        }
-                        renderTask.ChangeStatus(TwitchTaskStatus.Ready);
+                            ChatRenderTask renderTask = new ChatRenderTask();
+                            string fileFormat = renderPage.comboFormat.SelectedItem.ToString();
+                            string filePath = Path.Combine(folderPath, Path.GetFileNameWithoutExtension(fileName) + "." + fileFormat.ToLower());
+                            ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
+                            renderOptions.InputFile = fileName;
+                            renderTask.DownloadOptions = renderOptions;
+                            renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
+                            var (success, image) = await InfoHelper.TryGetThumb(InfoHelper.THUMBNAIL_MISSING_URL);
+                            if (success)
+                            {
+                                renderTask.Info.Thumbnail = image;
+                            }
+                            renderTask.ChangeStatus(TwitchTaskStatus.Ready);
 
-                        lock (PageQueue.taskLock)
+                            lock (PageQueue.taskLock)
+                            {
+                                PageQueue.taskList.Add(renderTask);
+                            }
+
+                            this.Close();
+                        }
+                        else
                         {
-                            PageQueue.taskList.Add(renderTask);
+                            MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
                         }
-
-                        this.Close();
-                    }
-                    else
-                    {
-                        MessageBox.Show("Invalid folder path (doesn't exist?)", "Invalid Folder Path", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 }
             }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -332,7 +332,7 @@ namespace TwitchDownloader
                 {
                     PageChatRender renderPage = (PageChatRender)parentPage;
                     string folderPath = textFolder.Text;
-                    foreach (string fileName in renderPage.fileNames)
+                    foreach (string fileName in renderPage.FileNames)
                     {
                         if (!Directory.Exists(folderPath))
                         {


### PR DESCRIPTION
Since chat renders are often slower than downloading videos and chat, I wanted to add support for selecting and queuing multiple chat files to be rendered at once.

With this change on the Chat Render tab, the JSON File selector now supports multiple files being selected at once and when you hit Render Chat (or Partial Render or Enqueue Render), it will prompt you to add all those render jobs to the task queue.