### PR TITLE
Quality of life GUI improvements

### DIFF
--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -241,10 +241,10 @@ namespace TwitchDownloaderWPF
             else if (radioCompressionGzip.IsChecked == true)
                 options.Compression = ChatCompression.Gzip;
 
-            options.EmbedData = (bool)checkEmbed.IsChecked;
-            options.BttvEmotes = (bool)checkBttvEmbed.IsChecked;
-            options.FfzEmotes = (bool)checkFfzEmbed.IsChecked;
-            options.StvEmotes = (bool)checkStvEmbed.IsChecked;
+            options.EmbedData = checkEmbed.IsChecked.GetValueOrDefault();
+            options.BttvEmotes = checkBttvEmbed.IsChecked.GetValueOrDefault();
+            options.FfzEmotes = checkFfzEmbed.IsChecked.GetValueOrDefault();
+            options.StvEmotes = checkStvEmbed.IsChecked.GetValueOrDefault();
             options.Filename = filename;
             options.ConnectionCount = (int)numChatDownloadConnections.Value;
             return options;
@@ -561,12 +561,12 @@ namespace TwitchDownloaderWPF
 
         private void checkCropStart_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropStart((bool)checkCropStart.IsChecked);
+            SetEnabledCropStart(checkCropStart.IsChecked.GetValueOrDefault());
         }
 
         private void checkCropEnd_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropEnd((bool)checkCropEnd.IsChecked);
