### PR TITLE
More video info

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -269,6 +269,8 @@ namespace TwitchDownloaderCore
             double videoEnd = 0.0;
             double videoDuration = 0.0;
             double videoTotalLength;
+            int viewCount;
+            string game;
             int connectionCount = downloadOptions.ConnectionCount;
 
             if (downloadType == DownloadType.Video)
@@ -286,6 +288,8 @@ namespace TwitchDownloaderCore
                 videoStart = downloadOptions.CropBeginning ? downloadOptions.CropBeginningTime : 0.0;
                 videoEnd = downloadOptions.CropEnding ? downloadOptions.CropEndingTime : videoInfoResponse.data.video.lengthSeconds;
                 videoTotalLength = videoInfoResponse.data.video.lengthSeconds;
+                viewCount = videoInfoResponse.data.video.viewCount;
+                game = videoInfoResponse.data.video.game?.displayName ?? "Unknown";
 
                 GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetVideoChapters(int.Parse(videoId));
                 foreach (var responseChapter in videoChapterResponse.data.video.moments.edges)
@@ -325,6 +329,8 @@ namespace TwitchDownloaderCore
                 videoStart = (int)clipInfoResponse.data.clip.videoOffsetSeconds;
                 videoEnd = (int)clipInfoResponse.data.clip.videoOffsetSeconds + clipInfoResponse.data.clip.durationSeconds;
                 videoTotalLength = clipInfoResponse.data.clip.durationSeconds;
+                viewCount = clipInfoResponse.data.clip.viewCount;
+                game = clipInfoResponse.data.clip.game?.displayName ?? "Unknown";
                 connectionCount = 1;
             }
 
@@ -334,6 +340,8 @@ namespace TwitchDownloaderCore
             chatRoot.video.start = videoStart;
             chatRoot.video.end = videoEnd;
             chatRoot.video.length = videoTotalLength;
