### PR TITLE
Add support to milliseconds information in timestamp

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -34,7 +34,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("stv", Default = true, HelpText = "Enable 7TV embedding in chat download. Requires -E / --embed-images!")]
         public bool? StvEmotes { get; set; }
 
-        [Option("timestamp-format", Default = TimestampFormat.Relative, HelpText = "Sets the timestamp format for .txt chat logs. Valid values are: Utc, Relative, and None")]
+        [Option("timestamp-format", Default = TimestampFormat.Relative, HelpText = "Sets the timestamp format for .txt chat logs. Valid values are: Utc, UtcFull, Relative, and None")]
         public TimestampFormat TimeFormat { get; set; }
 
         [Option("chat-connections", Default = 4, HelpText = "Number of downloading connections for chat")]

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -96,7 +96,7 @@ Time in seconds to crop ending. For example if I had a 10 second stream but only
 (Default: `true`) 7TV emote embedding. Requires `-E / --embed-images`.
 
 **--timestamp-format**
-(Default: `Relative`) Sets the timestamp format for .txt chat logs. Valid values are: `Utc`, `Relative`, and `None`.
+(Default: `Relative`) Sets the timestamp format for .txt chat logs. Valid values are: `Utc`, `UtcFull`, `Relative`, and `None`.
 
 **--chat-connections**
 (Default: `4`) The number of parallel downloads for chat.

--- a/TwitchDownloaderCore/Chat/ChatText.cs
+++ b/TwitchDownloaderCore/Chat/ChatText.cs
@@ -28,7 +28,12 @@ namespace TwitchDownloaderCore.Chat
                 string message = comment.message.body;
                 if (timeFormat == TimestampFormat.Utc)
                 {
-                    string timestamp = comment.created_at.ToString("u").Replace("Z", " UTC");
+                    var timestamp = comment.created_at.ToString("yyyy'-'MM'-'dd HH':'mm':'ss 'UTC'");;
+                    await sw.WriteLineAsync($"[{timestamp}] {username}: {message}");
+                }
+                else if (timeFormat == TimestampFormat.UtcMilliseconds)
+                {
+                    var timestamp = comment.created_at.ToString("yyyy'-'MM'-'dd HH':'mm':'ss.fff 'UTC'");;
                     await sw.WriteLineAsync($"[{timestamp}] {username}: {message}");
                 }
                 else if (timeFormat == TimestampFormat.Relative)

--- a/TwitchDownloaderCore/Chat/ChatText.cs
+++ b/TwitchDownloaderCore/Chat/ChatText.cs
@@ -31,7 +31,7 @@ namespace TwitchDownloaderCore.Chat
                     var timestamp = comment.created_at.ToString("yyyy'-'MM'-'dd HH':'mm':'ss 'UTC'");;
                     await sw.WriteLineAsync($"[{timestamp}] {username}: {message}");
                 }
-                else if (timeFormat == TimestampFormat.UtcMilliseconds)
+                else if (timeFormat == TimestampFormat.UtcFull)
                 {
                     var timestamp = comment.created_at.ToString("yyyy'-'MM'-'dd HH':'mm':'ss.fff 'UTC'");;
                     await sw.WriteLineAsync($"[{timestamp}] {username}: {message}");

--- a/TwitchDownloaderCore/Chat/TimestampFormat.cs
+++ b/TwitchDownloaderCore/Chat/TimestampFormat.cs
@@ -4,6 +4,7 @@
     {
         Utc,
         Relative,
-        None
+        None,
+        UtcMilliseconds
     }
 }

--- a/TwitchDownloaderCore/Chat/TimestampFormat.cs
+++ b/TwitchDownloaderCore/Chat/TimestampFormat.cs
@@ -5,6 +5,6 @@
         Utc,
         Relative,
         None,
-        UtcMilliseconds
+        UtcFull
     }
 }


### PR DESCRIPTION
Gonna keep it short since the change is minimal.
Add support to extract chat timestamps with milliseconds information (txt file only)

In some cases having the milliseconds information of the timestamp of each message could be interesting.
As such, I propose the addition of a UTCMilliseconds option to the `timestamp-format` flag.

**_HOW_**
* add the `UtcMilliseconds` value to the `TimestampFormat` Enum.
* Add a condition to support this new option to the `ChatText` class.