### PR TITLE
Add platform check to `ChatRenderer.OpenImage(SKBitmap)`

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1179,6 +1179,8 @@ namespace TwitchDownloaderCore
         //For debugging, works on Windows only
         private static void OpenImage(SKBitmap newBitmap)
         {
+            if (!OperatingSystem.IsWindows()) return;
+
             string tempFile = Path.GetFileNameWithoutExtension(Path.GetTempFileName()) + ".png";
             using (FileStream fs = new FileStream(tempFile, FileMode.Create))
                 newBitmap.Encode(SKEncodedImageFormat.Png, 100).SaveTo(fs);


### PR DESCRIPTION
## Description
This method had a comment, that it can only be run on Windows, so I added a check for it.