### PR TITLE
Credit Twemoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,5 @@ cd TwitchDownloaderCLI/bin/Release/net6.0/publish
 
 # Credits
 [Noto Color Emoji](https://github.com/googlefonts/noto-emoji) © Google and contributors.
+
 [Twemoji](https://github.com/twitter/twemoji) © Twitter and contributors.

--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ cd TwitchDownloaderCLI/bin/Release/net6.0/publish
 
 # Credits
 [Noto Color Emoji](https://github.com/googlefonts/noto-emoji) © Google and contributors.
+[Twemoji](https://github.com/twitter/twemoji) © Twitter and contributors.


### PR DESCRIPTION
Since we've credited Google for Noto, I feel Twemoji shouldn't be left out, especially since switching between different emoji vendors is in plans.