### PR TITLE
Legacy chat deserialization improvements

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1549,13 +1549,6 @@ namespace TwitchDownloaderCore
         public async Task<ChatRoot> ParseJsonAsync(CancellationToken cancellationToken = new())
         {
             chatRoot = await ChatJson.DeserializeAsync(renderOptions.InputFile, true, true, cancellationToken);
-
-            chatRoot.streamer ??= new Streamer
-            {
-                id = int.Parse(chatRoot.comments.First().channel_id),
-                name = await TwitchHelper.GetStreamerName(int.Parse(chatRoot.comments.First().channel_id))
-            };
-
             return chatRoot;
         }
 

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -362,13 +362,6 @@ namespace TwitchDownloaderCore
         public async Task<ChatRoot> ParseJsonAsync(CancellationToken cancellationToken = new())
         {
             chatRoot = await ChatJson.DeserializeAsync(_updateOptions.InputFile, true, true, cancellationToken);
-
-            chatRoot.streamer ??= new Streamer
-            {
-                id = int.Parse(chatRoot.comments.First().channel_id),
-                name = await TwitchHelper.GetStreamerName(int.Parse(chatRoot.comments.First().channel_id))
-            };
-
             return chatRoot;
         }
     }

--- a/TwitchDownloaderCore/Tools/TimeSpanExtensions.cs
+++ b/TwitchDownloaderCore/Tools/TimeSpanExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace TwitchDownloaderCore.Tools
+{
+    public static class TimeSpanExtensions
+    {
+        /// <summary>
+        /// Converts the span representation of a time interval in the format of '2d21h11m9s' to its <see cref="TimeSpan"/> equivalent.
+        /// </summary>
+        /// <param name="input">A span containing the characters that represent the time interval to convert.</param>
+        /// <returns>The <see cref="TimeSpan"/> equivalent to the time interval contained in the <paramref name="input"/> span.</returns>
+        public static TimeSpan ParseTimeCode(ReadOnlySpan<char> input)
+        {
+            var dayIndex = input.IndexOf('d');
+            var hourIndex = input.IndexOf('h');
+            var minuteIndex = input.IndexOf('m');
+            var secondIndex = input.IndexOf('s');
+            var returnTimespan = TimeSpan.Zero;
+
+            if (dayIndex != -1)
+            {
+                returnTimespan = returnTimespan.Add(TimeSpan.FromDays(int.Parse(input[..dayIndex])));
+            }
+
+            dayIndex++;
+
+            if (hourIndex != -1)
+            {
+                returnTimespan = returnTimespan.Add(TimeSpan.FromHours(int.Parse(input[dayIndex..hourIndex])));
+            }
+
+            hourIndex++;
+
+            if (minuteIndex != -1)
+            {
+                returnTimespan = returnTimespan.Add(TimeSpan.FromMinutes(int.Parse(input[hourIndex..minuteIndex])));
+            }
+
+            minuteIndex++;
+
+            if (secondIndex != -1)
+            {
+                returnTimespan = returnTimespan.Add(TimeSpan.FromSeconds(int.Parse(input[minuteIndex..secondIndex])));
+            }
+
+            return returnTimespan;
+        }
+    }
+}

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -193,6 +193,18 @@ namespace TwitchDownloaderCore.TwitchObjects
         public double end { get; set; }
         public double length { get; set; } = -1;
         public List<VideoChapter> chapters { get; set; } = new();
+
+#region DeprecatedProperties
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string duration { get; set; } = null;
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string user_id { get; set; } = null;
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string user_name { get; set; } = null;
+#endregion
     }
 
     public class EmbedEmoteData

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -195,13 +195,13 @@ namespace TwitchDownloaderCore.TwitchObjects
         public List<VideoChapter> chapters { get; set; } = new();
 
 #region DeprecatedProperties
-        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string duration { get; set; } = null;
-        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string user_id { get; set; } = null;
-        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21a.</summary>
+        /// <summary>Deprecated. Used only by chats from before 8d521f7a78222bec187b56c3c747909d240add21.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string user_name { get; set; } = null;
 #endregion

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media.Imaging;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
@@ -129,14 +130,14 @@ namespace TwitchDownloaderWPF
                     textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoTime.ToString(CultureInfo.CurrentCulture) : videoTime.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                     currentVideoTime = Settings.Default.UTCVideoTime ? videoTime : videoTime.ToLocalTime();
                     streamerId = int.Parse(videoInfo.data.video.owner.id);
-                    var urlTimecodeRegex = new Regex(@"\?t=(\d+)h(\d+)m(\d+)s");
-                    var urlTimecodeMatch = urlTimecodeRegex.Match(textUrl.Text);
-                    if (urlTimecodeMatch.Success)
+                    var urlTimeCodeMatch = Regex.Match(textUrl.Text, @"(?<=\?t=)\d+h\d+m\d+s");
+                    if (urlTimeCodeMatch.Success)
                     {
+                        var time = TimeSpanExtensions.ParseTimeCode(urlTimeCodeMatch.ValueSpan);
                         checkCropStart.IsChecked = true;
-                        numStartHour.Value = int.Parse(urlTimecodeMatch.Groups[1].ValueSpan);
-                        numStartMinute.Value = int.Parse(urlTimecodeMatch.Groups[2].ValueSpan);
-                        numStartSecond.Value = int.Parse(urlTimecodeMatch.Groups[3].ValueSpan);
+                        numStartHour.Value = time.Hours;
+                        numStartMinute.Value = time.Minutes;
+                        numStartSecond.Value = time.Seconds;
                     }
                     else
                     {

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
@@ -136,14 +137,14 @@ namespace TwitchDownloaderWPF
                 var videoCreatedAt = taskVideoInfo.Result.data.video.createdAt;
                 textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoCreatedAt.ToString(CultureInfo.CurrentCulture) : videoCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                 currentVideoTime = Settings.Default.UTCVideoTime ? videoCreatedAt : videoCreatedAt.ToLocalTime();
-                var urlTimecodeRegex = new Regex(@"\?t=(\d+)h(\d+)m(\d+)s");
-                var urlTimecodeMatch = urlTimecodeRegex.Match(textUrl.Text);
-                if (urlTimecodeMatch.Success)
+                var urlTimeCodeMatch = Regex.Match(textUrl.Text, @"(?<=\?t=)\d+h\d+m\d+s");
+                if (urlTimeCodeMatch.Success)
                 {
+                    var time = TimeSpanExtensions.ParseTimeCode(urlTimeCodeMatch.ValueSpan);
                     checkStart.IsChecked = true;
-                    numStartHour.Value = int.Parse(urlTimecodeMatch.Groups[1].ValueSpan);
-                    numStartMinute.Value = int.Parse(urlTimecodeMatch.Groups[2].ValueSpan);
-                    numStartSecond.Value = int.Parse(urlTimecodeMatch.Groups[3].ValueSpan);
+                    numStartHour.Value = time.Hours;
+                    numStartMinute.Value = time.Minutes;
+                    numStartSecond.Value = time.Seconds;
                 }
                 else
                 {


### PR DESCRIPTION
- Significantly improves deserialization of legacy chats from 8d521f7 or before
    - Fixes #728 
- Less allocations when deserializing `2d21h11m9s` time codes