+            SetEnabledCropEnd(checkCropEnd.IsChecked.GetValueOrDefault());
         }
 
 

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -117,20 +117,14 @@ namespace TwitchDownloaderWPF
                 {
                     GqlVideoResponse videoInfo = await TwitchHelper.GetVideoInfo(int.Parse(downloadId));
 
-                    try
-                    {
-                        string thumbUrl = videoInfo.data.video.thumbnailURLs.FirstOrDefault();
-                        imgThumbnail.Source = await ThumbnailService.GetThumb(thumbUrl);
-                    }
-                    catch
+                    var thumbUrl = videoInfo.data.video.thumbnailURLs.FirstOrDefault();
+                    if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                     {
                         AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                        var (success, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
-                        if (success)
-                        {
-                            imgThumbnail.Source = image;
-                        }
+                        _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                     }
+                    imgThumbnail.Source = image;
+
                     vodLength = TimeSpan.FromSeconds(videoInfo.data.video.lengthSeconds);
                     textTitle.Text = videoInfo.data.video.title;
                     textStreamer.Text = videoInfo.data.video.owner.displayName;
@@ -169,20 +163,14 @@ namespace TwitchDownloaderWPF
                     string clipId = downloadId;
                     GqlClipResponse clipInfo = await TwitchHelper.GetClipInfo(clipId);
 
-                    try
-                    {
-                        string thumbUrl = clipInfo.data.clip.thumbnailURL;
-                        imgThumbnail.Source = await ThumbnailService.GetThumb(thumbUrl);
-                    }
-                    catch
+                    var thumbUrl = clipInfo.data.clip.thumbnailURL;
+                    if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                     {
                         AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                        var (success, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
-                        if (success)
-                        {
-                            imgThumbnail.Source = image;
-                        }
+                        _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                     }
+                    imgThumbnail.Source = image;
+
                     TimeSpan clipLength = TimeSpan.FromSeconds(clipInfo.data.clip.durationSeconds);
                     textStreamer.Text = clipInfo.data.clip.broadcaster.displayName;
                     var clipCreatedAt = clipInfo.data.clip.createdAt;

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -96,13 +96,13 @@ namespace TwitchDownloaderWPF
                 InputFile = textJson.Text,
                 BackgroundColor = backgroundColor,
                 AlternateBackgroundColor = altBackgroundColor,
-                AlternateMessageBackgrounds = (bool)checkAlternateMessageBackgrounds.IsChecked,
+                AlternateMessageBackgrounds = checkAlternateMessageBackgrounds.IsChecked.GetValueOrDefault(),
                 ChatHeight = int.Parse(textHeight.Text),
                 ChatWidth = int.Parse(textWidth.Text),
-                BttvEmotes = (bool)checkBTTV.IsChecked,
-                FfzEmotes = (bool)checkFFZ.IsChecked,
-                StvEmotes = (bool)checkSTV.IsChecked,
-                Outline = (bool)checkOutline.IsChecked,
+                BttvEmotes = checkBTTV.IsChecked.GetValueOrDefault(),
+                FfzEmotes = checkFFZ.IsChecked.GetValueOrDefault(),
+                StvEmotes = checkSTV.IsChecked.GetValueOrDefault(),
+                Outline = checkOutline.IsChecked.GetValueOrDefault(),
                 Font = (string)comboFont.SelectedItem,
                 FontSize = numFontSize.Value,
                 UpdateRate = double.Parse(textUpdateTime.Text, CultureInfo.CurrentCulture),
@@ -118,22 +118,22 @@ namespace TwitchDownloaderWPF
                 VerticalSpacingScale = double.Parse(textVerticalScale.Text, CultureInfo.CurrentCulture),
                 IgnoreUsersArray = textIgnoreUsersList.Text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
                 BannedWordsArray = textBannedWordsList.Text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
-                Timestamp = (bool)checkTimestamp.IsChecked,
+                Timestamp = checkTimestamp.IsChecked.GetValueOrDefault(),
                 MessageColor = messageColor,
                 Framerate = int.Parse(textFramerate.Text),
                 InputArgs = CheckRenderSharpening.IsChecked == true ? textFfmpegInput.Text + " -filter_complex \"smartblur=lr=1:ls=-1.0\"" : textFfmpegInput.Text,
                 OutputArgs = textFfmpegOutput.Text,
                 MessageFontStyle = SKFontStyle.Normal,
                 UsernameFontStyle = SKFontStyle.Bold,
-                GenerateMask = (bool)checkMask.IsChecked,
+                GenerateMask = checkMask.IsChecked.GetValueOrDefault(),
                 OutlineSize = 4 * double.Parse(textOutlineScale.Text, CultureInfo.CurrentCulture),
                 FfmpegPath = "ffmpeg",
                 TempFolder = Settings.Default.TempPath,
-                SubMessages = (bool)checkSub.IsChecked,
-                ChatBadges = (bool)checkBadge.IsChecked,
-                Offline = (bool)checkOffline.IsChecked,
+                SubMessages = checkSub.IsChecked.GetValueOrDefault(),
+                ChatBadges = checkBadge.IsChecked.GetValueOrDefault(),
+                Offline = checkOffline.IsChecked.GetValueOrDefault(),
                 AllowUnlistedEmotes = true,
-                DisperseCommentOffsets = (bool)checkDispersion.IsChecked,
+                DisperseCommentOffsets = checkDispersion.IsChecked.GetValueOrDefault(),
                 LogFfmpegOutput = true
             };
             if (RadioEmojiNotoColor.IsChecked == true)
@@ -287,29 +287,29 @@ namespace TwitchDownloaderWPF
         public void SaveSettings()
         {
             Settings.Default.Font = comboFont.SelectedItem.ToString();
-            Settings.Default.Outline = (bool)checkOutline.IsChecked;
-            Settings.Default.Timestamp = (bool)checkTimestamp.IsChecked;
-            Settings.Default.BackgroundColorR = colorBackground.SelectedColor.Value.R;
-            Settings.Default.BackgroundColorG = colorBackground.SelectedColor.Value.G;
-            Settings.Default.BackgroundColorB = colorBackground.SelectedColor.Value.B;
-            Settings.Default.BackgroundColorA = colorBackground.SelectedColor.Value.A;
-            Settings.Default.AlternateBackgroundColorR = colorAlternateBackground.SelectedColor.Value.R;
-            Settings.Default.AlternateBackgroundColorG = colorAlternateBackground.SelectedColor.Value.G;
-            Settings.Default.AlternateBackgroundColorB = colorAlternateBackground.SelectedColor.Value.B;
-            Settings.Default.AlternateBackgroundColorA = colorAlternateBackground.SelectedColor.Value.A;
-            Settings.Default.FFZEmotes = (bool)checkFFZ.IsChecked;
-            Settings.Default.BTTVEmotes = (bool)checkBTTV.IsChecked;
-            Settings.Default.STVEmotes = (bool)checkSTV.IsChecked;
-            Settings.Default.FontColorR = colorFont.SelectedColor.Value.R;
-            Settings.Default.FontColorG = colorFont.SelectedColor.Value.G;
-            Settings.Default.FontColorB = colorFont.SelectedColor.Value.B;
-            Settings.Default.GenerateMask = (bool)checkMask.IsChecked;
-            Settings.Default.ChatRenderSharpening = (bool)CheckRenderSharpening.IsChecked;
-            Settings.Default.SubMessages = (bool)checkSub.IsChecked;
-            Settings.Default.ChatBadges = (bool)checkBadge.IsChecked;
-            Settings.Default.Offline = (bool)checkOffline.IsChecked;
-            Settings.Default.DisperseCommentOffsets = (bool)checkDispersion.IsChecked;
-            Settings.Default.AlternateMessageBackgrounds = (bool)checkAlternateMessageBackgrounds.IsChecked;
+            Settings.Default.Outline = checkOutline.IsChecked.GetValueOrDefault();
+            Settings.Default.Timestamp = checkTimestamp.IsChecked.GetValueOrDefault();
+            Settings.Default.BackgroundColorR = colorBackground.SelectedColor.GetValueOrDefault().R;
+            Settings.Default.BackgroundColorG = colorBackground.SelectedColor.GetValueOrDefault().G;
+            Settings.Default.BackgroundColorB = colorBackground.SelectedColor.GetValueOrDefault().B;
+            Settings.Default.BackgroundColorA = colorBackground.SelectedColor.GetValueOrDefault().A;
+            Settings.Default.AlternateBackgroundColorR = colorAlternateBackground.SelectedColor.GetValueOrDefault().R;
+            Settings.Default.AlternateBackgroundColorG = colorAlternateBackground.SelectedColor.GetValueOrDefault().G;
+            Settings.Default.AlternateBackgroundColorB = colorAlternateBackground.SelectedColor.GetValueOrDefault().B;
+            Settings.Default.AlternateBackgroundColorA = colorAlternateBackground.SelectedColor.GetValueOrDefault().A;
+            Settings.Default.FFZEmotes = checkFFZ.IsChecked.GetValueOrDefault();
+            Settings.Default.BTTVEmotes = checkBTTV.IsChecked.GetValueOrDefault();
+            Settings.Default.STVEmotes = checkSTV.IsChecked.GetValueOrDefault();
+            Settings.Default.FontColorR = colorFont.SelectedColor.GetValueOrDefault().R;
+            Settings.Default.FontColorG = colorFont.SelectedColor.GetValueOrDefault().G;
+            Settings.Default.FontColorB = colorFont.SelectedColor.GetValueOrDefault().B;
+            Settings.Default.GenerateMask = checkMask.IsChecked.GetValueOrDefault();
+            Settings.Default.ChatRenderSharpening = CheckRenderSharpening.IsChecked.GetValueOrDefault();
+            Settings.Default.SubMessages = checkSub.IsChecked.GetValueOrDefault();
+            Settings.Default.ChatBadges = checkBadge.IsChecked.GetValueOrDefault();
+            Settings.Default.Offline = checkOffline.IsChecked.GetValueOrDefault();
+            Settings.Default.DisperseCommentOffsets = checkDispersion.IsChecked.GetValueOrDefault();
+            Settings.Default.AlternateMessageBackgrounds = checkAlternateMessageBackgrounds.IsChecked.GetValueOrDefault();
             if (comboFormat.SelectedItem != null)
             {
                 Settings.Default.VideoContainer = ((VideoContainer)comboFormat.SelectedItem).Name;
@@ -376,21 +376,21 @@ namespace TwitchDownloaderWPF
 
             try
             {
-                int.Parse(textHeight.Text);
-                int.Parse(textWidth.Text);
-                double.Parse(textUpdateTime.Text, CultureInfo.CurrentCulture);
-                int.Parse(textFramerate.Text);
-                double.Parse(textEmoteScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textBadgeScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textEmojiScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textVerticalScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textSidePaddingScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textSectionHeightScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textWordSpaceScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textEmoteSpaceScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textAccentStrokeScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textAccentIndentScale.Text, CultureInfo.CurrentCulture);
-                double.Parse(textOutlineScale.Text, CultureInfo.CurrentCulture);
+                _ = int.Parse(textHeight.Text);
+                _ = int.Parse(textWidth.Text);
+                _ = double.Parse(textUpdateTime.Text, CultureInfo.CurrentCulture);
+                _ = int.Parse(textFramerate.Text);
+                _ = double.Parse(textEmoteScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textBadgeScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textEmojiScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textVerticalScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textSidePaddingScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textSectionHeightScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textWordSpaceScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textEmoteSpaceScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textAccentStrokeScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textAccentIndentScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textOutlineScale.Text, CultureInfo.CurrentCulture);
             }
             catch (Exception ex)
             {

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -119,7 +119,7 @@ namespace TwitchDownloaderWPF
                     if (videoInfo.data.video == null)
                     {
                         AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail + ": " + Translations.Strings.VodExpiredOrIdCorrupt);
-                        var (_, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
+                        _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out var image);
                         imgThumbnail.Source = image;
 
                         numStartHour.Maximum = 48;
@@ -135,11 +135,10 @@ namespace TwitchDownloaderWPF
                         Game = videoInfo.data.video.game?.displayName;
 
                         var thumbUrl = videoInfo.data.video.thumbnailURLs.FirstOrDefault();
-                        var (success, image) = await ThumbnailService.TryGetThumb(thumbUrl);
-                        if (!success)
+                        if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                         {
                             AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                            (_, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
+                            _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                         }
 
                         imgThumbnail.Source = image;
@@ -157,7 +156,7 @@ namespace TwitchDownloaderWPF
                     if (videoInfo.data.clip.video == null)
                     {
                         AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail + ": " + Translations.Strings.VodExpiredOrIdCorrupt);
-                        var (_, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
+                        _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out var image);
                         imgThumbnail.Source = image;
                     }
                     else
@@ -168,11 +167,10 @@ namespace TwitchDownloaderWPF
                         Game = videoInfo.data.clip.game?.displayName;
 
                         var thumbUrl = videoInfo.data.clip.thumbnailURL;
-                        var (success, image) = await ThumbnailService.TryGetThumb(thumbUrl);
-                        if (!success)
+                        if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                         {
                             AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                            (_, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
+                            _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                         }
 
                         imgThumbnail.Source = image;

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -268,22 +268,22 @@ namespace TwitchDownloaderWPF
         {
             ChatUpdateOptions options = new ChatUpdateOptions()
             {
-                EmbedMissing = (bool)checkEmbedMissing.IsChecked,
-                ReplaceEmbeds = (bool)checkReplaceEmbeds.IsChecked,
-                BttvEmotes = (bool)checkBttvEmbed.IsChecked,
-                FfzEmotes = (bool)checkFfzEmbed.IsChecked,
-                StvEmotes = (bool)checkStvEmbed.IsChecked,
+                EmbedMissing = checkEmbedMissing.IsChecked.GetValueOrDefault(),
+                ReplaceEmbeds = checkReplaceEmbeds.IsChecked.GetValueOrDefault(),
+                BttvEmotes = checkBttvEmbed.IsChecked.GetValueOrDefault(),
+                FfzEmotes = checkFfzEmbed.IsChecked.GetValueOrDefault(),
+                StvEmotes = checkStvEmbed.IsChecked.GetValueOrDefault(),
                 InputFile = textJson.Text,
                 OutputFile = outputFile,
                 CropBeginningTime = -1,
                 CropEndingTime = -1
             };
 
-            if ((bool)radioJson.IsChecked)
+            if (radioJson.IsChecked.GetValueOrDefault())
                 options.OutputFormat = ChatFormat.Json;
-            else if ((bool)radioHTML.IsChecked)
+            else if (radioHTML.IsChecked.GetValueOrDefault())
                 options.OutputFormat = ChatFormat.Html;
-            else if ((bool)radioText.IsChecked)
+            else if (radioText.IsChecked.GetValueOrDefault())
                 options.OutputFormat = ChatFormat.Text;
 
             if (radioCompressionNone.IsChecked == true)
@@ -304,11 +304,11 @@ namespace TwitchDownloaderWPF
                 options.CropEndingTime = (int)Math.Round(end.TotalSeconds);
             }
 
-            if ((bool)radioTimestampUTC.IsChecked)
+            if (radioTimestampUTC.IsChecked.GetValueOrDefault())
                 options.TextTimestampFormat = TimestampFormat.Utc;
-            else if ((bool)radioTimestampRelative.IsChecked)
+            else if (radioTimestampRelative.IsChecked.GetValueOrDefault())
                 options.TextTimestampFormat = TimestampFormat.Relative;
-            else if ((bool)radioTimestampNone.IsChecked)
+            else if (radioTimestampNone.IsChecked.GetValueOrDefault())
                 options.TextTimestampFormat = TimestampFormat.None;
 
             return options;
@@ -635,12 +635,12 @@ namespace TwitchDownloaderWPF
 
         private void checkStart_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropStart((bool)checkStart.IsChecked);
+            SetEnabledCropStart(checkStart.IsChecked.GetValueOrDefault());
         }
 
         private void checkEnd_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropEnd((bool)checkEnd.IsChecked);
+            SetEnabledCropEnd(checkEnd.IsChecked.GetValueOrDefault());
         }
 
         private void MenuItemEnqueue_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -60,20 +60,14 @@ namespace TwitchDownloaderWPF
 
                 GqlClipResponse clipData = taskClipInfo.Result;
 
-                try
-                {
-                    string thumbUrl = clipData.data.clip.thumbnailURL;
-                    imgThumbnail.Source = await ThumbnailService.GetThumb(thumbUrl);
-                }
-                catch
+                var thumbUrl = clipData.data.clip.thumbnailURL;
+                if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                 {
                     AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                    var (success, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
-                    if (success)
-                    {
-                        imgThumbnail.Source = image;
-                    }
+                    _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                 }
+                imgThumbnail.Source = image;
+
                 clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
                 textStreamer.Text = clipData.data.clip.broadcaster.displayName;
                 var clipCreatedAt = clipData.data.clip.createdAt;

--- a/TwitchDownloaderWPF/PageQueue.xaml
+++ b/TwitchDownloaderWPF/PageQueue.xaml
@@ -37,7 +37,7 @@
                 <ItemsControl x:Name="queueList" ItemsSource="{Binding taskList}" Margin="0,10" d:DataContext="{d:DesignInstance local:PageQueue}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border BorderThickness="1" CornerRadius="8" Margin="8,8,8,8" Padding="4" d:DataContext="{d:DesignInstance task:ITwitchTask}" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
+                            <Border BorderThickness="1" CornerRadius="8" Margin="8,8,8,8" Padding="4" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
                                 <Grid Margin="1,1">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="auto" />

--- a/TwitchDownloaderWPF/PageQueue.xaml
+++ b/TwitchDownloaderWPF/PageQueue.xaml
@@ -4,6 +4,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="clr-namespace:TwitchDownloaderWPF"
+      xmlns:task="clr-namespace:TwitchDownloaderWPF.TwitchTasks"
       xmlns:lex="http://wpflocalizeextension.codeplex.com"
       lex:LocalizeDictionary.DesignCulture=""
       lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
@@ -32,11 +33,11 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="1" Grid.RowSpan="2" BorderThickness="1" BorderBrush="{DynamicResource AppElementBorder}" Margin="0,0,0,10">
-            <ScrollViewer  VerticalScrollBarVisibility="Auto">
-                <ItemsControl x:Name="queueList" ItemsSource="{Binding taskList}" Margin="0,10">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="queueList" ItemsSource="{Binding taskList}" Margin="0,10" d:DataContext="{d:DesignInstance local:PageQueue}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border BorderThickness="1" CornerRadius="8" Margin="8,8,8,8" Padding="4" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
+                            <Border BorderThickness="1" CornerRadius="8" Margin="8,8,8,8" Padding="4" d:DataContext="{d:DesignInstance task:ITwitchTask}" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
                                 <Grid Margin="1,1">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="auto" />

--- a/TwitchDownloaderWPF/PageQueue.xaml.cs
+++ b/TwitchDownloaderWPF/PageQueue.xaml.cs
@@ -202,7 +202,7 @@ namespace TwitchDownloaderWPF
 
         private void btnTaskError_Click(object sender, RoutedEventArgs e)
         {
-            if (!(sender is Button { DataContext: ITwitchTask task }))
+            if (sender is not Button { DataContext: ITwitchTask task })
             {
                 return;
             }
@@ -225,7 +225,7 @@ namespace TwitchDownloaderWPF
 
         private void btnRemoveTask_Click(object sender, RoutedEventArgs e)
         {
-            if (!(sender is Button { DataContext: ITwitchTask task }))
+            if (sender is not Button { DataContext: ITwitchTask task })
             {
                 return;
             }

--- a/TwitchDownloaderWPF/PageQueue.xaml.cs
+++ b/TwitchDownloaderWPF/PageQueue.xaml.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -100,20 +100,14 @@ namespace TwitchDownloaderWPF
                 }
 
                 Task<string[]> taskPlaylist = TwitchHelper.GetVideoPlaylist(videoId, taskAccessToken.Result.data.videoPlaybackAccessToken.value, taskAccessToken.Result.data.videoPlaybackAccessToken.signature);
-                try
-                {
-                    string thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
-                    imgThumbnail.Source = await ThumbnailService.GetThumb(thumbUrl);
-                }
-                catch
+
+                var thumbUrl = taskVideoInfo.Result.data.video.thumbnailURLs.FirstOrDefault();
+                if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))
                 {
                     AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail);
-                    var (success, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
-                    if (success)
-                    {
-                        imgThumbnail.Source = image;
-                    }
+                    _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out image);
                 }
+                imgThumbnail.Source = image;
 
                 comboQuality.Items.Clear();
                 videoQualities.Clear();

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -49,8 +49,8 @@ namespace TwitchDownloaderWPF
             checkEnd.IsEnabled = isEnabled;
             SplitBtnDownload.IsEnabled = isEnabled;
             MenuItemEnqueue.IsEnabled = isEnabled;
-            SetEnabledCropStart(isEnabled & (bool)checkStart.IsChecked);
-            SetEnabledCropEnd(isEnabled & (bool)checkEnd.IsChecked);
+            SetEnabledCropStart(isEnabled & checkStart.IsChecked.GetValueOrDefault());
+            SetEnabledCropEnd(isEnabled & checkEnd.IsChecked.GetValueOrDefault());
         }
 
         private void SetEnabledCropStart(bool isEnabled)
@@ -211,9 +211,9 @@ namespace TwitchDownloaderWPF
                 Oauth = TextOauth.Text,
                 Quality = GetQualityWithoutSize(comboQuality.Text).ToString(),
                 Id = currentVideoId,
-                CropBeginning = (bool)checkStart.IsChecked,
+                CropBeginning = checkStart.IsChecked.GetValueOrDefault(),
                 CropBeginningTime = (int)(new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value).TotalSeconds),
-                CropEnding = (bool)checkEnd.IsChecked,
+                CropEnding = checkEnd.IsChecked.GetValueOrDefault(),
                 CropEndingTime = (int)(new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value).TotalSeconds),
                 FfmpegPath = "ffmpeg",
                 TempFolder = Settings.Default.TempPath
