### PR TITLE
Chatdownload bits_spent patch

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -20,7 +20,7 @@ namespace TwitchDownloaderCore
     {
         private readonly ChatDownloadOptions downloadOptions;
         private static HttpClient httpClient = new HttpClient();
-        private static readonly Regex _bitsRegex = new(@"(?:Cheer|BibleThump|cheerwhal|Corgo|Scoops|uni|ShowLove|Party|SeemsGood|Pride|Kappa|FrankerZ|HeyGuys|DansGame|EleGiggle|TriHard|Kreygasm|4Head|SwiftRage|NotLikeThis|FailFish|VoHiYo|PJSalt|MrDestructoid|bday|RIPCheer|Shamrock|DoodleCheer|BitBoss|Streamlabs|Muxy|HolidayCheer|Goal|Anon|Charity)(\d+)(?:\s|$)", RegexOptions.Compiled);
+        private static readonly Regex _bitsRegex = new(@"(?<=(?:\s|^)(?:4Head|Anon|Bi(?:bleThumb|tBoss)|bday|C(?:h(?:eer|arity)|orgo)|cheerwal|D(?:ansGame|oodleCheer)|EleGiggle|F(?:rankerZ|ailFish)|Goal|H(?:eyGuys|olidayCheer)|K(?:appa|reygasm)|M(?:rDestructoid|uxy)|NotLikeThis|P(?:arty|ride|JSalt)|RIPCheer|S(?:coops|h(?:owLove|amrock)|eemsGood|wiftRage|treamlabs)|TriHard|uni|VoHiYo))[1-9]\d?\d?\d?\d?\d?\d?(?=\s|$)", RegexOptions.Compiled);
         private enum DownloadType { Clip, Video }
 
         public ChatDownloader(ChatDownloadOptions DownloadOptions)
@@ -173,9 +173,9 @@ namespace TwitchDownloaderCore
                 message.user_color = oldComment.message.userColor;
                 message.emoticons = emoticons;
                 var bitMatch = _bitsRegex.Match(message.body);
-                if (bitMatch.Success)
+                if (bitMatch.Success && int.TryParse(bitMatch.ValueSpan, out var result))
                 {
-                    message.bits_spent = int.Parse(bitMatch.Groups[1].Value);
+                    message.bits_spent = result;
                 }
                 newComment.message = message;
 


### PR DESCRIPTION
- Fix integer overflow crash when downloading chats where users pretend to send high amount cheers - fixes #596 
- Optimize bit regex
    - The theoretical maximum cheer amount is now 9,999,999 bits, or $99,999. Surely nobody would donate $100,000USD in bits, or at least not in one message.
    - I hyper optimized the pattern itself. It looks a bit crazy now but I promise it works the same as before [(click for visualization)](https://regexper.com/#%28%3F%3A%5Cs%7C%5E%29%28%3F%3A4Head%7CAnon%7CBi%28%3F%3AbleThumb%7CtBoss%29%7Cbday%7CC%28%3F%3Ah%28%3F%3Aeer%7Carity%29%7Corgo%29%7Ccheerwal%7CD%28%3F%3AansGame%7CoodleCheer%29%7CEleGiggle%7CF%28%3F%3ArankerZ%7CailFish%29%7CGoal%7CH%28%3F%3AeyGuys%7ColidayCheer%29%7CK%28%3F%3Aappa%7Creygasm%29%7CM%28%3F%3ArDestructoid%7Cuxy%29%7CNotLikeThis%7CP%28%3F%3Aarty%7Cride%7CJSalt%29%7CRIPCheer%7CS%28%3F%3Acoops%7Ch%28%3F%3AowLove%7Camrock%29%7CeemsGood%7CwiftRage%7Ctreamlabs%29%7CTriHard%7Cuni%7CVoHiYo%29%5B1-9%5D%5Cd%3F%5Cd%3F%5Cd%3F%5Cd%3F%5Cd%3F%5Cd%3F%28%3F%3D%5Cs%7C%24%29) and is faster + more memory efficient than the old one on average.
        <details>
        <summary>Benchmarks screenshots</summary>

        ![image](https://user-images.githubusercontent.com/72096833/224231250-5143a36c-7c35-4357-b4c5-bf4f7b2ff2ba.png)
        ![image](https://user-images.githubusercontent.com/72096833/224232015-10a076f8-38f7-437b-a514-a6f21265d216.png)

       </details>