+            chatRoot.video.viewCount = viewCount;
+            chatRoot.video.game = game;
             videoDuration = videoEnd - videoStart;
 
             var tasks = new List<Task<List<Comment>>>();

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using TwitchDownloaderCore.TwitchObjects.Gql;
@@ -36,7 +37,7 @@ namespace TwitchDownloaderCore.Tools
 
         private static async Task SerializeChapters(StreamWriter sw, List<VideoMomentEdge> videoMomentEdges, double startOffsetSeconds)
         {
-            // Note: Ffmpeg automatically handles out of range chapters for us
+            // Note: FFmpeg automatically handles out of range chapters for us
             var startOffsetMillis = (int)(startOffsetSeconds * 1000);
             foreach (var momentEdge in videoMomentEdges)
             {
@@ -64,11 +65,17 @@ namespace TwitchDownloaderCore.Tools
                 return str;
             }
 
-            return str
+            if (str.AsSpan().IndexOfAny(@"=;#\") == -1)
+            {
+                return str;
+            }
+
+            return new StringBuilder(str)
                 .Replace("=", @"\=")
                 .Replace(";", @"\;")
                 .Replace("#", @"\#")
-                .Replace(@"\", @"\\");
+                .Replace(@"\", @"\\")
+                .ToString();
         }
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -198,6 +198,8 @@ namespace TwitchDownloaderCore.TwitchObjects
         public double start { get; set; }
         public double end { get; set; }
         public double length { get; set; } = -1;
+        public int viewCount { get; set; }
+        public string game { get; set; }
         public List<VideoChapter> chapters { get; set; } = new();
 
 #region DeprecatedProperties

--- a/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRootInfo.cs
@@ -18,7 +18,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public int Minor { get; set; } = 0;
         public int Patch { get; set; } = 0;
 
-        public static ChatRootVersion CurrentVersion { get; } = new(1, 3, 0);
+        public static ChatRootVersion CurrentVersion { get; } = new(1, 3, 1);
 
         // Constructors
         /// <summary>

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipResponse.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
@@ -15,6 +13,12 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public string id { get; set; }
     }
 
+    public class ClipGame
+    {
+        public string id { get; set; }
+        public string displayName { get; set; }
+    }
+
     public class Clip
     {
         public string title { get; set; }
@@ -24,6 +28,8 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public ClipBroadcaster broadcaster { get; set; }
         public int? videoOffsetSeconds { get; set; }
         public ClipVideo video { get; set; }
+        public int viewCount { get; set; }
+        public ClipGame game { get; set; }
     }
 
     public class ClipData

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipSearchResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipSearchResponse.cs
@@ -1,9 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
+    public class ClipNodeGame
+    {
+        public string id { get; set; }
+        public string displayName { get; set; }
+    }
+
     public class ClipNode
     {
         public string id { get; set; }
@@ -13,6 +18,7 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public int durationSeconds { get; set; }
         public string thumbnailURL { get; set; }
         public int viewCount { get; set; }
+        public ClipNodeGame game { get; set; }
     }
 
     public class Edge

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoChapterResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoChapterResponse.cs
@@ -23,7 +23,7 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
 
     public class VideoMoment
     {
-        public VideoMomentConnection moments { get; set; } // seemingly always blank. Probably needs Oauth in the request to be populated
+        public VideoMomentConnection moments { get; set; } // seemingly always blank. Oauth does not seem to make a difference
         public string id { get; set; }
         public int durationMilliseconds { get; set; }
         public int positionMilliseconds { get; set; }

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoResponse.cs
@@ -9,6 +9,12 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public string displayName { get; set; }
     }
 
+    public class VideoGame
+    {
+        public string id { get; set; }
+        public string displayName { get; set; }
+    }
+
     public class VideoInfo
     {
         public string title { get; set; }
@@ -16,6 +22,8 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public DateTime createdAt { get; set; }
         public int lengthSeconds { get; set; }
         public VideoOwner owner { get; set; }
+        public int viewCount { get; set; }
+        public VideoGame game { get; set; }
     }
 
     public class VideoData

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoSearchResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoSearchResponse.cs
@@ -1,9 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
+    public class VideoNodeGame
+    {
+        public string id { get; set; }
+        public string displayName { get; set; }
+    }
+
     public class VideoNode
     {
         public string title { get; set; }
@@ -12,6 +17,7 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public string previewThumbnailURL { get; set; }
         public DateTime createdAt { get; set; }
         public int viewCount { get; set; }
+        public VideoNodeGame game { get; set; }
     }
 
     public class VideoEdge

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -33,6 +33,8 @@ namespace TwitchDownloaderWPF
         public int streamerId;
         public DateTime currentVideoTime;
         public TimeSpan vodLength;
+        public int viewCount;
+        public string game;
         private CancellationTokenSource _cancellationTokenSource;
 
         public PageChatDownload()
@@ -136,6 +138,8 @@ namespace TwitchDownloaderWPF
                     textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoTime.ToString(CultureInfo.CurrentCulture) : videoTime.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                     currentVideoTime = Settings.Default.UTCVideoTime ? videoTime : videoTime.ToLocalTime();
                     streamerId = int.Parse(videoInfo.data.video.owner.id);
+                    viewCount = videoInfo.data.video.viewCount;
+                    game = videoInfo.data.video.game?.displayName ?? "Unknown";
                     var urlTimeCodeMatch = Regex.Match(textUrl.Text, @"(?<=\?t=)\d+h\d+m\d+s");
                     if (urlTimeCodeMatch.Success)
                     {
@@ -469,7 +473,8 @@ namespace TwitchDownloaderWPF
 
             saveFileDialog.FileName = FilenameService.GetFilename(Settings.Default.TemplateChat, textTitle.Text, downloadId, currentVideoTime, textStreamer.Text,
                 checkCropStart.IsChecked == true ? new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value) : TimeSpan.Zero,
-                checkCropEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength);
+                checkCropEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength,
+                viewCount.ToString(), game);
 
             if (saveFileDialog.ShowDialog() != true)
             {

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -27,6 +27,8 @@ namespace TwitchDownloaderWPF
         public string clipId = "";
         public DateTime currentVideoTime;
         public TimeSpan clipLength;
+        public int viewCount;
+        public string game;
         private CancellationTokenSource _cancellationTokenSource;
 
         public PageClipDownload()
@@ -79,6 +81,8 @@ namespace TwitchDownloaderWPF
                 currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();
                 textTitle.Text = clipData.data.clip.title;
                 labelLength.Text = clipLength.ToString("c");
+                viewCount = taskClipInfo.Result.data.clip.viewCount;
+                game = taskClipInfo.Result.data.clip.game?.displayName ?? "Unknown";
 
                 foreach (var quality in taskLinks.Result[0].data.clip.videoQualities)
                 {
@@ -180,7 +184,7 @@ namespace TwitchDownloaderWPF
             SaveFileDialog saveFileDialog = new SaveFileDialog
             {
                 Filter = "MP4 Files | *.mp4",
-                FileName = FilenameService.GetFilename(Settings.Default.TemplateClip, textTitle.Text, clipId, currentVideoTime, textStreamer.Text, TimeSpan.Zero, clipLength)
+                FileName = FilenameService.GetFilename(Settings.Default.TemplateClip, textTitle.Text, clipId, currentVideoTime, textStreamer.Text, TimeSpan.Zero, clipLength, viewCount.ToString(), game)
             };
             if (saveFileDialog.ShowDialog() != true)
             {

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -34,6 +34,8 @@ namespace TwitchDownloaderWPF
         public int currentVideoId;
         public DateTime currentVideoTime;
         public TimeSpan vodLength;
+        public int viewCount;
+        public string game;
         private CancellationTokenSource _cancellationTokenSource;
 
         public PageVodDownload()
@@ -170,6 +172,8 @@ namespace TwitchDownloaderWPF
                 numEndMinute.Value = vodLength.Minutes;
                 numEndSecond.Value = vodLength.Seconds;
                 labelLength.Text = vodLength.ToString("c");
+                viewCount = taskVideoInfo.Result.data.video.viewCount;
+                game = taskVideoInfo.Result.data.video.game?.displayName ?? "Unknown";
 
                 UpdateVideoSizeEstimates();
 
@@ -209,7 +213,8 @@ namespace TwitchDownloaderWPF
                     : -1,
                 Filename = filename ?? Path.Combine(folder, FilenameService.GetFilename(Settings.Default.TemplateVod, textTitle.Text, currentVideoId.ToString(), currentVideoTime, textStreamer.Text,
                     checkStart.IsChecked == true ? new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value) : TimeSpan.Zero,
-                    checkEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength) + ".mp4"),
+                    checkEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength,
+                    viewCount.ToString(), game) + ".mp4"),
                 Oauth = TextOauth.Text,
                 Quality = GetQualityWithoutSize(comboQuality.Text).ToString(),
                 Id = currentVideoId,
@@ -407,7 +412,8 @@ namespace TwitchDownloaderWPF
                 Filter = "MP4 Files | *.mp4",
                 FileName = FilenameService.GetFilename(Settings.Default.TemplateVod, textTitle.Text, currentVideoId.ToString(), currentVideoTime, textStreamer.Text,
                     checkStart.IsChecked == true ? new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value) : TimeSpan.Zero,
-                    checkEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength)
+                    checkEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength,
+                    viewCount.ToString(), game)
             };
             if (saveFileDialog.ShowDialog() == false)
             {

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -753,7 +753,7 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {title} {id} {date} {channel} {date_custom=&quot;&quot;} {random_string} {crop_start} {crop_end} {crop_start_custom=&quot;&quot;} {crop_end_custom=&quot;&quot;}.
+        ///   Looks up a localized string similar to {title} {id} {date} {channel} {date_custom=&quot;&quot;} {random_string} {crop_start} {crop_end} {crop_start_custom=&quot;&quot;} {crop_end_custom=&quot;&quot;} {length} {length_custom=&quot;&quot;} {views} {game}.
         /// </summary>
         public static string FilenameTemplateParameters {
             get {
@@ -1536,7 +1536,7 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to crop_start_custom and crop_end_custom formattings are based on the.
+        ///   Looks up a localized string similar to crop_start_custom, crop_end_custom, and length_custom formattings are based on the.
         /// </summary>
         public static string TimeSpanCustomFormatting {
             get {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -298,7 +298,7 @@
     <value>Emotes FFZ:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>No traducir</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -733,7 +733,7 @@
     <value>Escala de contorno:</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>Los formatos crop_start_custom y crop_end_custom se basan en el formato</value>
+    <value>Los formatos crop_start_custom, crop_end_custom y length_custom se basan en el formato</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>Cadenas de formato de intervalo de tiempo estándar de C#</value>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -298,7 +298,7 @@
     <value>Emoticônes FFZ:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -733,7 +733,7 @@
     <value>Échelle des contours:</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>crop_start_custom and crop_end_custom formattings are based on the</value>
+    <value>crop_start_custom, crop_end_custom et length_custom formattings are based on the</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>C# standard TimeSpan format strings</value>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -298,7 +298,7 @@
     <value>Emotki FFZ:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -733,7 +733,7 @@
     <value>Outline Scale:</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>formatowanie crop_start_custom i crop_end_custom jest bazowane na</value>
+    <value>formatowanie crop_start_custom, crop_end_custom, i length_custom jest bazowane na</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>Standardowych ciągach formatujących TimeSpan C#</value>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -298,7 +298,7 @@
     <value>FFZ Emotes:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -732,7 +732,7 @@
     <value>Outline Scale:</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>crop_start_custom and crop_end_custom formattings are based on the</value>
+    <value>crop_start_custom, crop_end_custom, and length_custom formattings are based on the</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>C# standard TimeSpan format strings</value>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -298,7 +298,7 @@
     <value>FFZ Эмодзи:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -299,7 +299,7 @@
     <value>FFZ Emojileri:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -734,7 +734,7 @@
     <value>Anahat Ölçeği:</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>crop_start_custom and crop_end_custom formattings are based on the</value>
+    <value>crop_start_custom, crop_end_custom, and length_custom formattings are based on the</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>C# standart TimeSpan biçim dizeleri</value>

--- a/TwitchDownloaderWPF/Translations/Strings.zh.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh.resx
@@ -298,7 +298,7 @@
     <value>FFZ Emotes:</value>
   </data>
   <data name="FilenameTemplateParameters" xml:space="preserve">
-    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""}</value>
+    <value>{title} {id} {date} {channel} {date_custom=""} {random_string} {crop_start} {crop_end} {crop_start_custom=""} {crop_end_custom=""} {length} {length_custom=""} {views} {game}</value>
     <comment>Do not translate</comment>
   </data>
   <data name="FontColor" xml:space="preserve">
@@ -732,7 +732,7 @@
     <value>边框比例：</value>
   </data>
   <data name="TimeSpanCustomFormatting" xml:space="preserve">
-    <value>crop_start_custom和crop_end_custom格式基于</value>
+    <value>crop_start_custom、crop_end_custom和length_custom格式基于</value>
   </data>
   <data name="TimeSpanCustomFormattingHyperlink" xml:space="preserve">
     <value>C#标准的时间跨度格式字符串</value>

--- a/TwitchDownloaderWPF/TwitchTasks/TaskData.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/TaskData.cs
@@ -12,6 +12,7 @@ namespace TwitchDownloaderWPF.TwitchTasks
         public DateTime Time { get; set; }
         public int Length { get; set; }
         public int Views { get; set; }
+        public string Game { get; set; }
         public string LengthFormatted
         {
             get

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -78,6 +78,7 @@ namespace TwitchDownloaderWPF
                         data.Time = Settings.Default.UTCVideoTime ? video.node.createdAt : video.node.createdAt.ToLocalTime();
                         data.Views = video.node.viewCount;
                         data.Streamer = currentChannel;
+                        data.Game = video.node.game?.displayName ?? "Unknown";
                         try
                         {
                             var bitmapImage = new BitmapImage();
@@ -126,6 +127,7 @@ namespace TwitchDownloaderWPF
                         data.Time = Settings.Default.UTCVideoTime ? clip.node.createdAt : clip.node.createdAt.ToLocalTime();
                         data.Views = clip.node.viewCount;
                         data.Streamer = currentChannel;
+                        data.Game = clip.node.game?.displayName ?? "Unknown";
                         try
                         {
                             var bitmapImage = new BitmapImage();

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -198,7 +198,7 @@ namespace TwitchDownloaderWPF
 
                     ClipDownloadTask downloadTask = new ClipDownloadTask();
                     ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                    downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime, clipPage.textStreamer.Text, TimeSpan.Zero, clipPage.clipLength) + ".mp4");
+                    downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, clipPage.textTitle.Text, clipPage.clipId, clipPage.currentVideoTime, clipPage.textStreamer.Text, TimeSpan.Zero, clipPage.clipLength, clipPage.viewCount.ToString(), clipPage.game) + ".mp4");
                     downloadOptions.Id = clipPage.clipId;
                     downloadOptions.Quality = clipPage.comboQuality.Text;
                     downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
@@ -227,7 +227,7 @@ namespace TwitchDownloaderWPF
                             chatOptions.DownloadFormat = ChatFormat.Text;
                         chatOptions.TimeFormat = TimestampFormat.Relative;
                         chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
-                        chatOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime, clipPage.textStreamer.Text, TimeSpan.Zero, clipPage.clipLength) + "." + chatOptions.FileExtension);
+                        chatOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime, clipPage.textStreamer.Text, TimeSpan.Zero, clipPage.clipLength, clipPage.viewCount.ToString(), clipPage.game) + "." + chatOptions.FileExtension);
 
                         chatTask.DownloadOptions = chatOptions;
                         chatTask.Info.Title = clipPage.textTitle.Text;