@@ -300,7 +300,7 @@ namespace TwitchDownloaderWPF
 
         public bool ValidateInputs()
         {
-            if ((bool)checkStart.IsChecked)
+            if (checkStart.IsChecked.GetValueOrDefault())
             {
                 var beginTime = new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value);
                 if (beginTime.TotalSeconds >= vodLength.TotalSeconds)
@@ -308,7 +308,7 @@ namespace TwitchDownloaderWPF
                     return false;
                 }
 
-                if ((bool)checkEnd.IsChecked)
+                if (checkEnd.IsChecked.GetValueOrDefault())
                 {
                     var endTime = new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value);
                     if (endTime.TotalSeconds < beginTime.TotalSeconds)
@@ -375,14 +375,14 @@ namespace TwitchDownloaderWPF
 
         private void checkStart_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropStart((bool)checkStart.IsChecked);
+            SetEnabledCropStart(checkStart.IsChecked.GetValueOrDefault());
 
             UpdateVideoSizeEstimates();
         }
 
         private void checkEnd_OnCheckStateChanged(object sender, RoutedEventArgs e)
         {
-            SetEnabledCropEnd((bool)checkEnd.IsChecked);
+            SetEnabledCropEnd(checkEnd.IsChecked.GetValueOrDefault());
 
             UpdateVideoSizeEstimates();
         }

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -46,7 +46,7 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Border BorderThickness="1" CornerRadius="8" Margin="0,0,8,8" Padding="4" MouseUp="Border_MouseUp" Initialized="Border_Initialized" d:DataContext="{d:DesignInstance task:TaskData}" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
+                        <Border BorderThickness="1" CornerRadius="8" Margin="0,0,8,8" Padding="4" MouseUp="Border_MouseUp" Initialized="Border_Initialized" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
                             <StackPanel Orientation="Vertical" Width="220" Background="{DynamicResource AppElementBackground}">
                                 <Image Source="{Binding Thumbnail}" MaxHeight="90"></Image>
                                 <emoji:TextBlock TextWrapping="Wrap" MaxHeight="40" TextTrimming="CharacterEllipsis" Foreground="{DynamicResource AppText}">

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -10,7 +10,7 @@
         lex:LocalizeDictionary.DesignCulture=""
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
-		xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
+        xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
         xmlns:gif="http://wpfanimatedgif.codeplex.com"
         mc:Ignorable="d"
         Title="Mass Downloader" MinHeight="250" Height="700" MinWidth="775" Width="1100" Loaded="Window_Loaded">

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:TwitchDownloaderWPF"
+        xmlns:task="clr-namespace:TwitchDownloaderWPF.TwitchTasks"
         xmlns:behave="clr-namespace:TwitchDownloaderWPF.Behaviors"
         xmlns:lex="http://wpflocalizeextension.codeplex.com"
         lex:LocalizeDictionary.DesignCulture=""
