### PR TITLE
Render emoji patch

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1264,11 +1264,11 @@ namespace TwitchDownloaderCore
         /// <remarks>chatRoot.embeddedData will be empty after calling this to save on memory!</remarks>
         private async Task FetchScaledImages(CancellationToken cancellationToken)
         {
-            var badgeTask = GetScaledBadges();
-            var emoteTask = GetScaledEmotes();
+            var badgeTask = GetScaledBadges(cancellationToken);
+            var emoteTask = GetScaledEmotes(cancellationToken);
             var emoteThirdTask = GetScaledThirdEmotes(cancellationToken);
-            var cheerTask = GetScaledBits();
-            var emojiTask = GetScaledEmojis();
+            var cheerTask = GetScaledBits(cancellationToken);
+            var emojiTask = GetScaledEmojis(cancellationToken);
 
             await Task.WhenAll(badgeTask, emoteTask, emoteThirdTask, cheerTask, emojiTask);
 
@@ -1285,7 +1285,7 @@ namespace TwitchDownloaderCore
             emojiCache = emojiTask.Result;
         }
 
-        private async Task<List<ChatBadge>> GetScaledBadges()
+        private async Task<List<ChatBadge>> GetScaledBadges(CancellationToken cancellationToken)
         {
             // Do not fetch if badges are disabled
             if (!renderOptions.ChatBadges)
@@ -1293,7 +1293,7 @@ namespace TwitchDownloaderCore
                 return new List<ChatBadge>();
             }
 
