### PR TITLE
Add support for animated FFZ emotes

### DIFF
--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -205,7 +205,9 @@ namespace TwitchDownloaderCore
                 string id = emote.id.ToString();
                 string name = emote.code;
                 string mime = emote.imageType;
-                string url = $"https://cdn.betterttv.net/frankerfacez_emote/{id}/[scale]";
+                string url = emote.animated
+                    ? $"https://cdn.betterttv.net/frankerfacez_emote/{id}/animated/[scale]"
+                    : $"https://cdn.betterttv.net/frankerfacez_emote/{id}/[scale]";
                 ffzResponse.Add(new EmoteResponseItem() { Id = id, Code = name, ImageType = mime, ImageUrl = url });
             }
         }

--- a/TwitchDownloaderCore/TwitchObjects/Api/FFZEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/FFZEmote.cs
@@ -10,6 +10,8 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
         public string code { get; set; }
         public FFZImages images { get; set; }
         public string imageType { get; set; }
+        public bool animated { get; set; }
+        public bool modifier { get; set; }
     }
 
     public class FFZImages


### PR DESCRIPTION
Just checked and the BetterTTV FFZ endpoint now properly supports passing the correct _animated_ value for animated emotes

- Closes #577 