@@ -34,7 +35,7 @@
         </StackPanel>
         <WrapPanel HorizontalAlignment="Left" Height="329" Margin="10,54,0,0" VerticalAlignment="Top" Width="772"/>
         <ScrollViewer x:Name="scrollDownload" VerticalScrollBarVisibility="Auto" Margin="10,41,10,45">
-            <ItemsControl x:Name="itemList" ItemsSource="{Binding videoList}">
+            <ItemsControl x:Name="itemList" ItemsSource="{Binding videoList}" d:DataContext="{d:DesignInstance local:WindowMassDownload}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top"/>
@@ -42,7 +43,7 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Border BorderThickness="1" CornerRadius="8" Margin="0,0,8,8" Padding="4" MouseUp="Border_MouseUp" Initialized="Border_Initialized" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
+                        <Border BorderThickness="1" CornerRadius="8" Margin="0,0,8,8" Padding="4" MouseUp="Border_MouseUp" Initialized="Border_Initialized" d:DataContext="{d:DesignInstance task:TaskData}" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}">
                             <StackPanel Orientation="Vertical" Width="220" Background="{DynamicResource AppElementBackground}">
                                 <Image Source="{Binding Thumbnail}" MaxHeight="90"></Image>
                                 <emoji:TextBlock TextWrapping="Wrap" MaxHeight="40" TextTrimming="CharacterEllipsis" Foreground="{DynamicResource AppText}">

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -11,6 +11,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
 		xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
+        xmlns:gif="http://wpfanimatedgif.codeplex.com"
         mc:Ignorable="d"
         Title="Mass Downloader" MinHeight="250" Height="700" MinWidth="775" Width="1100" Loaded="Window_Loaded">
     <Window.Resources>
@@ -20,20 +21,22 @@
     </Window.Resources>
 
     <Grid Background="{DynamicResource AppBackground}">
-        <StackPanel Orientation="Horizontal">
-            <Label x:Name="labelSort" Content="{lex:Loc Sort}" HorizontalAlignment="Left" Margin="10,6,0,0" VerticalAlignment="Top" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-            <ComboBox SelectedIndex="2" x:Name="comboSort" HorizontalAlignment="Left" Margin="5,6,0,0" VerticalAlignment="Top" MinWidth="120" SelectionChanged="comboSort_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <Label x:Name="labelSort" Content="{lex:Loc Sort}" Margin="10,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <ComboBox SelectedIndex="2" x:Name="comboSort" Margin="5,6,0,0" MinWidth="120" SelectionChanged="comboSort_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <ComboBoxItem Content="{lex:Loc TopTwentyFourHours}" Tag="LAST_DAY"/>
                 <ComboBoxItem Content="{lex:Loc TopSevenDays}" Tag="LAST_WEEK"/>
                 <ComboBoxItem Content="{lex:Loc TopThirtyDays}" Tag="LAST_MONTH"/>
                 <ComboBoxItem Content="{lex:Loc TopAllTime}" Tag="ALL_TIME"/>
             </ComboBox>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-            <TextBox x:Name="textChannel" HorizontalAlignment="Center" Height="23" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="194" Margin="0,6,0,0" KeyDown="TextChannel_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
-            <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" HorizontalAlignment="Left" Margin="3,6,0,0" VerticalAlignment="Top" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
+            <TextBox x:Name="textChannel" Height="23" TextWrapping="Wrap" Text="" Width="194" Margin="0,6,0,0" KeyDown="TextChannel_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+            <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" Margin="3,6,0,0" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
-        <WrapPanel HorizontalAlignment="Left" Height="329" Margin="10,54,0,0" VerticalAlignment="Top" Width="772"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+            <Image x:Name="StatusImage" gif:ImageBehavior.AnimatedSource="Images/ppOverheat.gif" MaxWidth="50" Margin="0, 6, 6, 0" Visibility="Collapsed" />
+        </StackPanel>
         <ScrollViewer x:Name="scrollDownload" VerticalScrollBarVisibility="Auto" Margin="10,41,10,45">
             <ItemsControl x:Name="itemList" ItemsSource="{Binding videoList}" d:DataContext="{d:DesignInstance local:WindowMassDownload}">
                 <ItemsControl.ItemsPanel>
@@ -64,14 +67,14 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
-        <StackPanel Orientation="Horizontal">
-            <Label HorizontalAlignment="Left" Margin="10,0,0,3" VerticalAlignment="Bottom" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" >
+            <Label Margin="10,0,0,3" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <TextBlock>
                 <Run Text="{lex:Loc SelectedItems}"/>
                 <Run x:Name="textCount" Text="0"/>
                 </TextBlock>
             </Label>
-            <Button x:Name="btnSelectAll" Content="{lex:Loc SelectAll}" HorizontalAlignment="Left" Margin="5,0,0,3" VerticalAlignment="Bottom" MinWidth="80" Height="30" Click="btnSelectAll_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="btnSelectAll" Content="{lex:Loc SelectAll}" Margin="5,0,0,3" MinWidth="80" Height="30" Click="btnSelectAll_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
         <Button x:Name="btnPrev" Content="&lt;-" HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="34" Margin="0,0,80,4" Click="btnPrev_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <Button x:Name="btnNext" Content="->" HorizontalAlignment="Center" VerticalAlignment="Bottom" Width="34" Margin="80,0,0,4" Click="btnNext_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -189,7 +189,7 @@ namespace TwitchDownloaderWPF
 
             if (selectedItems.Any(x => x.Id == taskData.Id))
             {
-                border.BorderBrush = Brushes.LightBlue;
+                border.Background = Brushes.LightBlue;
             }
         }
 

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -58,6 +58,8 @@ namespace TwitchDownloaderWPF
 
         private async Task UpdateList()
         {
+            if (StatusImage != null) StatusImage.Visibility = Visibility.Visible;
+
             if (downloaderType == DownloadType.Video)
             {
                 string currentCursor = "";
@@ -65,7 +67,7 @@ namespace TwitchDownloaderWPF
                 {
                     currentCursor = cursorList[cursorIndex];
                 }
-                GqlVideoSearchResponse res = await TwitchHelper.GetGqlVideos(currentChannel, currentCursor, 100);
+                GqlVideoSearchResponse res = await TwitchHelper.GetGqlVideos(currentChannel, currentCursor, 50);
                 videoList.Clear();
                 if (res.data.user != null)
                 {
@@ -142,6 +144,8 @@ namespace TwitchDownloaderWPF
                     }
                 }
             }
+
+            if (StatusImage != null) StatusImage.Visibility = Visibility.Collapsed;
         }
 
         private void Border_MouseUp(object sender, MouseButtonEventArgs e)

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -238,7 +238,7 @@ namespace TwitchDownloaderWPF
                 ? Translations.Strings.TitleVideoMassDownloader
                 : Translations.Strings.TitleClipMassDownloader;
             App.RequestTitleBarChange();
-		}
+        }
 
         private async void TextChannel_OnKeyDown(object sender, KeyEventArgs e)
         {

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -182,13 +182,11 @@ namespace TwitchDownloaderWPF
 
         private void Border_Initialized(object sender, EventArgs e)
         {
-            Border border = (Border)sender;
-            if (border.DataContext != null)
+            if (sender is not Border border) return;
+
+            if (border.DataContext is TaskData taskData && selectedItems.Any(x => x.Id == taskData.Id))
             {
-                if (selectedItems.Any(x => x.Id == ((TaskData)border.DataContext).Id))
-                {
-                    border.Background = Brushes.LightBlue;
-                }
+                border.BorderBrush = Brushes.LightBlue;
             }
         }
 
@@ -197,8 +195,7 @@ namespace TwitchDownloaderWPF
             if (selectedItems.Count > 0)
             {
                 WindowQueueOptions queue = new WindowQueueOptions(selectedItems);
-                bool? queued = queue.ShowDialog();
-                if (queued != null && (bool)queued)
+                if (queue.ShowDialog().GetValueOrDefault())
                     this.Close();
             }
         }
@@ -217,18 +214,20 @@ namespace TwitchDownloaderWPF
             //I'm sure there is a much better way to do this. Could not find a way to iterate over each itemcontrol border
             foreach (var video in videoList)
             {
-                if (!selectedItems.Any(x => x.Id == video.Id))
+                if (selectedItems.All(x => x.Id != video.Id))
                 {
                     selectedItems.Add(video);
                 }
             }
 
