### PR TITLE
Videodownload patch

### DIFF
--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -15,12 +15,12 @@ namespace TwitchDownloaderCLI.Modes
         {
             FfmpegHandler.DetectFfmpeg(inputOptions.FfmpegPath);
 
-            var downloadOptions = GetDownloadOptions(inputOptions);
-
-            VideoDownloader videoDownloader = new(downloadOptions);
             Progress<ProgressReport> progress = new();
             progress.ProgressChanged += ProgressHandler.Progress_ProgressChanged;
-            videoDownloader.DownloadAsync(progress, new CancellationToken()).Wait();
+
+            var downloadOptions = GetDownloadOptions(inputOptions);
+            VideoDownloader videoDownloader = new(downloadOptions, progress);
+            videoDownloader.DownloadAsync(new CancellationToken()).Wait();
         }
 
         private static VideoDownloadOptions GetDownloadOptions(VideoDownloadArgs inputOptions)

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -353,10 +353,19 @@ namespace TwitchDownloaderCore
             if (!int.TryParse(encodingTimeMatch.Groups[4].ValueSpan, out var milliseconds)) return;
             var encodingTime = new TimeSpan(0, hours, minutes, seconds, milliseconds);
 
-            var percent = (int)(encodingTime.TotalSeconds / videoLength * 100);
+            var percent = (int)Math.Round(encodingTime.TotalSeconds / videoLength * 100);
 
-            progress.Report(new ProgressReport(ReportType.SameLineStatus, $"Finalizing Video {percent}% [4/4]"));
-            progress.Report(new ProgressReport(percent));
+            // Apparently it is possible for the percent to not be within the range of 0-100. lay295#716
+            if (percent is < 0 or > 100)
+            {
+                progress.Report(new ProgressReport(ReportType.SameLineStatus, "Finalizing Video... [4/4]"));
+                progress.Report(new ProgressReport(0));
+            }
+            else
+            {
+                progress.Report(new ProgressReport(ReportType.SameLineStatus, $"Finalizing Video {percent}% [4/4]"));
+                progress.Report(new ProgressReport(percent));
+            }
         }
 
         private async Task DownloadVideoPartAsync(string baseUrl, string videoPartName, string downloadFolder, double vodAge, int throttleKib, CancellationToken cancellationToken)

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -436,8 +436,8 @@ namespace TwitchDownloaderWPF
 
             VideoDownloadOptions options = GetOptions(saveFileDialog.FileName, null);
 
-            VideoDownloader currentDownload = new VideoDownloader(options);
             Progress<ProgressReport> downloadProgress = new Progress<ProgressReport>(OnProgressChanged);
+            VideoDownloader currentDownload = new VideoDownloader(options, downloadProgress);
             _cancellationTokenSource = new CancellationTokenSource();
 
             SetImage("Images/ppOverheat.gif", true);
@@ -445,7 +445,7 @@ namespace TwitchDownloaderWPF
             UpdateActionButtons(true);
             try
             {
-                await currentDownload.DownloadAsync(downloadProgress, _cancellationTokenSource.Token);
+                await currentDownload.DownloadAsync(_cancellationTokenSource.Token);
                 statusMessage.Text = Translations.Strings.StatusDone;
                 SetImage("Images/ppHop.gif", true);
             }

--- a/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
@@ -56,13 +56,13 @@ namespace TwitchDownloaderWPF.TwitchTasks
                 return;
             }
 
-            VideoDownloader downloader = new VideoDownloader(DownloadOptions);
             Progress<ProgressReport> progress = new Progress<ProgressReport>();
             progress.ProgressChanged += Progress_ProgressChanged;
+            VideoDownloader downloader = new VideoDownloader(DownloadOptions, progress);
             ChangeStatus(TwitchTaskStatus.Running);
             try
             {
-                await downloader.DownloadAsync(progress, TokenSource.Token);
+                await downloader.DownloadAsync(TokenSource.Token);
                 if (TokenSource.IsCancellationRequested)
                 {
                     ChangeStatus(TwitchTaskStatus.Canceled);


### PR DESCRIPTION
- Use a `ConcurrentQueue` instead of LINQ for managing video part downloads
- Fallback to non-throttled download when receiving an unexpected EOF
- Add video part verification, redownload if needed
  - This also brings us closer to implementing #544 
- Add a range check to ffmpeg finalization percentage because apparently it can be out of range
  - Fixes #716