### PR TITLE
fix: typo in cli docs

### DIFF
--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -41,7 +41,7 @@ Extra example, if I wanted only seconds 3-6 in a 10 second stream I would do `-b
 (Default: `-1`) The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or `-1` for no maximum.
 
 **--oauth**
-OAuth access token to download subscriber only VODs. <ins>**DO NOT SHARE YOUR OUATH TOKEN WITH ANYONE.**</ins>
+OAuth access token to download subscriber only VODs. <ins>**DO NOT SHARE YOUR OAUTH TOKEN WITH ANYONE.**</ins>
 
 **--ffmpeg-path**
 Path to ffmpeg executable.


### PR DESCRIPTION
This corrects a small typo with oauth