-            List<TaskData> oldData = videoList.ToList();
+            // Remove and re-add all of the items to trigger Border_Initialized
+            var oldData = videoList.ToArray();
             videoList.Clear();
             foreach (var item in oldData)
             {
                 videoList.Add(item);
             }
+
             textCount.Text = selectedItems.Count.ToString();
         }
 

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -22,15 +22,15 @@ namespace TwitchDownloaderWPF
     {
         public DownloadType downloaderType { get; set; }
         public ObservableCollection<TaskData> videoList { get; set; } = new ObservableCollection<TaskData>();
-        public List<TaskData> selectedItems = new List<TaskData>();
-        public List<string> cursorList = new List<string>();
+        public readonly List<TaskData> selectedItems = new List<TaskData>();
+        public readonly List<string> cursorList = new List<string>();
         public int cursorIndex = -1;
         public string currentChannel = "";
         public string period = "";
 
-        public WindowMassDownload(DownloadType Type)
+        public WindowMassDownload(DownloadType type)
         {
-            downloaderType = Type;
+            downloaderType = type;
             InitializeComponent();
             itemList.ItemsSource = videoList;
             if (downloaderType == DownloadType.Video)
@@ -150,16 +150,18 @@ namespace TwitchDownloaderWPF
 
         private void Border_MouseUp(object sender, MouseButtonEventArgs e)
         {
-            Border border = sender as Border;
-            if (selectedItems.Any(x => x.Id == ((TaskData)border.DataContext).Id))
+            if (sender is not Border border) return;
+            if (border.DataContext is not TaskData taskData) return;
+
+            if (selectedItems.Any(x => x.Id == taskData.Id))
             {
                 border.Background = Brushes.Transparent;
-                selectedItems.RemoveAll(x => x.Id == ((TaskData)border.DataContext).Id);
+                selectedItems.RemoveAll(x => x.Id == taskData.Id);
             }
             else
             {
                 border.Background = Brushes.LightBlue;
-                selectedItems.Add((TaskData)border.DataContext);
+                selectedItems.Add(taskData);
             }
             textCount.Text = selectedItems.Count.ToString();
         }
@@ -183,8 +185,9 @@ namespace TwitchDownloaderWPF
         private void Border_Initialized(object sender, EventArgs e)
         {
             if (sender is not Border border) return;
+            if (border.DataContext is not TaskData taskData) return;
 
-            if (border.DataContext is TaskData taskData && selectedItems.Any(x => x.Id == taskData.Id))
+            if (selectedItems.Any(x => x.Id == taskData.Id))
             {
                 border.BorderBrush = Brushes.LightBlue;
             }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -97,7 +97,7 @@ namespace TwitchDownloaderWPF
                 textFolder.Text = queueFolder;
         }
 
-        private async void btnQueue_Click(object sender, RoutedEventArgs e)
+        private void btnQueue_Click(object sender, RoutedEventArgs e)
         {
             if (parentPage != null)
             {
@@ -365,8 +365,7 @@ namespace TwitchDownloaderWPF
                         renderOptions.InputFile = fileName;
                         renderTask.DownloadOptions = renderOptions;
                         renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
-                        var (success, image) = await ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL);
-                        if (success)
+                        if (ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out var image))
                         {
                             renderTask.Info.Thumbnail = image;
                         }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -110,11 +110,16 @@ namespace TwitchDownloaderWPF
                         return;
                     }
 
-                    VodDownloadTask downloadTask = new VodDownloadTask();
                     VideoDownloadOptions downloadOptions = vodDownloadPage.GetOptions(null, textFolder.Text);
-                    downloadTask.DownloadOptions = downloadOptions;
-                    downloadTask.Info.Title = vodDownloadPage.textTitle.Text;
-                    downloadTask.Info.Thumbnail = vodDownloadPage.imgThumbnail.Source;
+                    VodDownloadTask downloadTask = new VodDownloadTask
+                    {
+                        DownloadOptions = downloadOptions,
+                        Info =
+                        {
+                            Title = vodDownloadPage.textTitle.Text,
+                            Thumbnail = vodDownloadPage.imgThumbnail.Source
+                        }
+                    };
                     downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                     lock (PageQueue.taskLock)
@@ -124,7 +129,6 @@ namespace TwitchDownloaderWPF
 
                     if (checkChat.IsChecked.GetValueOrDefault())
                     {
-                        ChatDownloadTask chatTask = new ChatDownloadTask();
                         ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
                         chatOptions.Id = downloadOptions.Id.ToString();
                         if (radioJson.IsChecked == true)
@@ -148,9 +152,15 @@ namespace TwitchDownloaderWPF
                             chatOptions.CropEndingTime = downloadOptions.CropEndingTime;
                         }
 
-                        chatTask.DownloadOptions = chatOptions;
-                        chatTask.Info.Title = vodDownloadPage.textTitle.Text;
-                        chatTask.Info.Thumbnail = vodDownloadPage.imgThumbnail.Source;
+                        ChatDownloadTask chatTask = new ChatDownloadTask
+                        {
+                            DownloadOptions = chatOptions,
+                            Info =
+                            {
+                                Title = vodDownloadPage.textTitle.Text,
+                                Thumbnail = vodDownloadPage.imgThumbnail.Source
+                            }
+                        };
                         chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)
@@ -160,7 +170,6 @@ namespace TwitchDownloaderWPF
 
                         if (checkRender.IsChecked.GetValueOrDefault() && chatOptions.DownloadFormat == ChatFormat.Json)
                         {
-                            ChatRenderTask renderTask = new ChatRenderTask();
                             ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), '.' + MainWindow.pageChatRender.comboFormat.Text.ToLower()));
                             if (renderOptions.OutputFile.Trim() == downloadOptions.Filename!.Trim())
                             {
@@ -168,9 +177,16 @@ namespace TwitchDownloaderWPF
                                 renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT." + MainWindow.pageChatRender.comboFormat.Text.ToLower());
                             }
                             renderOptions.InputFile = chatOptions.Filename;
-                            renderTask.DownloadOptions = renderOptions;
-                            renderTask.Info.Title = vodDownloadPage.textTitle.Text;
-                            renderTask.Info.Thumbnail = vodDownloadPage.imgThumbnail.Source;
+
+                            ChatRenderTask renderTask = new ChatRenderTask
+                            {
+                                DownloadOptions = renderOptions,
+                                Info =
+                                {
+                                    Title = vodDownloadPage.textTitle.Text,
+                                    Thumbnail = vodDownloadPage.imgThumbnail.Source
+                                }
+                            };
                             renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
                             renderTask.DependantTask = chatTask;
 
@@ -193,20 +209,30 @@ namespace TwitchDownloaderWPF
                         return;
                     }
 
-                    ClipDownloadTask downloadTask = new ClipDownloadTask();
-                    ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                    downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, clipDownloadPage.textTitle.Text, clipDownloadPage.clipId, clipDownloadPage.currentVideoTime, clipDownloadPage.textStreamer.Text, TimeSpan.Zero, clipDownloadPage.clipLength, clipDownloadPage.viewCount.ToString(), clipDownloadPage.game) + ".mp4");
-                    downloadOptions.Id = clipDownloadPage.clipId;
-                    downloadOptions.Quality = clipDownloadPage.comboQuality.Text;
-                    downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
-                        ? Settings.Default.MaximumBandwidthKib
-                        : -1;
-                    downloadOptions.TempFolder = Settings.Default.TempPath;
-                    downloadOptions.EncodeMetadata = clipDownloadPage.CheckMetadata.IsChecked!.Value;
-                    downloadOptions.FfmpegPath = "ffmpeg";
-                    downloadTask.DownloadOptions = downloadOptions;
-                    downloadTask.Info.Title = clipDownloadPage.textTitle.Text;
-                    downloadTask.Info.Thumbnail = clipDownloadPage.imgThumbnail.Source;
+                    ClipDownloadOptions downloadOptions = new ClipDownloadOptions
+                    {
+                        Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, clipDownloadPage.textTitle.Text, clipDownloadPage.clipId,
+                            clipDownloadPage.currentVideoTime, clipDownloadPage.textStreamer.Text, TimeSpan.Zero, clipDownloadPage.clipLength,
+                            clipDownloadPage.viewCount.ToString(), clipDownloadPage.game) + ".mp4"),
+                        Id = clipDownloadPage.clipId,
+                        Quality = clipDownloadPage.comboQuality.Text,
+                        ThrottleKib = Settings.Default.DownloadThrottleEnabled
+                            ? Settings.Default.MaximumBandwidthKib
+                            : -1,
+                        TempFolder = Settings.Default.TempPath,
+                        EncodeMetadata = clipDownloadPage.CheckMetadata.IsChecked!.Value,
+                        FfmpegPath = "ffmpeg"
+                    };
+
+                    ClipDownloadTask downloadTask = new ClipDownloadTask
+                    {
+                        DownloadOptions = downloadOptions,
+                        Info =
+                        {
+                            Title = clipDownloadPage.textTitle.Text,
+                            Thumbnail = clipDownloadPage.imgThumbnail.Source
+                        }
+                    };
                     downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                     lock (PageQueue.taskLock)