@@ -279,8 +279,9 @@ namespace TwitchDownloaderWPF
                     ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
                     chatOptions.Id = chatPage.downloadId;
                     chatOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatOptions.Id, chatPage.currentVideoTime, chatPage.textStreamer.Text,
-                        chatOptions.CropBeginning ? TimeSpan.FromSeconds(chatOptions.CropBeginningTime) : TimeSpan.Zero,  chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatPage.vodLength
-                    ) + "." + chatOptions.FileExtension);
+                        chatOptions.CropBeginning ? TimeSpan.FromSeconds(chatOptions.CropBeginningTime) : TimeSpan.Zero,
+                        chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatPage.vodLength,
+                        chatPage.viewCount.ToString(), chatPage.game) + "." + chatOptions.FileExtension);
 
                     chatTask.DownloadOptions = chatOptions;
                     chatTask.Info.Title = chatPage.textTitle.Text;
@@ -326,8 +327,9 @@ namespace TwitchDownloaderWPF
                     ChatUpdateOptions chatOptions = MainWindow.pageChatUpdate.GetOptions(null);
                     chatOptions.InputFile = chatPage.InputFile;
                     chatOptions.OutputFile = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, chatPage.textTitle.Text, chatPage.VideoId, chatPage.VideoCreatedAt, chatPage.textStreamer.Text,
