### PR TITLE
Add support for dark title bars on Windows 10 1809-2004 

### DIFF
--- a/TwitchDownloaderWPF/Services/NativeFunctions.cs
+++ b/TwitchDownloaderWPF/Services/NativeFunctions.cs
@@ -8,6 +8,6 @@ namespace TwitchDownloaderWPF.Services
     public static class NativeFunctions
     {
         [DllImport("dwmapi.dll", EntryPoint = "DwmSetWindowAttribute", PreserveSig = true)]
-        public static extern int SetWindowAttribute(IntPtr handle, int attribute, ref bool attributeValue, int attributeSize);
+        public static extern int SetWindowAttribute(IntPtr handle, int attribute, [In] ref int attributeValue, int attributeSize);
     }
 }

--- a/TwitchDownloaderWPF/Services/ThemeService.cs
+++ b/TwitchDownloaderWPF/Services/ThemeService.cs
@@ -1,8 +1,6 @@
 ﻿using HandyControl.Data;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Media;
 using System.Xml.Serialization;
@@ -13,8 +11,6 @@ namespace TwitchDownloaderWPF.Services
 {
     public class ThemeService
     {
-        private const int TITLEBAR_THEME_ATTRIBUTE = 20;
-
         private bool _darkAppTitleBar = false;
         private bool _darkHandyControl = false;
 
@@ -81,32 +77,7 @@ namespace TwitchDownloaderWPF.Services
             }
         }
 
-        [SupportedOSPlatform("windows")]
-        public void SetTitleBarTheme(WindowCollection windows)
-        {
-            // If windows 10 build is before 1903, it doesn't support dark title bars
-            if (Environment.OSVersion.Version.Build < 18362)
-            {
-                return;
-            }
-
-            foreach (Window window in windows)
-            {
-                var windowHandle = new System.Windows.Interop.WindowInteropHelper(window).Handle;
-                NativeFunctions.SetWindowAttribute(windowHandle, TITLEBAR_THEME_ATTRIBUTE, ref _darkAppTitleBar, Marshal.SizeOf(_darkAppTitleBar));
-            }
-
-            Window wnd = new()
-            {
-                SizeToContent = SizeToContent.WidthAndHeight,
-                Top = int.MinValue + 1,
-                WindowStyle = WindowStyle.None
-            };
-            wnd.Show();
-            wnd.Close();
-            // Dark title bar is a bit buggy, requires window resize or focus change to fully apply
-            // Win11 might not have this issue but Win10 does so please leave this
-        }
+        public void SetTitleBarTheme(WindowCollection windows) => WindowsThemeService.SetTitleBarTheme(windows, _darkAppTitleBar);
 
         private void ChangeThemePath(string newTheme)
         {

--- a/TwitchDownloaderWPF/Services/WindowsThemeService.cs
+++ b/TwitchDownloaderWPF/Services/WindowsThemeService.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Windows;
+using System.Windows.Interop;
 
 namespace TwitchDownloaderWPF.Services
 {
@@ -17,15 +18,16 @@ namespace TwitchDownloaderWPF.Services
         private const string REGISTRY_KEY_NAME = "AppsUseLightTheme";
         private const string LIGHT_THEME = "Light";
         private const string DARK_THEME = "Dark";
+        private const int WINDOWS_1809_BUILD_NUMBER = 17763;
+        private const int WINDOWS_2004_INSIDER_BUILD_NUMBER = 18985;
+        private const int USE_IMMERSIVE_DARK_MODE_ATTRIBUTE_BEFORE_2004 = 19;
+        private const int USE_IMMERSIVE_DARK_MODE_ATTRIBUTE = 20;
 
         public WindowsThemeService()
         {
             // If the OS is older than Windows 10 1809 then it doesn't have the app theme registry key
-            const int WINDOWS_1809_BUILD_NUMBER = 17763;
             if (Environment.OSVersion.Version.Major < 10 || Environment.OSVersion.Version.Build < WINDOWS_1809_BUILD_NUMBER)
-            {
                 return;
-            }
 
             var currentUser = WindowsIdentity.GetCurrent().User;
 
@@ -64,6 +66,35 @@ namespace TwitchDownloaderWPF.Services
             return windowsThemeValue > 0
                 ? LIGHT_THEME
                 : DARK_THEME;
+        }
+
+        public static void SetTitleBarTheme(WindowCollection windows, bool useDarkTitleBar)
+        {
+            if (Environment.OSVersion.Version.Major < 10 || Environment.OSVersion.Version.Build < WINDOWS_1809_BUILD_NUMBER)
+                return;
+
+            var useDarkTitleBarInt = Convert.ToInt32(useDarkTitleBar);
+            var darkTitleBarAttribute = Environment.OSVersion.Version.Build < WINDOWS_2004_INSIDER_BUILD_NUMBER
+                ? USE_IMMERSIVE_DARK_MODE_ATTRIBUTE_BEFORE_2004
+                : USE_IMMERSIVE_DARK_MODE_ATTRIBUTE;
+
+            foreach (Window window in windows)
+            {
+                var windowHandle = new WindowInteropHelper(window).Handle;
+                NativeFunctions.SetWindowAttribute(windowHandle, darkTitleBarAttribute, ref useDarkTitleBarInt, sizeof(int));
+            }
+
+            Window wnd = new()
+            {
+                SizeToContent = SizeToContent.WidthAndHeight,
+                Top = int.MinValue + 1,
+                WindowStyle = WindowStyle.None
+            };
+            wnd.Show();
+            wnd.Close();
+            // Dark title bar is a bit buggy, requires window redraw (focus change, resize, transparency change) to fully apply.
+            // We *could* send a repaint message to win32.dll, but this solution works and is way easier.
+            // Win11 might not have this issue but Win10 does so please leave this
         }
     }
 }