@@ -216,7 +242,6 @@ namespace TwitchDownloaderWPF
 
                     if (checkChat.IsChecked.GetValueOrDefault())
                     {
-                        ChatDownloadTask chatTask = new ChatDownloadTask();
                         ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
                         chatOptions.Id = downloadOptions.Id;
                         if (radioJson.IsChecked == true)
@@ -229,9 +254,15 @@ namespace TwitchDownloaderWPF
                         chatOptions.EmbedData = checkEmbed.IsChecked.GetValueOrDefault();
                         chatOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipDownloadPage.currentVideoTime, clipDownloadPage.textStreamer.Text, TimeSpan.Zero, clipDownloadPage.clipLength, clipDownloadPage.viewCount.ToString(), clipDownloadPage.game) + "." + chatOptions.FileExtension);
 
-                        chatTask.DownloadOptions = chatOptions;
-                        chatTask.Info.Title = clipDownloadPage.textTitle.Text;
-                        chatTask.Info.Thumbnail = clipDownloadPage.imgThumbnail.Source;
+                        ChatDownloadTask chatTask = new ChatDownloadTask
+                        {
+                            DownloadOptions = chatOptions,
+                            Info =
+                            {
+                                Title = clipDownloadPage.textTitle.Text,
+                                Thumbnail = clipDownloadPage.imgThumbnail.Source
+                            }
+                        };
                         chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                         lock (PageQueue.taskLock)
@@ -241,7 +272,6 @@ namespace TwitchDownloaderWPF
 
                         if (checkRender.IsChecked.GetValueOrDefault() && chatOptions.DownloadFormat == ChatFormat.Json)
                         {
-                            ChatRenderTask renderTask = new ChatRenderTask();
                             ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), '.' + MainWindow.pageChatRender.comboFormat.Text.ToLower()));
                             if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
                             {
@@ -249,11 +279,18 @@ namespace TwitchDownloaderWPF
                                 renderOptions.OutputFile = Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), " - CHAT." + MainWindow.pageChatRender.comboFormat.Text.ToLower());
                             }
                             renderOptions.InputFile = chatOptions.Filename;
-                            renderTask.DownloadOptions = renderOptions;
-                            renderTask.Info.Title = clipDownloadPage.textTitle.Text;
-                            renderTask.Info.Thumbnail = clipDownloadPage.imgThumbnail.Source;
+
+                            ChatRenderTask renderTask = new ChatRenderTask
+                            {
+                                DownloadOptions = renderOptions,
+                                Info =
+                                {
+                                    Title = clipDownloadPage.textTitle.Text,
+                                    Thumbnail = clipDownloadPage.imgThumbnail.Source
+                                },
+                                DependantTask = chatTask
+                            };
                             renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                            renderTask.DependantTask = chatTask;
 
                             lock (PageQueue.taskLock)
                             {
@@ -274,7 +311,6 @@ namespace TwitchDownloaderWPF
                         return;
                     }
 
-                    ChatDownloadTask chatTask = new ChatDownloadTask();
                     ChatDownloadOptions chatOptions = MainWindow.pageChatDownload.GetOptions(null);
                     chatOptions.Id = chatDownloadPage.downloadId;
                     chatOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, chatDownloadPage.textTitle.Text, chatOptions.Id, chatDownloadPage.currentVideoTime, chatDownloadPage.textStreamer.Text,
@@ -282,9 +318,15 @@ namespace TwitchDownloaderWPF
                         chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatDownloadPage.vodLength,
                         chatDownloadPage.viewCount.ToString(), chatDownloadPage.game) + "." + chatOptions.FileExtension);
 
-                    chatTask.DownloadOptions = chatOptions;
-                    chatTask.Info.Title = chatDownloadPage.textTitle.Text;
-                    chatTask.Info.Thumbnail = chatDownloadPage.imgThumbnail.Source;
+                    ChatDownloadTask chatTask = new ChatDownloadTask
+                    {
+                        DownloadOptions = chatOptions,
+                        Info =
+                        {
+                            Title = chatDownloadPage.textTitle.Text,
+                            Thumbnail = chatDownloadPage.imgThumbnail.Source
+                        }
+                    };
                     chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                     lock (PageQueue.taskLock)
@@ -292,16 +334,22 @@ namespace TwitchDownloaderWPF
                         PageQueue.taskList.Add(chatTask);
                     }
 
-                    if ((bool)checkRender.IsChecked && chatOptions.DownloadFormat == ChatFormat.Json)
+                    if (checkRender.IsChecked.GetValueOrDefault() && chatOptions.DownloadFormat == ChatFormat.Json)
                     {
-                        ChatRenderTask renderTask = new ChatRenderTask();
                         ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(chatOptions.Filename.Replace(".gz", ""), '.' + MainWindow.pageChatRender.comboFormat.Text.ToLower()));
                         renderOptions.InputFile = chatOptions.Filename;
-                        renderTask.DownloadOptions = renderOptions;
-                        renderTask.Info.Title = chatDownloadPage.textTitle.Text;
-                        renderTask.Info.Thumbnail = chatDownloadPage.imgThumbnail.Source;
+
+                        ChatRenderTask renderTask = new ChatRenderTask
+                        {
+                            DownloadOptions = renderOptions,
+                            Info =
+                            {
+                                Title = chatDownloadPage.textTitle.Text,
+                                Thumbnail = chatDownloadPage.imgThumbnail.Source
+                            },
+                            DependantTask = chatTask
+                        };
                         renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                        renderTask.DependantTask = chatTask;
 
                         lock (PageQueue.taskLock)
                         {
@@ -321,7 +369,6 @@ namespace TwitchDownloaderWPF
                         return;
                     }
 
-                    ChatUpdateTask chatTask = new ChatUpdateTask();
                     ChatUpdateOptions chatOptions = MainWindow.pageChatUpdate.GetOptions(null);
                     chatOptions.InputFile = chatUpdatePage.InputFile;
                     chatOptions.OutputFile = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, chatUpdatePage.textTitle.Text, chatUpdatePage.VideoId, chatUpdatePage.VideoCreatedAt, chatUpdatePage.textStreamer.Text,
@@ -329,9 +376,15 @@ namespace TwitchDownloaderWPF
                         chatOptions.CropEnding ? TimeSpan.FromSeconds(chatOptions.CropEndingTime) : chatUpdatePage.VideoLength,
                         chatUpdatePage.ViewCount.ToString(), chatUpdatePage.Game) + "." + chatOptions.FileExtension);
 
-                    chatTask.UpdateOptions = chatOptions;
-                    chatTask.Info.Title = chatUpdatePage.textTitle.Text;
-                    chatTask.Info.Thumbnail = chatUpdatePage.imgThumbnail.Source;
+                    ChatUpdateTask chatTask = new ChatUpdateTask
+                    {
+                        UpdateOptions = chatOptions,
+                        Info =
+                        {
+                            Title = chatUpdatePage.textTitle.Text,
+                            Thumbnail = chatUpdatePage.imgThumbnail.Source
+                        }
+                    };
                     chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
                     lock (PageQueue.taskLock)
@@ -353,13 +406,19 @@ namespace TwitchDownloaderWPF
                             return;
                         }
 
-                        ChatRenderTask renderTask = new ChatRenderTask();
                         string fileFormat = chatRenderPage.comboFormat.SelectedItem.ToString()!;
                         string filePath = Path.Combine(folderPath, Path.GetFileNameWithoutExtension(fileName) + "." + fileFormat.ToLower());
                         ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(filePath);
                         renderOptions.InputFile = fileName;
-                        renderTask.DownloadOptions = renderOptions;
-                        renderTask.Info.Title = Path.GetFileNameWithoutExtension(filePath);
+                        ChatRenderTask renderTask = new ChatRenderTask
+                        {
+                            DownloadOptions = renderOptions,
+                            Info =
+                            {
+                                Title = Path.GetFileNameWithoutExtension(filePath)
+                            }
+                        };
+
                         if (ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out var image))
                         {
                             renderTask.Info.Thumbnail = image;
@@ -375,132 +434,165 @@ namespace TwitchDownloaderWPF
                     }
                 }
             }