-                        chatOptions.CropBeginning ? TimeSpan.FromSeconds(chatOptions.CropBeginningTime) : TimeSpan.Zero,  chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatPage.VideoLength
-                        ) + "." + chatOptions.FileExtension);
+                        chatOptions.CropBeginning ? TimeSpan.FromSeconds(chatOptions.CropBeginningTime) : TimeSpan.Zero,
+                        chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatPage.VideoLength,
+                        chatPage.ViewCount.ToString(), chatPage.Game) + "." + chatOptions.FileExtension);
 
                     chatTask.UpdateOptions = chatOptions;
                     chatTask.Info.Title = chatPage.textTitle.Text;
@@ -390,15 +392,16 @@ namespace TwitchDownloaderWPF
 
                     for (int i = 0; i < dataList.Count; i++)
                     {
+                        var taskData = dataList[i];
                         if ((bool)checkVideo.IsChecked)
                         {
-                            if (dataList[i].Id.All(Char.IsDigit))
+                            if (taskData.Id.All(Char.IsDigit))
                             {
                                 VodDownloadTask downloadTask = new VodDownloadTask();
                                 VideoDownloadOptions downloadOptions = new VideoDownloadOptions();
                                 downloadOptions.Oauth = Settings.Default.OAuth;
                                 downloadOptions.TempFolder = Settings.Default.TempPath;
-                                downloadOptions.Id = int.Parse(dataList[i].Id);
+                                downloadOptions.Id = int.Parse(taskData.Id);
                                 downloadOptions.FfmpegPath = "ffmpeg";
                                 downloadOptions.CropBeginning = false;
                                 downloadOptions.CropEnding = false;
@@ -406,12 +409,13 @@ namespace TwitchDownloaderWPF
                                 downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
                                     ? Settings.Default.MaximumBandwidthKib
                                     : -1;
-                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateVod, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer,
-                                    downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,  downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(dataList[i].Length)
-                                    ) + ".mp4");
+                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateVod, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                                    downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
+                                    downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
+                                taskData.Views.ToString(), taskData.Game) + ".mp4");
                                 downloadTask.DownloadOptions = downloadOptions;
