### PR TITLE
Do not clear cache on failed video download finalizing

### DIFF
--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -681,7 +681,6 @@ namespace TwitchDownloaderCore
             }
 
             // Let's delete any video download cache folders older than 24 hours
-            // Or that have been inactive for 2 hours
             var videoFolderRegex = new Regex(@"\d+_(\d+)$", RegexOptions.RightToLeft); // Matches "...###_###" and captures the 2nd ###
             var directories = Directory.GetDirectories(cacheFolder);
             foreach (var directory in directories)
@@ -689,30 +688,25 @@ namespace TwitchDownloaderCore
                 var videoFolderMatch = videoFolderRegex.Match(directory);
                 if (videoFolderMatch.Success)
                 {
-                    bool wasDeleted = DeleteOldDirectory(directory, videoFolderMatch.Groups[1].ToString());
-
-                    if (wasDeleted) continue;
-
-                    wasDeleted = DeleteColdDirectory(directory);
-
-                    if (wasDeleted) continue;
+                    DeleteOldDirectory(directory, videoFolderMatch.Groups[1].ValueSpan);
                 }
             }
         }
 
-        private static bool DeleteOldDirectory(string directory, string directoryCreationMillis)
+        private static bool DeleteOldDirectory(string directory, ReadOnlySpan<char> directoryCreationMillis)
         {
             var downloadTime = long.Parse(directoryCreationMillis);
             var currentTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            if (currentTime - downloadTime > 86_400_000) // 24 hours in millis
+            const int TWENTY_FOUR_HOURS_MILLIS = 86_400_000;
+            if (currentTime - downloadTime > TWENTY_FOUR_HOURS_MILLIS)
             {
                 try
                 {
                     Directory.Delete(directory, true);
                     return true;
                 }
-                catch { }
+                catch { /* Eat the exception */ }
             }
             return false;
         }
@@ -723,14 +717,15 @@ namespace TwitchDownloaderCore
             var directoryWriteTimeMillis = Directory.GetLastWriteTimeUtc(directory).Ticks / TimeSpan.TicksPerMillisecond;
             var currentTimeMillis = DateTimeOffset.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
-            if (currentTimeMillis - directoryWriteTimeMillis > 14_400_000) // 4 hours in millis
+            const int SIX_HOURS_MILLIS = 21_600_000;
+            if (currentTimeMillis - directoryWriteTimeMillis > SIX_HOURS_MILLIS)
             {
                 try
                 {
                     Directory.Delete(directory, true);
                     return true;
                 }
-                catch { }
+                catch { /* Eat the exception */ }
             }
             return false;
         }

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -32,7 +32,7 @@ namespace TwitchDownloaderCore
 
         public async Task DownloadAsync(IProgress<ProgressReport> progress, CancellationToken cancellationToken)
         {
-            TwitchHelper.CleanupUnmanagedCacheFiles(downloadOptions.TempFolder);
+            TwitchHelper.CleanupUnmanagedCacheFiles(downloadOptions.TempFolder, progress);
 
             string downloadFolder = Path.Combine(
                 downloadOptions.TempFolder,


### PR DESCRIPTION
- Check for failed ffmpeg when copying videos
- Do not clear the cache on failed ffmpeg
- Generate log file of ffmpeg output in the cache directory, this should help us get to the root of #541 
- Log when old video caches are deleted