-            else
+            else if (_dataList.Count > 0)
             {
-                if (_dataList.Count > 0)
+                EnqueueDataList();
+            }
+        }
+
+        private void EnqueueDataList()
+        {
+            string folderPath = textFolder.Text;
+            if (!Directory.Exists(folderPath))
+            {
+                MessageBox.Show(Translations.Strings.InvaliFolderPathMessage, Translations.Strings.InvalidFolderPath, MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            foreach (var taskData in _dataList)
+            {
+                if (checkVideo.IsChecked.GetValueOrDefault())
                 {
-                    string folderPath = textFolder.Text;
-                    if (!Directory.Exists(folderPath))
+                    if (taskData.Id.All(char.IsDigit))
                     {
-                        MessageBox.Show(Translations.Strings.InvaliFolderPathMessage, Translations.Strings.InvalidFolderPath, MessageBoxButton.OK, MessageBoxImage.Error);
-                        return;
-                    }
-
-                    foreach (var taskData in _dataList)
-                    {
-                        if (checkVideo.IsChecked.GetValueOrDefault())
+                        VideoDownloadOptions downloadOptions = new VideoDownloadOptions
                         {
-                            if (taskData.Id.All(char.IsDigit))
-                            {
-                                VodDownloadTask downloadTask = new VodDownloadTask();
-                                VideoDownloadOptions downloadOptions = new VideoDownloadOptions();
-                                downloadOptions.Oauth = Settings.Default.OAuth;
-                                downloadOptions.TempFolder = Settings.Default.TempPath;
-                                downloadOptions.Id = int.Parse(taskData.Id);
-                                downloadOptions.FfmpegPath = "ffmpeg";
-                                downloadOptions.CropBeginning = false;
-                                downloadOptions.CropEnding = false;
-                                downloadOptions.DownloadThreads = Settings.Default.VodDownloadThreads;
-                                downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
-                                    ? Settings.Default.MaximumBandwidthKib
-                                    : -1;
-                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateVod, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
-                                    downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
-                                    downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
-                                    taskData.Views.ToString(), taskData.Game) + ".mp4");
-                                downloadTask.DownloadOptions = downloadOptions;
-                                downloadTask.Info.Title = taskData.Title;
-                                downloadTask.Info.Thumbnail = taskData.Thumbnail;
-                                downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+                            Oauth = Settings.Default.OAuth,
+                            TempFolder = Settings.Default.TempPath,
+                            Id = int.Parse(taskData.Id),
+                            FfmpegPath = "ffmpeg",
+                            CropBeginning = false,
+                            CropEnding = false,
+                            DownloadThreads = Settings.Default.VodDownloadThreads,
+                            ThrottleKib = Settings.Default.DownloadThrottleEnabled
+                                ? Settings.Default.MaximumBandwidthKib
+                                : -1
+                        };
+                        downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateVod, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                            downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
+                            downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
+                            taskData.Views.ToString(), taskData.Game) + ".mp4");
 
-                                lock (PageQueue.taskLock)
-                                {
-                                    PageQueue.taskList.Add(downloadTask);
-                                }
-                            }
-                            else
-                            {
-                                ClipDownloadTask downloadTask = new ClipDownloadTask();
-                                ClipDownloadOptions downloadOptions = new ClipDownloadOptions();
-                                downloadOptions.Id = taskData.Id;
-                                downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
-                                    TimeSpan.Zero, TimeSpan.FromSeconds(taskData.Length), taskData.Views.ToString(), taskData.Game) + ".mp4");
-                                downloadOptions.ThrottleKib = Settings.Default.DownloadThrottleEnabled
-                                    ? Settings.Default.MaximumBandwidthKib
-                                    : -1;
-                                downloadOptions.TempFolder = Settings.Default.TempPath;
-                                downloadOptions.EncodeMetadata = Settings.Default.EncodeClipMetadata;
-                                downloadOptions.FfmpegPath = "ffmpeg";
-                                downloadTask.DownloadOptions = downloadOptions;
-                                downloadTask.Info.Title = taskData.Title;
-                                downloadTask.Info.Thumbnail = taskData.Thumbnail;
-                                downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                                lock (PageQueue.taskLock)
-                                {
-                                    PageQueue.taskList.Add(downloadTask);
-                                }
-                            }
-                        }
-
-                        if (checkChat.IsChecked.GetValueOrDefault())
+                        VodDownloadTask downloadTask = new VodDownloadTask
                         {
-                            ChatDownloadTask downloadTask = new ChatDownloadTask();
-                            ChatDownloadOptions downloadOptions = new ChatDownloadOptions();
-                            if (radioJson.IsChecked == true)
-                                downloadOptions.DownloadFormat = ChatFormat.Json;
-                            else if (radioHTML.IsChecked == true)
-                                downloadOptions.DownloadFormat = ChatFormat.Html;
-                            else
-                                downloadOptions.DownloadFormat = ChatFormat.Text;
-                            downloadOptions.Compression = RadioCompressionNone.IsChecked == true ? ChatCompression.None : ChatCompression.Gzip;
-                            downloadOptions.EmbedData = checkEmbed.IsChecked.GetValueOrDefault();
-                            downloadOptions.TimeFormat = TimestampFormat.Relative;
-                            downloadOptions.Id = taskData.Id;
-                            downloadOptions.CropBeginning = false;
-                            downloadOptions.CropEnding = false;
-                            downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
-                                downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
-                                downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
-                                taskData.Views.ToString(), taskData.Game) + "." + downloadOptions.FileExtension);
-                            downloadTask.DownloadOptions = downloadOptions;
-                            downloadTask.Info.Title = taskData.Title;
-                            downloadTask.Info.Thumbnail = taskData.Thumbnail;
-                            downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
-
-                            lock (PageQueue.taskLock)
+                            DownloadOptions = downloadOptions,
+                            Info =
                             {
-                                PageQueue.taskList.Add(downloadTask);
+                                Title = taskData.Title,
+                                Thumbnail = taskData.Thumbnail
                             }
+                        };
+                        downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
 
-                            if (checkRender.IsChecked.GetValueOrDefault() && downloadOptions.DownloadFormat == ChatFormat.Json)
-                            {
-                                ChatRenderTask renderTask = new ChatRenderTask();
-                                ChatRenderOptions renderOptions = MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), '.' + MainWindow.pageChatRender.comboFormat.Text.ToLower()));
-                                if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
-                                {
-                                    //Just in case VOD and chat paths are the same. Like the previous defaults
-                                    renderOptions.OutputFile = Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), " - CHAT." + MainWindow.pageChatRender.comboFormat.Text.ToLower());
-                                }
-                                renderOptions.InputFile = downloadOptions.Filename;
-                                renderTask.DownloadOptions = renderOptions;
-                                renderTask.Info.Title = taskData.Title;
-                                renderTask.Info.Thumbnail = taskData.Thumbnail;
-                                renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
-                                renderTask.DependantTask = downloadTask;
-
-                                lock (PageQueue.taskLock)
-                                {
-                                    PageQueue.taskList.Add(renderTask);
-                                }
-                            }
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(downloadTask);
                         }
                     }
+                    else
+                    {
+                        ClipDownloadOptions downloadOptions = new ClipDownloadOptions
+                        {
+                            Id = taskData.Id,
+                            Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                                TimeSpan.Zero, TimeSpan.FromSeconds(taskData.Length), taskData.Views.ToString(), taskData.Game) + ".mp4"),
+                            ThrottleKib = Settings.Default.DownloadThrottleEnabled
+                                ? Settings.Default.MaximumBandwidthKib
+                                : -1,
+                            TempFolder = Settings.Default.TempPath,
+                            EncodeMetadata = Settings.Default.EncodeClipMetadata,
+                            FfmpegPath = "ffmpeg"
+                        };
 