--- a/TwitchDownloaderWPF/Services/WindowsThemeService.cs
+++ b/TwitchDownloaderWPF/Services/WindowsThemeService.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Windows;
-using System.Windows.Interop;
 
 namespace TwitchDownloaderWPF.Services
 {
@@ -19,9 +18,6 @@ namespace TwitchDownloaderWPF.Services
         private const string LIGHT_THEME = "Light";
         private const string DARK_THEME = "Dark";
         private const int WINDOWS_1809_BUILD_NUMBER = 17763;
-        private const int WINDOWS_2004_INSIDER_BUILD_NUMBER = 18985;
-        private const int USE_IMMERSIVE_DARK_MODE_ATTRIBUTE_BEFORE_2004 = 19;
-        private const int USE_IMMERSIVE_DARK_MODE_ATTRIBUTE = 20;
 
         public WindowsThemeService()
         {
@@ -66,35 +62,6 @@ namespace TwitchDownloaderWPF.Services
             return windowsThemeValue > 0
                 ? LIGHT_THEME
                 : DARK_THEME;
-        }
-
-        public static void SetTitleBarTheme(WindowCollection windows, bool useDarkTitleBar)
-        {
-            if (Environment.OSVersion.Version.Major < 10 || Environment.OSVersion.Version.Build < WINDOWS_1809_BUILD_NUMBER)
-                return;
-
-            var useDarkTitleBarInt = Convert.ToInt32(useDarkTitleBar);
-            var darkTitleBarAttribute = Environment.OSVersion.Version.Build < WINDOWS_2004_INSIDER_BUILD_NUMBER
-                ? USE_IMMERSIVE_DARK_MODE_ATTRIBUTE_BEFORE_2004
-                : USE_IMMERSIVE_DARK_MODE_ATTRIBUTE;
-
-            foreach (Window window in windows)
-            {
-                var windowHandle = new WindowInteropHelper(window).Handle;
-                NativeFunctions.SetWindowAttribute(windowHandle, darkTitleBarAttribute, ref useDarkTitleBarInt, sizeof(int));
-            }
-
-            Window wnd = new()
-            {
-                SizeToContent = SizeToContent.WidthAndHeight,
-                Top = int.MinValue + 1,
-                WindowStyle = WindowStyle.None
-            };
-            wnd.Show();
-            wnd.Close();
-            // Dark title bar is a bit buggy, requires window redraw (focus change, resize, transparency change) to fully apply.
-            // We *could* send a repaint message to win32.dll, but this solution works and is way easier.
-            // Win11 might not have this issue but Win10 does so please leave this
         }
     }
 }


### PR DESCRIPTION
I setup a new device for someone recently and it shipped with 20H2 installed. It's not unreasonable to assume that there exist other devices still running these other ancient versions of Windows 10.