### PR TITLE
Improve memory performance for txt chat download

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -40,6 +40,9 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("chat-connections", Default = 4, HelpText = "Number of downloading connections for chat")]
         public int ChatConnections { get; set; }
 
+        [Option('q', "quiet", Default = false, HelpText = "Suppresses progress console output")]
+        public bool Quiet { get; set; }
+
         [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
         public string TempFolder { get; set; }
     }

--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -61,6 +61,7 @@ namespace TwitchDownloaderCLI.Modes
                 Compression = inputOptions.Compression,
                 TimeFormat = inputOptions.TimeFormat,
                 ConnectionCount = inputOptions.ChatConnections,
+                Quiet = inputOptions.Quiet,
                 BttvEmotes = (bool)inputOptions.BttvEmotes!,
                 FfzEmotes = (bool)inputOptions.FfzEmotes!,
                 StvEmotes = (bool)inputOptions.StvEmotes!,

--- a/TwitchDownloaderCore/Chat/ChatText.cs
+++ b/TwitchDownloaderCore/Chat/ChatText.cs
@@ -24,17 +24,18 @@ namespace TwitchDownloaderCore.Chat
             await using var sw = new StreamWriter(filePath);
             foreach (var comment in chatRoot.comments)
             {
-                string username = comment.commenter.display_name;
-                string message = comment.message.body;
+                var username = comment.commenter.display_name;
+                var message = comment.message.body;
                 if (timeFormat == TimestampFormat.Utc)
                 {
-                    string timestamp = comment.created_at.ToString("u").Replace("Z", " UTC");
+                    var timestamp = comment.created_at.ToString("yyyy'-'MM'-'dd HH':'mm':'ss 'UTC'");;
                     await sw.WriteLineAsync($"[{timestamp}] {username}: {message}");
                 }
                 else if (timeFormat == TimestampFormat.Relative)
                 {
                     var time = TimeSpan.FromSeconds(comment.content_offset_seconds);
-                    await sw.WriteLineAsync(string.Format(new TimeSpanHFormat(), @"[{0:H\:mm\:ss}] {1}: {2}", time, username, message));
+                    await sw.WriteLineAsync(string.Format(new TimeSpanHFormat(), @"[{0:H\:mm\:ss}] {1}: {2}", time,
+                        username, message));
                 }
                 else if (timeFormat == TimestampFormat.None)
                 {

--- a/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
@@ -17,6 +17,7 @@ namespace TwitchDownloaderCore.Options
         public bool FfzEmotes { get; set; }
         public bool StvEmotes { get; set; }
         public int ConnectionCount { get; set; } = 1;
+        public bool Quiet { get; set; } = false;
         public TimestampFormat TimeFormat { get; set; }
         public string FileExtension
         {


### PR DESCRIPTION
**_WHY_**
My use case includes running this cli to download twitch chats, in a constraint environment (e.g, Rapsberri Pi).

The tool is great, but for large streams (with a lot of messages) the memory footprint can be big. 
for instance for:
 https://www.twitch.tv/videos/1857424785
The tool takes around 510 mbs of memory (see images).

I was looking at the code, and I found out some points in which we could optimize. 
For instance, emotes, and Badges information are not used for txt files.
And creating these instances takes a lot of memory.
With the proposed changes I was able to reduce the memory usage significantly, to around: 360mbs for that particular case.

I also added a quiet mode (-q) option to the CLI, since some users might not be interested in keeping track of the progress (for instance my case, were the process is automated and I'm not looking at the progress), and this also lowers the memory consumption.

Improve memory performance.
![image](https://github.com/lay295/TwitchDownloader/assets/45356734/cf961e1b-1d14-45cf-8564-f393739bc405)
![image](https://github.com/lay295/TwitchDownloader/assets/45356734/d968f975-f6dd-4cf1-80bb-f899fef66bff)


**_HOW_**
* Add quiet mode option (`-q`).
* Improve Datetime parsing. 
* Added conditions to verify what is the Ouput File format when converting comments.
* Changed Comment's message body creation to use a StringBuilder to improve memory performance.
* Change progress percentages List to an `int` array to be allocated in the stack and initialized at 0.
* Change DownloadSection to return a `List` of `Comment`s objects, and made the comments unification and sorting after all tasks are finished to avoid concurrency issues,



**_Note:_**
Hi this is my first attempt to contribute to this project, so I'm sorry if I overlooked something.