-                    this.DialogResult = true;
-                    this.Close();
+                        ClipDownloadTask downloadTask = new ClipDownloadTask
+                        {
+                            DownloadOptions = downloadOptions,
+                            Info =
+                            {
+                                Title = taskData.Title,
+                                Thumbnail = taskData.Thumbnail
+                            }
+                        };
+                        downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(downloadTask);
+                        }
+                    }
+                }
+
+                if (checkChat.IsChecked.GetValueOrDefault())
+                {
+                    ChatDownloadOptions downloadOptions = new ChatDownloadOptions
+                    {
+                        Compression = RadioCompressionNone.IsChecked.GetValueOrDefault() ? ChatCompression.None : ChatCompression.Gzip,
+                        EmbedData = checkEmbed.IsChecked.GetValueOrDefault(),
+                        TimeFormat = TimestampFormat.Relative,
+                        Id = taskData.Id,
+                        CropBeginning = false,
+                        CropEnding = false
+                    };
+                    downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateChat, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
+                        downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
+                        downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : TimeSpan.FromSeconds(taskData.Length),
+                        taskData.Views.ToString(), taskData.Game) + "." + downloadOptions.FileExtension);
+                    if (radioJson.IsChecked == true)
+                        downloadOptions.DownloadFormat = ChatFormat.Json;
+                    else if (radioHTML.IsChecked == true)
+                        downloadOptions.DownloadFormat = ChatFormat.Html;
+                    else
+                        downloadOptions.DownloadFormat = ChatFormat.Text;
+
+                    ChatDownloadTask downloadTask = new ChatDownloadTask
+                    {
+                        DownloadOptions = downloadOptions,
+                        Info =
+                        {
+                            Title = taskData.Title,
+                            Thumbnail = taskData.Thumbnail
+                        }
+                    };
+                    downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                    lock (PageQueue.taskLock)
+                    {
+                        PageQueue.taskList.Add(downloadTask);
+                    }
+
+                    if (checkRender.IsChecked.GetValueOrDefault() && downloadOptions.DownloadFormat == ChatFormat.Json)
+                    {
+                        ChatRenderOptions renderOptions =
+                            MainWindow.pageChatRender.GetOptions(Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), '.' + MainWindow.pageChatRender.comboFormat.Text.ToLower()));
+                        if (renderOptions.OutputFile.Trim() == downloadOptions.Filename.Trim())
+                        {
+                            //Just in case VOD and chat paths are the same. Like the previous defaults
+                            renderOptions.OutputFile = Path.ChangeExtension(downloadOptions.Filename.Replace(".gz", ""), " - CHAT." + MainWindow.pageChatRender.comboFormat.Text.ToLower());
+                        }
+                        renderOptions.InputFile = downloadOptions.Filename;
+
+                        ChatRenderTask renderTask = new ChatRenderTask
+                        {
+                            DownloadOptions = renderOptions,
+                            Info =
+                            {
+                                Title = taskData.Title,
+                                Thumbnail = taskData.Thumbnail
+                            },
+                            DependantTask = downloadTask
+                        };
+                        renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(renderTask);
+                        }
+                    }
                 }
             }
+
+            this.DialogResult = true;
+            this.Close();
         }
 
         private void btnFolder_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/WindowRangeSelect.xaml.cs
+++ b/TwitchDownloaderWPF/WindowRangeSelect.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using TwitchDownloaderCore;
@@ -26,8 +27,8 @@ namespace TwitchDownloaderWPF
             startSeconds = (int)Math.Floor(CurrentRender.chatRoot.video.start);
             endSeconds = (int)Math.Ceiling(CurrentRender.chatRoot.video.end);
 
-            numStart.Text = startSeconds.ToString();
-            numEnd.Text = endSeconds.ToString();
+            numStart.Text = startSeconds.ToString(CultureInfo.CurrentCulture);
+            numEnd.Text = endSeconds.ToString(CultureInfo.CurrentCulture);
             rangeTime.Maximum = endSeconds;
             rangeTime.Minimum = startSeconds;
             rangeTime.ValueEnd = endSeconds;
@@ -35,16 +36,16 @@ namespace TwitchDownloaderWPF
 
         private void rangeTime_ValueChanged(object sender, RoutedPropertyChangedEventArgs<HandyControl.Data.DoubleRange> e)
         {
-            numStart.Text = rangeTime.ValueStart.ToString();
-            numEnd.Text = rangeTime.ValueEnd.ToString();
+            numStart.Text = rangeTime.ValueStart.ToString(CultureInfo.CurrentCulture);
+            numEnd.Text = rangeTime.ValueEnd.ToString(CultureInfo.CurrentCulture);
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             try
             {
-                startSeconds = int.Parse(numStart.Text);
-                endSeconds = int.Parse(numEnd.Text);
+                startSeconds = int.Parse(numStart.Text, CultureInfo.CurrentCulture);
+                endSeconds = int.Parse(numEnd.Text, CultureInfo.CurrentCulture);
                 OK = true;
             }
             catch
@@ -54,32 +55,24 @@ namespace TwitchDownloaderWPF
             this.Close();
         }
 
-        private void numStart_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
-        {
-
-        }
-
-        private void numEnd_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
-        {
-
-        }
-
         private void numStart_TextChanged(object sender, TextChangedEventArgs e)
         {
             try
             {
-                rangeTime.ValueStart = int.Parse(numStart.Text);
+                rangeTime.ValueStart = int.Parse(numStart.Text, CultureInfo.CurrentCulture);
             }
-            catch { }
+            catch (FormatException) { }
+            catch (OverflowException) { }
         }
 
         private void numEnd_TextChanged(object sender, TextChangedEventArgs e)
         {
             try
             {
-                rangeTime.ValueEnd = int.Parse(numEnd.Text);
+                rangeTime.ValueEnd = int.Parse(numEnd.Text, CultureInfo.CurrentCulture);
             }
-            catch { }
+            catch (FormatException) { }
+            catch (OverflowException) { }
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -64,7 +64,7 @@
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,7,3,3" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc MaximumThreadBandwidth}" /><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc MaximumThreadBandwidthTooltip}" /></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
-                <CheckBox x:Name="CheckThrottleEnabled" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1, 6, 3, 3" Checked="CheckThrottleEnabled_Checked" Unchecked="CheckThrottleEnabled_Unchecked" BorderBrush="{DynamicResource AppElementBackground}" />
+                <CheckBox x:Name="CheckThrottleEnabled" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1, 6, 3, 3" Checked="CheckThrottleEnabled_Checked" Unchecked="CheckThrottleEnabled_Unchecked" BorderBrush="{DynamicResource AppElementBorder}" />
                 <hc:NumericUpDown x:Name="NumMaximumBandwidth" Value="4096" Minimum="1" Maximum="122070" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                 <TextBlock Margin="3,7,0,0" Text="KiB/s" Foreground="{DynamicResource AppText}" />
             </StackPanel>

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -64,7 +64,7 @@
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,7,3,3" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc MaximumThreadBandwidth}" /><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc MaximumThreadBandwidthTooltip}" /></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
-                <CheckBox x:Name="CheckThrottleEnabled" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1, 6, 3, 3" Checked="CheckThrottleEnabled_Checked" Unchecked="CheckThrottleEnabled_Unchecked" BorderBrush="{DynamicResource AppElementBorder}" />
+                <CheckBox x:Name="CheckThrottleEnabled" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1, 6, 3, 3" Checked="CheckThrottleEnabled_CheckedChanged" Unchecked="CheckThrottleEnabled_CheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
                 <hc:NumericUpDown x:Name="NumMaximumBandwidth" Value="4096" Minimum="1" Maximum="122070" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                 <TextBlock Margin="3,7,0,0" Text="KiB/s" Foreground="{DynamicResource AppText}" />
             </StackPanel>

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -119,11 +119,11 @@ namespace TwitchDownloaderWPF
             Settings.Default.TemplateClip = textClipTemplate.Text;
             Settings.Default.TemplateChat = textChatTemplate.Text;
             Settings.Default.TempPath = textTempPath.Text;
-            Settings.Default.HideDonation = (bool)checkDonation.IsChecked;
-            Settings.Default.VerboseErrors = (bool)checkVerboseErrors.IsChecked;
+            Settings.Default.HideDonation = checkDonation.IsChecked.GetValueOrDefault();
+            Settings.Default.VerboseErrors = checkVerboseErrors.IsChecked.GetValueOrDefault();
             Settings.Default.MaximumBandwidthKib = (int)NumMaximumBandwidth.Value;
-            Settings.Default.UTCVideoTime = (bool)radioTimeFormatUTC.IsChecked;
-            Settings.Default.DownloadThrottleEnabled = (bool)CheckThrottleEnabled.IsChecked;
+            Settings.Default.UTCVideoTime = radioTimeFormatUTC.IsChecked.GetValueOrDefault();
+            Settings.Default.DownloadThrottleEnabled = CheckThrottleEnabled.IsChecked.GetValueOrDefault();
             Settings.Default.Save();
         }
 
@@ -167,7 +167,7 @@ namespace TwitchDownloaderWPF
 
         private void CheckThrottleEnabled_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            NumMaximumBandwidth.IsEnabled = CheckThrottleEnabled.IsChecked!.Value;
+            NumMaximumBandwidth.IsEnabled = CheckThrottleEnabled.IsChecked.GetValueOrDefault();
         }
     }
 }

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -165,14 +165,9 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void CheckThrottleEnabled_Checked(object sender, RoutedEventArgs e)
+        private void CheckThrottleEnabled_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            NumMaximumBandwidth.IsEnabled = true;
-        }
-
-        private void CheckThrottleEnabled_Unchecked(object sender, RoutedEventArgs e)
-        {
-            NumMaximumBandwidth.IsEnabled = false;
+            NumMaximumBandwidth.IsEnabled = CheckThrottleEnabled.IsChecked!.Value;
         }
     }
 }


### PR DESCRIPTION
- Use URIs when fetching thumbnails so they can be properly cached
- Add design time `DataContext`s to `ItemsControl`s so the intellisense warnings go away
- Add ppOverheat loading animation to WindowMassDownload (and decrease video count from 100 to 50 to match clips)
- Fix incorrect border color on bandwidth throttle checkbox that made it impossible to see