-            var badgeTask = await TwitchHelper.GetChatBadges(chatRoot.comments, chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
+            var badgeTask = await TwitchHelper.GetChatBadges(chatRoot.comments, chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline, cancellationToken);
 
             foreach (var badge in badgeTask)
             {
@@ -1308,9 +1308,9 @@ namespace TwitchDownloaderCore
             return badgeTask;
         }
 
-        private async Task<List<TwitchEmote>> GetScaledEmotes()
+        private async Task<List<TwitchEmote>> GetScaledEmotes(CancellationToken cancellationToken)
         {
-            var emoteTask = await TwitchHelper.GetEmotes(chatRoot.comments, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline);
+            var emoteTask = await TwitchHelper.GetEmotes(chatRoot.comments, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.Offline, cancellationToken);
 
             foreach (var emote in emoteTask)
             {
@@ -1343,9 +1343,9 @@ namespace TwitchDownloaderCore
             return emoteThirdTask;
         }
 
-        private async Task<List<CheerEmote>> GetScaledBits()
+        private async Task<List<CheerEmote>> GetScaledBits(CancellationToken cancellationToken)
         {
-            var cheerTask = await TwitchHelper.GetBits(chatRoot.comments, renderOptions.TempFolder, chatRoot.streamer.id.ToString(), chatRoot.embeddedData, renderOptions.Offline);
+            var cheerTask = await TwitchHelper.GetBits(chatRoot.comments, renderOptions.TempFolder, chatRoot.streamer.id.ToString(), chatRoot.embeddedData, renderOptions.Offline, cancellationToken);
 
             foreach (var cheer in cheerTask)
             {
@@ -1364,9 +1364,9 @@ namespace TwitchDownloaderCore
             return cheerTask;
         }
 
-        private async Task<Dictionary<string, SKBitmap>> GetScaledEmojis()
+        private async Task<Dictionary<string, SKBitmap>> GetScaledEmojis(CancellationToken cancellationToken)
         {
-            var emojiTask = await TwitchHelper.GetTwitterEmojis(renderOptions.TempFolder);
+            var emojiTask = await TwitchHelper.GetTwitterEmojis(renderOptions.TempFolder, cancellationToken);
 
             //Assume emojis are 4x (they're 72x72)
             double emojiScale = 0.5 * renderOptions.ReferenceScale * renderOptions.EmojiScale;

--- a/TwitchDownloaderWPF/App.config
+++ b/TwitchDownloaderWPF/App.config
@@ -8,213 +8,216 @@
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-  <userSettings>
-    <TwitchDownloaderWPF.Properties.Settings>
-      <setting name="VodDownloadThreads" serializeAs="String">
-        <value>4</value>
-      </setting>
-      <setting name="Font" serializeAs="String">
-        <value>Arial</value>
-      </setting>
-      <setting name="FontSize" serializeAs="String">
-        <value>24</value>
-      </setting>
-      <setting name="Outline" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="Timestamp" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="Height" serializeAs="String">
-        <value>1200</value>
-      </setting>
-      <setting name="Width" serializeAs="String">
-        <value>700</value>
-      </setting>
-      <setting name="UpdateTime" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="FFZEmotes" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="BTTVEmotes" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="STVEmotes" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="BackgroundColorR" serializeAs="String">
-        <value>17</value>
-      </setting>
-      <setting name="BackgroundColorG" serializeAs="String">
-        <value>17</value>
-      </setting>
-      <setting name="BackgroundColorB" serializeAs="String">
-        <value>17</value>
-      </setting>
-      <setting name="FontColorR" serializeAs="String">
-        <value>255</value>
-      </setting>
-      <setting name="FontColorG" serializeAs="String">
-        <value>255</value>
-      </setting>
-      <setting name="FontColorB" serializeAs="String">
-        <value>255</value>
-      </setting>
-      <setting name="Framerate" serializeAs="String">
-        <value>60</value>
-      </setting>
-      <setting name="VideoContainer" serializeAs="String">
-        <value>MP4</value>
-      </setting>
-      <setting name="VideoCodec" serializeAs="String">
-        <value>H264</value>
-      </setting>
-      <setting name="BackgroundColorA" serializeAs="String">
-        <value>255</value>
-      </setting>
-      <setting name="OAuth" serializeAs="String">
-        <value />
-      </setting>
-      <setting name="EncodeCFR" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="GenerateMask" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="TempPath" serializeAs="String">
-        <value />
-      </setting>
-      <setting name="HideDonation" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="TemplateVod" serializeAs="String">
-        <value>[{date_custom="M-d-yy"}] {channel} - {title}</value>
-      </setting>
-      <setting name="TemplateClip" serializeAs="String">
-        <value>[{date_custom="M-d-yy"}] {channel} - {title}</value>
-      </setting>
-      <setting name="TemplateChat" serializeAs="String">
-        <value>[{date_custom="M-d-yy"}] {channel} - {title} - Chat</value>
-      </setting>
-      <setting name="SubMessages" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="UpgradeRequired" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="ChatBadges" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="LimitVod" serializeAs="String">
-        <value>6</value>
-      </setting>
-      <setting name="LimitClip" serializeAs="String">
-        <value>10</value>
-      </setting>
-      <setting name="LimitChat" serializeAs="String">
-        <value>10</value>
-      </setting>
-      <setting name="LimitRender" serializeAs="String">
-        <value>2</value>
-      </setting>
-      <setting name="QueueFolder" serializeAs="String">
-        <value />
-      </setting>
-      <setting name="ChatDownloadThreads" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="ChatDownloadType" serializeAs="String">
-        <value>0</value>
-      </setting>
-      <setting name="ChatEmbedEmotes" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="FfmpegArguments" serializeAs="String">
-        <value>[]</value>
-      </setting>
-      <setting name="EmoteScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="GuiTheme" serializeAs="String">
-        <value>System</value>
-      </setting>
-      <setting name="IgnoreUsersList" serializeAs="String">
-        <value />
-      </setting>
-      <setting name="ChatBadgeMask" serializeAs="String">
-        <value>0</value>
-      </setting>
-      <setting name="VerboseErrors" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="ChatEmbedMissing" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="ChatReplaceEmbeds" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="Offline" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="BannedWordsList" serializeAs="String">
-        <value />
-      </setting>
-      <setting name="BadgeScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="VerticalSpacingScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="EmojiScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="LeftSpacingScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="SectionHeightScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="WordSpacingScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="EmoteSpacingScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="AccentStrokeScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="AccentIndentScale" serializeAs="String">
-        <value>1</value>
-      </setting>
-      <setting name="DisperseCommentOffsets" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="GuiCulture" serializeAs="String">
-        <value>en-US</value>
-      </setting>
-      <setting name="MaximumBandwidthKb" serializeAs="String">
-        <value>2048</value>
-      </setting>
-      <setting name="ChatRenderSharpening" serializeAs="String">
-        <value>False</value>
-      </setting>
-    </TwitchDownloaderWPF.Properties.Settings>
-  </userSettings>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <userSettings>
+        <TwitchDownloaderWPF.Properties.Settings>
+            <setting name="VodDownloadThreads" serializeAs="String">
+                <value>4</value>
+            </setting>
+            <setting name="Font" serializeAs="String">
+                <value>Arial</value>
+            </setting>
+            <setting name="FontSize" serializeAs="String">
+                <value>24</value>
+            </setting>
+            <setting name="Outline" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="Timestamp" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="Height" serializeAs="String">
+                <value>1200</value>
+            </setting>
+            <setting name="Width" serializeAs="String">
+                <value>700</value>
+            </setting>
+            <setting name="UpdateTime" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="FFZEmotes" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="BTTVEmotes" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="STVEmotes" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="BackgroundColorR" serializeAs="String">
+                <value>17</value>
+            </setting>
+            <setting name="BackgroundColorG" serializeAs="String">
+                <value>17</value>
+            </setting>
+            <setting name="BackgroundColorB" serializeAs="String">
+                <value>17</value>
+            </setting>
+            <setting name="FontColorR" serializeAs="String">
+                <value>255</value>
+            </setting>
+            <setting name="FontColorG" serializeAs="String">
+                <value>255</value>
+            </setting>
+            <setting name="FontColorB" serializeAs="String">
+                <value>255</value>
+            </setting>
+            <setting name="Framerate" serializeAs="String">
+                <value>60</value>
+            </setting>
+            <setting name="VideoContainer" serializeAs="String">
+                <value>MP4</value>
+            </setting>
+            <setting name="VideoCodec" serializeAs="String">
+                <value>H264</value>
+            </setting>
+            <setting name="BackgroundColorA" serializeAs="String">
+                <value>255</value>
+            </setting>
+            <setting name="OAuth" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="EncodeCFR" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GenerateMask" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="TempPath" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="HideDonation" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="TemplateVod" serializeAs="String">
+                <value>[{date_custom="M-d-yy"}] {channel} - {title}</value>
+            </setting>
+            <setting name="TemplateClip" serializeAs="String">
+                <value>[{date_custom="M-d-yy"}] {channel} - {title}</value>
+            </setting>
+            <setting name="TemplateChat" serializeAs="String">
+                <value>[{date_custom="M-d-yy"}] {channel} - {title} - Chat</value>
+            </setting>
+            <setting name="SubMessages" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="UpgradeRequired" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="ChatBadges" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="LimitVod" serializeAs="String">
+                <value>6</value>
+            </setting>
+            <setting name="LimitClip" serializeAs="String">
+                <value>10</value>
+            </setting>
+            <setting name="LimitChat" serializeAs="String">
+                <value>10</value>
+            </setting>
+            <setting name="LimitRender" serializeAs="String">
+                <value>2</value>
+            </setting>
+            <setting name="QueueFolder" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="ChatDownloadThreads" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="ChatDownloadType" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="ChatEmbedEmotes" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="FfmpegArguments" serializeAs="String">
+                <value>[]</value>
+            </setting>
+            <setting name="EmoteScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="GuiTheme" serializeAs="String">
+                <value>System</value>
+            </setting>
+            <setting name="IgnoreUsersList" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="ChatBadgeMask" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="VerboseErrors" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ChatEmbedMissing" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ChatReplaceEmbeds" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="Offline" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="BannedWordsList" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="BadgeScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="VerticalSpacingScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="EmojiScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="LeftSpacingScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="SectionHeightScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="WordSpacingScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="EmoteSpacingScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="AccentStrokeScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="AccentIndentScale" serializeAs="String">
+                <value>1</value>
+            </setting>
+            <setting name="DisperseCommentOffsets" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GuiCulture" serializeAs="String">
+                <value>en-US</value>
+            </setting>
+            <setting name="MaximumBandwidthKb" serializeAs="String">
+                <value>2048</value>
+            </setting>
+            <setting name="ChatRenderSharpening" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="UTCVideoTime" serializeAs="String">
+                <value>False</value>
+            </setting>
+        </TwitchDownloaderWPF.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -91,17 +91,14 @@ namespace TwitchDownloaderWPF
         private async void btnGetInfo_Click(object sender, RoutedEventArgs e)
         {
             string id = ValidateUrl(textUrl.Text.Trim());
-            if (id == "")
+            if (string.IsNullOrWhiteSpace(id))
             {
                 MessageBox.Show(Translations.Strings.UnableToParseLinkMessage, Translations.Strings.UnableToParseLink, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
             btnGetInfo.IsEnabled = false;
             downloadId = id;
-            if (id.All(Char.IsDigit))
-                downloadType = DownloadType.Video;
-            else
-                downloadType = DownloadType.Clip;
+            downloadType = id.All(char.IsDigit) ? DownloadType.Video : DownloadType.Clip;
 
             try
             {

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -123,8 +124,9 @@ namespace TwitchDownloaderWPF
                     TimeSpan vodLength = TimeSpan.FromSeconds(videoInfo.data.video.lengthSeconds);
                     textTitle.Text = videoInfo.data.video.title;
                     textStreamer.Text = videoInfo.data.video.owner.displayName;
-                    textCreatedAt.Text = videoInfo.data.video.createdAt.ToLocalTime().ToString();
-                    currentVideoTime = videoInfo.data.video.createdAt.ToLocalTime();
+                    var videoTime = videoInfo.data.video.createdAt;
+                    textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoTime.ToString(CultureInfo.CurrentCulture) : videoTime.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+                    currentVideoTime = Settings.Default.UTCVideoTime ? videoTime : videoTime.ToLocalTime();
                     streamerId = int.Parse(videoInfo.data.video.owner.id);
                     var urlTimecodeRegex = new Regex(@"\?t=(\d+)h(\d+)m(\d+)s");
                     var urlTimecodeMatch = urlTimecodeRegex.Match(textUrl.Text);
@@ -171,8 +173,9 @@ namespace TwitchDownloaderWPF
                     }
                     TimeSpan clipLength = TimeSpan.FromSeconds(clipInfo.data.clip.durationSeconds);
                     textStreamer.Text = clipInfo.data.clip.broadcaster.displayName;
-                    textCreatedAt.Text = clipInfo.data.clip.createdAt.ToLocalTime().ToString();
-                    currentVideoTime = clipInfo.data.clip.createdAt.ToLocalTime();
+                    var clipCreatedAt = clipInfo.data.clip.createdAt;
+                    textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+                    currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();
                     textTitle.Text = clipInfo.data.clip.title;
                     streamerId = int.Parse(clipInfo.data.clip.broadcaster.id);
                     labelLength.Text = clipLength.ToString("c");

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -590,7 +590,6 @@ namespace TwitchDownloaderWPF
 
                 SetImage("Images/ppOverheat.gif", true);
                 statusMessage.Text = Translations.Strings.StatusRendering;
-                SplitBtnRender.IsEnabled = false;
                 ffmpegLog.Clear();
                 UpdateActionButtons(true);
                 try

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -58,10 +59,10 @@ namespace TwitchDownloaderWPF
 
             ChatJsonInfo = await ChatJson.DeserializeAsync(InputFile, getEmbeds: false);
             textStreamer.Text = ChatJsonInfo.streamer.name;
-            textCreatedAt.Text = ChatJsonInfo.video.created_at.ToLocalTime().ToString();
+            var videoCreatedAt = ChatJsonInfo.video.created_at;
+            textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoCreatedAt.ToString(CultureInfo.CurrentCulture) : videoCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+            VideoCreatedAt = Settings.Default.UTCVideoTime ? videoCreatedAt : videoCreatedAt.ToLocalTime();
             textTitle.Text = ChatJsonInfo.video.title ?? Translations.Strings.Unknown;
-
-            VideoCreatedAt = ChatJsonInfo.video.created_at.ToLocalTime();
 
             TimeSpan chatStart = TimeSpan.FromSeconds(ChatJsonInfo.video.start);
             numStartHour.Value = (int)chatStart.TotalHours;

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,8 +67,9 @@ namespace TwitchDownloaderWPF
                 }
                 TimeSpan clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
                 textStreamer.Text = clipData.data.clip.broadcaster.displayName;
-                textCreatedAt.Text = clipData.data.clip.createdAt.ToLocalTime().ToString();
-                currentVideoTime = clipData.data.clip.createdAt.ToLocalTime();
+                var clipCreatedAt = clipData.data.clip.createdAt;
+                textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+                currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();
                 textTitle.Text = clipData.data.clip.title;
                 labelLength.Text = clipLength.ToString("c");
 

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -67,7 +67,7 @@ namespace TwitchDownloaderWPF
                 }
                 TimeSpan clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
                 textStreamer.Text = clipData.data.clip.broadcaster.displayName;
-                textCreatedAt.Text = clipData.data.clip.createdAt.ToString();
+                textCreatedAt.Text = clipData.data.clip.createdAt.ToLocalTime().ToString();
                 currentVideoTime = clipData.data.clip.createdAt.ToLocalTime();
                 textTitle.Text = clipData.data.clip.title;
                 labelLength.Text = clipLength.ToString("c");

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -127,7 +127,7 @@ namespace TwitchDownloaderWPF
                 TimeSpan vodLength = TimeSpan.FromSeconds(taskVideoInfo.Result.data.video.lengthSeconds);
                 textStreamer.Text = taskVideoInfo.Result.data.video.owner.displayName;
                 textTitle.Text = taskVideoInfo.Result.data.video.title;
-                textCreatedAt.Text = taskVideoInfo.Result.data.video.createdAt.ToString();
+                textCreatedAt.Text = taskVideoInfo.Result.data.video.createdAt.ToLocalTime().ToString();
                 currentVideoTime = taskVideoInfo.Result.data.video.createdAt.ToLocalTime();
                 var urlTimecodeRegex = new Regex(@"\?t=(\d+)h(\d+)m(\d+)s");
                 var urlTimecodeMatch = urlTimecodeRegex.Match(textUrl.Text);

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -127,8 +128,9 @@ namespace TwitchDownloaderWPF
                 TimeSpan vodLength = TimeSpan.FromSeconds(taskVideoInfo.Result.data.video.lengthSeconds);
                 textStreamer.Text = taskVideoInfo.Result.data.video.owner.displayName;
                 textTitle.Text = taskVideoInfo.Result.data.video.title;
-                textCreatedAt.Text = taskVideoInfo.Result.data.video.createdAt.ToLocalTime().ToString();
-                currentVideoTime = taskVideoInfo.Result.data.video.createdAt.ToLocalTime();
+                var videoCreatedAt = taskVideoInfo.Result.data.video.createdAt;
+                textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoCreatedAt.ToString(CultureInfo.CurrentCulture) : videoCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+                currentVideoTime = Settings.Default.UTCVideoTime ? videoCreatedAt : videoCreatedAt.ToLocalTime();
                 var urlTimecodeRegex = new Regex(@"\?t=(\d+)h(\d+)m(\d+)s");
                 var urlTimecodeMatch = urlTimecodeRegex.Match(textUrl.Text);
                 if (urlTimecodeMatch.Success)

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -8,20 +8,20 @@
 //------------------------------------------------------------------------------
 
 namespace TwitchDownloaderWPF.Properties {
-
-
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
+        
         public static Settings Default {
             get {
                 return defaultInstance;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("4")]
@@ -33,7 +33,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["VodDownloadThreads"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Arial")]
@@ -45,7 +45,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Font"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("24")]
@@ -57,7 +57,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FontSize"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -69,7 +69,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Outline"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -81,7 +81,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Timestamp"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1200")]
@@ -93,7 +93,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Height"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("700")]
@@ -105,7 +105,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Width"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -117,7 +117,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["UpdateTime"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -129,7 +129,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FFZEmotes"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -141,7 +141,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BTTVEmotes"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -153,7 +153,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["STVEmotes"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("17")]
@@ -165,7 +165,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BackgroundColorR"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("17")]
@@ -177,7 +177,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BackgroundColorG"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("17")]
@@ -189,7 +189,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BackgroundColorB"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("255")]
@@ -201,7 +201,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FontColorR"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("255")]
@@ -213,7 +213,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FontColorG"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("255")]
@@ -225,7 +225,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FontColorB"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("60")]
@@ -237,7 +237,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Framerate"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("MP4")]
@@ -249,7 +249,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["VideoContainer"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("H264")]
@@ -261,7 +261,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["VideoCodec"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("255")]
@@ -273,7 +273,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BackgroundColorA"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -285,7 +285,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["OAuth"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -297,7 +297,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["EncodeCFR"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -309,7 +309,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["GenerateMask"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -321,7 +321,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["TempPath"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -333,7 +333,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["HideDonation"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("[{date_custom=\"M-d-yy\"}] {channel} - {title}")]
@@ -345,7 +345,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["TemplateVod"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("[{date_custom=\"M-d-yy\"}] {channel} - {title}")]
@@ -357,7 +357,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["TemplateClip"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("[{date_custom=\"M-d-yy\"}] {channel} - {title} - Chat")]
@@ -369,7 +369,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["TemplateChat"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -381,7 +381,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["SubMessages"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -393,7 +393,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["UpgradeRequired"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
@@ -405,7 +405,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatBadges"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("6")]
@@ -417,7 +417,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LimitVod"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("10")]
@@ -429,7 +429,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LimitClip"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("10")]
@@ -441,7 +441,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LimitChat"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("2")]
@@ -453,7 +453,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LimitRender"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -465,10 +465,10 @@ namespace TwitchDownloaderWPF.Properties {
                 this["QueueFolder"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("4")]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
         public int ChatDownloadThreads {
             get {
                 return ((int)(this["ChatDownloadThreads"]));
@@ -477,7 +477,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatDownloadThreads"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
@@ -489,7 +489,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatDownloadType"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -501,7 +501,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatEmbedEmotes"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("[]")]
@@ -513,7 +513,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FfmpegArguments"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -525,7 +525,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["EmoteScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("System")]
@@ -537,7 +537,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["GuiTheme"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -549,7 +549,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["IgnoreUsersList"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
@@ -561,7 +561,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatBadgeMask"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -573,7 +573,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["VerboseErrors"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -585,7 +585,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatEmbedMissing"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -597,7 +597,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ChatReplaceEmbeds"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -609,7 +609,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["Offline"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -621,7 +621,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BannedWordsList"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -633,7 +633,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["BadgeScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -645,7 +645,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["VerticalSpacingScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -657,7 +657,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["EmojiScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -669,7 +669,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LeftSpacingScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -681,7 +681,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["SectionHeightScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -693,7 +693,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["WordSpacingScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -705,7 +705,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["EmoteSpacingScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -717,7 +717,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["AccentStrokeScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
@@ -729,7 +729,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["AccentIndentScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -741,7 +741,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["DisperseCommentOffsets"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("en-US")]
@@ -753,7 +753,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["GuiCulture"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("2048")]
@@ -765,7 +765,7 @@ namespace TwitchDownloaderWPF.Properties {
                 this["MaximumBandwidthKb"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -775,6 +775,18 @@ namespace TwitchDownloaderWPF.Properties {
             }
             set {
                 this["ChatRenderSharpening"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UTCVideoTime {
+            get {
+                return ((bool)(this["UTCVideoTime"]));
+            }
+            set {
+                this["UTCVideoTime"] = value;
             }
         }
     }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="TwitchDownloaderWPF.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
@@ -81,13 +81,13 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="TemplateVod" Type="System.String" Scope="User">
-      <Value Profile="(Default)">[{date_custom="M-d-yy"}] {channel} - {title}</Value>
+      <Value Profile="(Default)">[{date_custom=&quot;M-d-yy&quot;}] {channel} - {title}</Value>
     </Setting>
     <Setting Name="TemplateClip" Type="System.String" Scope="User">
-      <Value Profile="(Default)">[{date_custom="M-d-yy"}] {channel} - {title}</Value>
+      <Value Profile="(Default)">[{date_custom=&quot;M-d-yy&quot;}] {channel} - {title}</Value>
     </Setting>
     <Setting Name="TemplateChat" Type="System.String" Scope="User">
-      <Value Profile="(Default)">[{date_custom="M-d-yy"}] {channel} - {title} - Chat</Value>
+      <Value Profile="(Default)">[{date_custom=&quot;M-d-yy&quot;}] {channel} - {title} - Chat</Value>
     </Setting>
     <Setting Name="SubMessages" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
@@ -191,5 +191,9 @@
     <Setting Name="ChatRenderSharpening" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="UTCVideoTime" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
+

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -1194,6 +1194,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Time Format:.
+        /// </summary>
+        public static string SettingsTimeFormat {
+            get {
+                return ResourceManager.GetString("SettingsTimeFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Side Padding Scale:.
         /// </summary>
         public static string SidePaddingScale {
@@ -1415,6 +1424,15 @@ namespace TwitchDownloaderWPF.Translations {
         public static string TimestampFormat {
             get {
                 return ResourceManager.GetString("TimestampFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local.
+        /// </summary>
+        public static string TimestampLocal {
+            get {
+                return ResourceManager.GetString("TimestampLocal", resourceCulture);
             }
         }
         

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -702,4 +702,10 @@
   <data name="RenderImageSharpening" xml:space="preserve">
     <value>Renforcement de l'image:</value>
   </data>
+  <data name="SettingsTimeFormat" xml:space="preserve">
+    <value>Format horaire:</value>
+  </data>
+  <data name="TimestampLocal" xml:space="preserve">
+    <value>L'Heure locale</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -701,4 +701,10 @@
   <data name="RenderImageSharpening" xml:space="preserve">
     <value>Wyostrzanie:</value>
   </data>
+  <data name="TimestampLocal" xml:space="preserve">
+    <value>Local</value>
+  </data>
+  <data name="SettingsTimeFormat" xml:space="preserve">
+    <value>Time Format:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -701,4 +701,10 @@
   <data name="RenderImageSharpening" xml:space="preserve">
     <value>Sharpening:</value>
   </data>
+  <data name="TimestampLocal" xml:space="preserve">
+    <value>Local</value>
+  </data>
+  <data name="SettingsTimeFormat" xml:space="preserve">
+    <value>Time Format:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -703,4 +703,10 @@
   <data name="RenderImageSharpening" xml:space="preserve">
     <value>Keskinlik:</value>
   </data>
+  <data name="TimestampLocal" xml:space="preserve">
+    <value>Local</value>
+  </data>
+  <data name="SettingsTimeFormat" xml:space="preserve">
+    <value>Time Format:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.TwitchObjects.Gql;
+using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.TwitchTasks;
 using static TwitchDownloaderWPF.App;
 
@@ -70,7 +71,7 @@ namespace TwitchDownloaderWPF
                         data.Title = video.node.title;
                         data.Length = video.node.lengthSeconds;
                         data.Id = video.node.id;
-                        data.Time = video.node.createdAt.ToLocalTime();
+                        data.Time = Settings.Default.UTCVideoTime ? video.node.createdAt : video.node.createdAt.ToLocalTime();
                         data.Views = video.node.viewCount;
                         data.Streamer = currentChannel;
                         try
@@ -118,7 +119,7 @@ namespace TwitchDownloaderWPF
                         data.Title = clip.node.title;
                         data.Length = clip.node.durationSeconds;
                         data.Id = clip.node.slug;
-                        data.Time = clip.node.createdAt.ToLocalTime();
+                        data.Time = Settings.Default.UTCVideoTime ? clip.node.createdAt : clip.node.createdAt.ToLocalTime();
                         data.Views = clip.node.viewCount;
                         data.Streamer = currentChannel;
                         try

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -138,7 +138,7 @@ namespace TwitchDownloaderWPF
                         else
                             chatOptions.DownloadFormat = ChatFormat.Text;
                         chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, vodPage.currentVideoTime.ToLocalTime(), vodPage.textStreamer.Text) + "." + chatOptions.DownloadFormat);
+                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, vodPage.currentVideoTime, vodPage.textStreamer.Text) + "." + chatOptions.DownloadFormat);
 
                         if (downloadOptions.CropBeginning)
                         {
@@ -200,7 +200,7 @@ namespace TwitchDownloaderWPF
 
                     ClipDownloadTask downloadTask = new ClipDownloadTask();
                     ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                    downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + ".mp4");
+                    downloadOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime, clipPage.textStreamer.Text) + ".mp4");
                     downloadOptions.Id = clipPage.clipId;
                     downloadOptions.Quality = clipPage.comboQuality.Text;
                     downloadTask.DownloadOptions = downloadOptions;
@@ -226,7 +226,7 @@ namespace TwitchDownloaderWPF
                             chatOptions.DownloadFormat = ChatFormat.Text;
                         chatOptions.TimeFormat = TimestampFormat.Relative;
                         chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime.ToLocalTime(), clipPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+                        chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime, clipPage.textStreamer.Text) + "." + chatOptions.FileExtension);
 
                         chatTask.DownloadOptions = chatOptions;
                         chatTask.Info.Title = clipPage.textTitle.Text;
@@ -277,7 +277,7 @@ namespace TwitchDownloaderWPF
                     ChatDownloadTask chatTask = new ChatDownloadTask();
                     ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
                     chatOptions.Id = chatPage.downloadId;
-                    chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatOptions.Id, chatPage.currentVideoTime.ToLocalTime(), chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
+                    chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatOptions.Id, chatPage.currentVideoTime, chatPage.textStreamer.Text) + "." + chatOptions.FileExtension);
 
                     chatTask.DownloadOptions = chatOptions;
                     chatTask.Info.Title = chatPage.textTitle.Text;

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -11,7 +11,7 @@
         xmlns:hc="https://handyorg.github.io/handycontrol"
         xmlns:fa="http://schemas.fontawesome.com/icons/"
         mc:Ignorable="d"
-        Title="Global Settings" MinWidth="400" MinHeight="444" Width="500" Height="480" Initialized="Window_Initialized" Closing="Window_Closing">
+        Title="Global Settings" MinWidth="400" MinHeight="450" Width="500" Height="500" Initialized="Window_Initialized" Closing="Window_Closing">
     <Grid Background="{DynamicResource AppBackground}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="8"/>
@@ -35,6 +35,11 @@
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,4,3,3" Text="{lex:Loc HideDonationButton}" Foreground="{DynamicResource AppText}" />
                 <CheckBox x:Name="checkDonation" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" BorderBrush="{DynamicResource AppElementBorder}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
+                <TextBlock Margin="3,4,3,3" Text="{lex:Loc SettingsTimeFormat}" Foreground="{DynamicResource AppText}" />
+                <RadioButton x:Name="radioTimeFormatUTC" Content="{lex:Loc TimestampUtc}" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                <RadioButton x:Name="radioTimeFormatLocal" IsChecked="True" Content="{lex:Loc TimestampLocal}" Margin="3,0,0,0" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,4,3,3" Text="{lex:Loc VerboseErrors}" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -50,6 +50,7 @@ namespace TwitchDownloaderWPF
             checkDonation.IsChecked = Settings.Default.HideDonation;
             checkVerboseErrors.IsChecked = Settings.Default.VerboseErrors;
             NumMaximumBandwidth.Value = Settings.Default.MaximumBandwidthKb;
+            radioTimeFormatUTC.IsChecked = Settings.Default.UTCVideoTime;
 
             // Setup theme dropdown
             comboTheme.Items.Add("System"); // Cannot be localized
@@ -123,6 +124,7 @@ namespace TwitchDownloaderWPF
             Settings.Default.HideDonation = (bool)checkDonation.IsChecked;
             Settings.Default.VerboseErrors = (bool)checkVerboseErrors.IsChecked;
             Settings.Default.MaximumBandwidthKb = (int)NumMaximumBandwidth.Value;
+            Settings.Default.UTCVideoTime = (bool)radioTimeFormatUTC.IsChecked;
             Settings.Default.Save();
         }
 
@@ -141,9 +143,9 @@ namespace TwitchDownloaderWPF
 
         private void comboTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (!comboTheme.SelectedItem.ToString().Equals(Settings.Default.GuiTheme, StringComparison.OrdinalIgnoreCase))
+            if (!((string)comboTheme.SelectedItem).Equals(Settings.Default.GuiTheme, StringComparison.OrdinalIgnoreCase))
             {
-                Settings.Default.GuiTheme = comboTheme.SelectedItem.ToString();
+                Settings.Default.GuiTheme = (string)comboTheme.SelectedItem;
                 AppSingleton.RequestAppThemeChange();
             }
         }

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.TwitchObjects.Gql;
+using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.TwitchTasks;
 using static TwitchDownloaderWPF.App;
 
@@ -105,7 +106,7 @@ namespace TwitchDownloaderWPF
                         catch { }
                         newData.Title = data.data.video.title;
                         newData.Streamer = data.data.video.owner.displayName;
-                        newData.Time = data.data.video.createdAt.ToLocalTime();
+                        newData.Time = Settings.Default.UTCVideoTime ? data.data.video.createdAt : data.data.video.createdAt.ToLocalTime();
                         dataList.Add(newData);
                     }
                     else
@@ -137,7 +138,7 @@ namespace TwitchDownloaderWPF
                         catch { }
                         newData.Title = data.data.clip.title;
                         newData.Streamer = data.data.clip.broadcaster.displayName;
-                        newData.Time = data.data.clip.createdAt.ToLocalTime();
+                        newData.Time = Settings.Default.UTCVideoTime ? data.data.clip.createdAt : data.data.clip.createdAt.ToLocalTime();
                         dataList.Add(newData);
                     }
                     else


### PR DESCRIPTION
- Add cancellation tokens to chatrender image fetching
- Remove 4.2MB of unused content from twemoji-14.0.0.zip - only the 72x72 png assets and licenses remain
- Extract & read emojis/emoji zip using streams to save some memory