### PR TITLE
Fully remove Newtonsoft from Core

### DIFF
--- a/TwitchDownloaderCore/TwitchDownloaderCore.csproj
+++ b/TwitchDownloaderCore/TwitchDownloaderCore.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />

--- a/TwitchDownloaderCore/TwitchObjects/Api/FFZEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/FFZEmote.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace TwitchDownloaderCore.TwitchObjects.Api
 {
@@ -15,15 +14,12 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
 
     public class FFZImages
     {
-        [JsonProperty("1x")]
         [JsonPropertyName("1x")]
         public string _1x { get; set; }
 
-        [JsonProperty("2x")]
         [JsonPropertyName("2x")]
         public string _2x { get; set; }
 
-        [JsonProperty("4x")]
         [JsonPropertyName("4x")]
         public string _4x { get; set; }
     }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -1,8 +1,7 @@
-﻿using Newtonsoft = Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using SystemText = System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace TwitchDownloaderCore.TwitchObjects
 {
@@ -98,7 +97,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public List<Fragment> fragments { get; set; }
         public List<UserBadge> user_badges { get; set; }
         public string user_color { get; set; }
-        [SystemText::JsonIgnore(Condition = SystemText.JsonIgnoreCondition.WhenWritingNull)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public UserNoticeParams user_notice_params { get; set; }
         public List<Emoticon2> emoticons { get; set; }
 
@@ -175,8 +174,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string id { get; set; }
         public int startMilliseconds { get; set; }
         public int lengthMilliseconds { get; set; }
-        [Newtonsoft::JsonProperty("type")]
-        [SystemText::JsonPropertyName("type")]
+        [JsonPropertyName("type")]
         public string _type { get; set; }
         public string description { get; set; }
         public string subDescription { get; set; }
@@ -212,7 +210,7 @@ namespace TwitchDownloaderCore.TwitchObjects
     {
         public string name { get; set; }
         public Dictionary<string, byte[]> versions { get; set; }
-        [SystemText::JsonIgnore(Condition = SystemText.JsonIgnoreCondition.WhenWritingNull)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Dictionary<string, string> urls { get; set; }
     }
 

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoChapterResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoChapterResponse.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable IDE1006
-using Newtonsoft.Json;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace TwitchDownloaderCore.TwitchObjects.Gql
@@ -29,7 +27,6 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public string id { get; set; }
         public int durationMilliseconds { get; set; }
         public int positionMilliseconds { get; set; }
-        [JsonProperty("type")]
         [JsonPropertyName("type")]
         public string _type { get; set; }
         public string description { get; set; }


### PR DESCRIPTION
Migrating everything to `System.Text.Json` so we don't need to double-attribute every property with a custom name. Unfortunately `Xabe.Ffmpeg` implicitly installs a really old version of Newtonsoft so we can't eliminate it entirely :P Maybe I'll send them a PR to switch as well.