-                                downloadTask.Info.Title = dataList[i].Title;
-                                downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
+                                downloadTask.Info.Title = taskData.Title;
+                                downloadTask.Info.Thumbnail = taskData.Thumbnail;
                                 downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                                 lock (PageQueue.taskLock)
@@ -423,15 +427,15 @@ namespace TwitchDownloaderWPF
                             {
                                 ClipDownloadTask downloadTask = new ClipDownloadTask();
                                 ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                                downloadOptions.Id = dataList[i].Id;
-                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer,
-                                    TimeSpan.Zero, TimeSpan.FromSeconds(dataList[i].Length)) + ".mp4");
+                                downloadOptions.Id = taskData.Id;
+                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                                    TimeSpan.Zero, TimeSpan.FromSeconds(taskData.Length), taskData.Views.ToString(), taskData.Game) + ".mp4");
                                 downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
                                     ? Settings.Default.MaximumBandwidthKib
                                     : -1;
                                 downloadTask.DownloadOptions = downloadOptions;
-                                downloadTask.Info.Title = dataList[i].Title;
-                                downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
+                                downloadTask.Info.Title = taskData.Title;
+                                downloadTask.Info.Thumbnail = taskData.Thumbnail;
                                 downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                                 lock (PageQueue.taskLock)
@@ -454,15 +458,16 @@ namespace TwitchDownloaderWPF
                             downloadOptions.Compression = RadioCompressionNone.IsChecked == true ? ChatCompression.None : ChatCompression.Gzip;
                             downloadOptions.EmbedData = (bool)checkEmbed.IsChecked;
                             downloadOptions.TimeFormat = TimestampFormat.Relative;
