### PR TITLE
Account for alternate video highlight url format

### DIFF
--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes
 {
@@ -30,9 +30,8 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
-            var vodClipIdRegex = new Regex(@"(?<=^|(?:clips\.)?twitch\.tv\/(?:videos|\S+\/clip)?\/?)[\w-]+?(?=$|\?)");
-            var vodClipIdMatch = vodClipIdRegex.Match(inputOptions.Id);
-            if (!vodClipIdMatch.Success)
+            var vodClipIdMatch = TwitchRegex.MatchVideoOrClipId(inputOptions.Id);
+            if (vodClipIdMatch is not { Success: true })
             {
                 Console.WriteLine("[ERROR] - Unable to parse Vod/Clip ID/URL.");
                 Environment.Exit(1);

--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes
 {
@@ -35,9 +35,8 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
-            var clipIdRegex = new Regex(@"(?<=^|(?:clips\.)?twitch\.tv\/(?:\S+\/clip)?\/?)[\w-]+?(?=$|\?)");
-            var clipIdMatch = clipIdRegex.Match(inputOptions.Id);
-            if (!clipIdMatch.Success)
+            var clipIdMatch = TwitchRegex.MatchClipId(inputOptions.Id);
+            if (clipIdMatch is not { Success: true })
             {
                 Console.WriteLine("[ERROR] - Unable to parse Clip ID/URL.");
                 Environment.Exit(1);

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes
 {
@@ -31,9 +31,8 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
-            var vodIdRegex = new Regex(@"(?<=^|twitch\.tv\/videos\/)\d+(?=$|\?)");
-            var vodIdMatch = vodIdRegex.Match(inputOptions.Id);
-            if (!vodIdMatch.Success)
+            var vodIdMatch = TwitchRegex.MatchVideoId(inputOptions.Id);
+            if (vodIdMatch is not { Success: true})
             {
                 Console.WriteLine("[ERROR] - Unable to parse Vod ID/URL.");
                 Environment.Exit(1);

--- a/TwitchDownloaderCore/Tools/TwitchRegex.cs
+++ b/TwitchDownloaderCore/Tools/TwitchRegex.cs
@@ -45,20 +45,14 @@ namespace TwitchDownloaderCore.Tools
         /// <returns>A <see cref="Match"/> of the video/clip's id or <see langword="null"/>.</returns>
         public static Match MatchVideoOrClipId(string text)
         {
-            var videoIdMatch = VideoId.Match(text);
-            if (videoIdMatch.Success)
+            var videoIdMatch = MatchVideoId(text);
+            if (videoIdMatch is { Success: true })
             {
                 return videoIdMatch;
             }
 
-            var highlightIdMatch = HighlightId.Match(text);
-            if (highlightIdMatch.Success)
-            {
-                return highlightIdMatch;
-            }
-
-            var clipIdMatch = ClipId.Match(text);
-            if (clipIdMatch.Success && !clipIdMatch.Value.All(char.IsDigit))
+            var clipIdMatch = MatchClipId(text);
+            if (clipIdMatch is { Success: true })
             {
                 return clipIdMatch;
             }

--- a/TwitchDownloaderCore/Tools/TwitchRegex.cs
+++ b/TwitchDownloaderCore/Tools/TwitchRegex.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TwitchDownloaderCore.Tools
+{
+    public static class TwitchRegex
+    {
+        // TODO: Use source generators when .NET7
+        private static readonly Regex VideoId = new(@"(?<=^|twitch\.tv\/videos\/)\d+(?=$|\?|\s)", RegexOptions.Compiled);
+        private static readonly Regex HighlightId = new(@"(?<=^|twitch\.tv\/\w+\/video\/)\d+(?=$|\?|\s)", RegexOptions.Compiled);
+        private static readonly Regex ClipId = new(@"(?<=^|(?:clips\.)?twitch\.tv\/(?:\w+\/clip\/)?)[\w-]+?(?=$|\?|\s)", RegexOptions.Compiled);
+
+        public static readonly Regex UrlTimeCode = new(@"(?<=(?:\?|&)t=)\d+h\d+m\d+s(?=$|\?|\s)", RegexOptions.Compiled);
+
+        /// <returns>A <see cref="Match"/> of the video's id or <see langword="null"/>.</returns>
+        public static Match MatchVideoId(string text)
+        {
+            var videoIdMatch = VideoId.Match(text);
+            if (videoIdMatch.Success)
+            {
+                return videoIdMatch;
+            }
+
+            var highlightIdMatch = HighlightId.Match(text);
+            if (highlightIdMatch.Success)
+            {
+                return highlightIdMatch;
+            }
+
+            return null;
+        }
+
+        /// <returns>A <see cref="Match"/> of the clip's id or <see langword="null"/>.</returns>
+        public static Match MatchClipId(string text)
+        {
+            var clipIdMatch = ClipId.Match(text);
+            if (clipIdMatch.Success && !clipIdMatch.Value.All(char.IsDigit))
+            {
+                return clipIdMatch;
+            }
+
+            return null;
+        }
+
+        /// <returns>A <see cref="Match"/> of the video/clip's id or <see langword="null"/>.</returns>
+        public static Match MatchVideoOrClipId(string text)
+        {
+            var videoIdMatch = VideoId.Match(text);
+            if (videoIdMatch.Success)
+            {
+                return videoIdMatch;
+            }
+
+            var highlightIdMatch = HighlightId.Match(text);
+            if (highlightIdMatch.Success)
+            {
+                return highlightIdMatch;
+            }
+
+            var clipIdMatch = ClipId.Match(text);
+            if (clipIdMatch.Success && !clipIdMatch.Value.All(char.IsDigit))
+            {
+                return clipIdMatch;
+            }
+
+            return null;
+        }
+    }
+}

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -14,6 +13,7 @@ using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Extensions;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
@@ -140,7 +140,7 @@ namespace TwitchDownloaderWPF
                     streamerId = int.Parse(videoInfo.data.video.owner.id);
                     viewCount = videoInfo.data.video.viewCount;
                     game = videoInfo.data.video.game?.displayName ?? "Unknown";
-                    var urlTimeCodeMatch = Regex.Match(textUrl.Text, @"(?<=\?t=)\d+h\d+m\d+s");
+                    var urlTimeCodeMatch = TwitchRegex.UrlTimeCode.Match(textUrl.Text);
                     if (urlTimeCodeMatch.Success)
                     {
                         var time = TimeSpanExtensions.ParseTimeCode(urlTimeCodeMatch.ValueSpan);
@@ -224,8 +224,8 @@ namespace TwitchDownloaderWPF
 
         public static string ValidateUrl(string text)
         {
-            var vodClipIdMatch = Regex.Match(text, @"(?<=^|(?:clips\.)?twitch\.tv\/(?:videos|\S+\/clip)?\/?)[\w-]+?(?=$|\?)");
-            return vodClipIdMatch.Success
+            var vodClipIdMatch = TwitchRegex.MatchVideoOrClipId(text);
+            return vodClipIdMatch is { Success: true }
                 ? vodClipIdMatch.Value
                 : null;
         }

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -12,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Tools;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
@@ -118,9 +118,8 @@ namespace TwitchDownloaderWPF
 
         private static string ValidateUrl(string text)
         {
-            var clipIdRegex = new Regex(@"(?<=^|(?:clips\.)?twitch\.tv\/(?:\S+\/clip)?\/?)[\w-]+?(?=$|\?)");
-            var clipIdMatch = clipIdRegex.Match(text);
-            return clipIdMatch.Success
+            var clipIdMatch = TwitchRegex.MatchClipId(text);
+            return clipIdMatch is { Success: true }
                 ? clipIdMatch.Value
                 : null;
         }

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -150,7 +149,7 @@ namespace TwitchDownloaderWPF
                 var videoCreatedAt = taskVideoInfo.Result.data.video.createdAt;
                 textCreatedAt.Text = Settings.Default.UTCVideoTime ? videoCreatedAt.ToString(CultureInfo.CurrentCulture) : videoCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                 currentVideoTime = Settings.Default.UTCVideoTime ? videoCreatedAt : videoCreatedAt.ToLocalTime();
-                var urlTimeCodeMatch = Regex.Match(textUrl.Text, @"(?<=\?t=)\d+h\d+m\d+s");
+                var urlTimeCodeMatch = TwitchRegex.UrlTimeCode.Match(textUrl.Text);
                 if (urlTimeCodeMatch.Success)
                 {
                     var time = TimeSpanExtensions.ParseTimeCode(urlTimeCodeMatch.ValueSpan);
@@ -296,8 +295,8 @@ namespace TwitchDownloaderWPF
 
         private static int ValidateUrl(string text)
         {
-            var vodIdMatch = Regex.Match(text, @"(?<=^|twitch\.tv\/videos\/)\d+(?=$|\?)");
-            if (vodIdMatch.Success && int.TryParse(vodIdMatch.ValueSpan, out var vodId))
+            var vodIdMatch = TwitchRegex.MatchVideoId(text);
+            if (vodIdMatch is {Success: true} && int.TryParse(vodIdMatch.ValueSpan, out var vodId))
             {
                 return vodId;
             }


### PR DESCRIPTION
- Add support for `twitch.tv/streamer/video/id` url formatting
  - Fixes #787 
- Increase maintainability of video/clip id regex matching