### PR TITLE
Clip download progress

### DIFF
--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
@@ -48,7 +49,7 @@ namespace TwitchDownloaderCLI.Modes
                 Filename = inputOptions.OutputFile,
                 Quality = inputOptions.Quality,
                 ThrottleKib = inputOptions.ThrottleKib,
-                FfmpegPath = inputOptions.FfmpegPath,
+                FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
                 EncodeMetadata = inputOptions.EncodeMetadata!.Value,
                 TempFolder = inputOptions.TempFolder
             };

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -150,7 +150,7 @@ namespace TwitchDownloaderCore
                     StartInfo =
                     {
                         FileName = downloadOptions.FfmpegPath,
-                        Arguments = $"-i \"{inputFile}\" -i \"{metadataFile}\" -map_metadata 1 -c copy \"{destinationFile}\"",
+                        Arguments = $"-i \"{inputFile}\" -i \"{metadataFile}\" -map_metadata 1 -y -c copy \"{destinationFile}\"",
                         UseShellExecute = false,
                         CreateNoWindow = true,
                         RedirectStandardInput = false,

--- a/TwitchDownloaderCore/Extensions/StreamExtensions.cs
+++ b/TwitchDownloaderCore/Extensions/StreamExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TwitchDownloaderCore.Extensions
+{
+    public record struct StreamCopyProgress(long SourceLength, long BytesCopied);
+
+    public static class StreamExtensions
+    {
+        // The default size from Stream.GetCopyBufferSize() is 81_920.
+        private const int STREAM_DEFAULT_BUFFER_LENGTH = 81_920;
+
+        public static async Task ProgressCopyToAsync(this Stream source, Stream destination, long? sourceLength, IProgress<StreamCopyProgress> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!sourceLength.HasValue)
+            {
+                await source.CopyToAsync(destination, cancellationToken);
+                return;
+            }
+
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(STREAM_DEFAULT_BUFFER_LENGTH);
+            var buffer = rentedBuffer.AsMemory(0, STREAM_DEFAULT_BUFFER_LENGTH);
+            var totalBytesRead = 0L;
+
+            try
+            {
+                var bytesRead = 0;
+                do
+                {
+                    bytesRead = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (bytesRead == 0)
+                        continue;
+
+                    await destination.WriteAsync(buffer[..bytesRead], cancellationToken).ConfigureAwait(false);
+                    totalBytesRead += bytesRead;
+
+                    progress?.Report(new StreamCopyProgress(sourceLength!.Value, totalBytesRead));
+                } while (bytesRead != 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
+        }
+    }
+}

--- a/TwitchDownloaderCore/Tools/ThrottledStream.cs
+++ b/TwitchDownloaderCore/Tools/ThrottledStream.cs
@@ -50,6 +50,14 @@ namespace TwitchDownloaderCore.Tools
             return read;
         }
 
+        public override int Read(Span<byte> buffer)
+        {
+            var newCount = GetBytesToReturn(buffer.Length);
+            var read = BaseStream.Read(buffer[..newCount]);
+            Interlocked.Add(ref _totalBytesRead, read);
+            return read;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return BaseStream.Seek(offset, origin);
@@ -58,6 +66,8 @@ namespace TwitchDownloaderCore.Tools
         public override void SetLength(long value) { }
 
         public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override void Write(ReadOnlySpan<byte> buffer) { }
 
         private int GetBytesToReturn(int count)
         {


### PR DESCRIPTION
- Add progress reporting to clip downloader
- Fix downloading clips with metadata not overwriting
- Fix crash when not providing a specific path to FFmpeg in the CLI
- Add `Span<byte>`/`ReadOnlySpan<byte>` overloads for `Read()`/`Write()` to ThrottledStream