### PR TITLE
Fix null or empty video title causing crash when serializing metadata

### DIFF
--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -59,6 +59,11 @@ namespace TwitchDownloaderCore.Tools
 
         private static string SanitizeKeyValue(string str)
         {
+            if (string.IsNullOrWhiteSpace(str))
+            {
+                return str;
+            }
+
             return str
                 .Replace("=", @"\=")
                 .Replace(";", @"\;")


### PR DESCRIPTION
- Fixes #588 