-                            downloadOptions.Id = dataList[i].Id;
+                            downloadOptions.Id = taskData.Id;
                             downloadOptions.CropBeginning = false;
                             downloadOptions.CropEnding = false;
-                            downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, dataList[i].Title, dataList[i].Id, dataList[i].Time, dataList[i].Streamer,
-                                downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,  downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(dataList[i].Length)
-                                ) + "." + downloadOptions.FileExtension);
+                            downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                                downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
+                                downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
+                                taskData.Views.ToString(), taskData.Game) + "." + downloadOptions.FileExtension);
                             downloadTask.DownloadOptions = downloadOptions;
-                            downloadTask.Info.Title = dataList[i].Title;
-                            downloadTask.Info.Thumbnail = dataList[i].Thumbnail;
+                            downloadTask.Info.Title = taskData.Title;
+                            downloadTask.Info.Thumbnail = taskData.Thumbnail;
                             downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                             lock (PageQueue.taskLock)
@@ -481,8 +486,8 @@ namespace TwitchDownloaderWPF
                                 }
                                 renderOptions.InputFile = downloadOptions.Filename;
                                 renderTask.DownloadOptions = renderOptions;
-                                renderTask.Info.Title = dataList[i].Title;
-                                renderTask.Info.Thumbnail = dataList[i].Thumbnail;
+                                renderTask.Info.Title = taskData.Title;
+                                renderTask.Info.Thumbnail = taskData.Thumbnail;
                                 renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
                                 renderTask.DependantTask = downloadTask;
 


### PR DESCRIPTION
- Adds the filename template parameters `{views}` `{game}` `{length}` `{length_custom=""}`
- Would have added 0b92773469c601ca7e824f25f8880c911d9ade69 had I not accidentally staged it to master 😅
- Adds `viewCount` and `game` to ChatRoot.Video and bumps ChatRootVersion to 1.3.1