### PR TITLE
Better FFmpeg download progress reporting

### DIFF
--- a/TwitchDownloaderCLI/Tools/FfmpegHandler.cs
+++ b/TwitchDownloaderCLI/Tools/FfmpegHandler.cs
@@ -1,7 +1,10 @@
 ﻿using Mono.Unix;
 using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using Xabe.FFmpeg;
 using Xabe.FFmpeg.Downloader;
@@ -24,8 +27,7 @@ namespace TwitchDownloaderCLI.Tools
         {
             Console.Write("[INFO] - Downloading FFmpeg");
 
-            var progressHandler = new Progress<ProgressInfo>();
-            progressHandler.ProgressChanged += new XabeProgressHandler().OnProgressReceived;
+            using var progressHandler = new XabeProgressHandler();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -63,19 +65,40 @@ namespace TwitchDownloaderCLI.Tools
             Environment.Exit(1);
         }
 
-        private class XabeProgressHandler
+        private sealed class XabeProgressHandler : IProgress<ProgressInfo>, IDisposable
         {
             private int _lastPercent = -1;
+            private readonly ConcurrentQueue<int> _percentQueue = new();
+            private readonly Timer _timer;
 
-            internal void OnProgressReceived(object sender, ProgressInfo e)
+            public XabeProgressHandler()
             {
-                var percent = (int)(e.DownloadedBytes / (double)e.TotalBytes * 100);
+                _timer = new Timer(Callback, _percentQueue, 0, 100);
+
+                static void Callback(object state)
+                {
+                    if (state is not ConcurrentQueue<int> { IsEmpty: false } queue) return;
+
+                    var currentPercent = queue.Max();
+                    Console.Write($"\r[INFO] - Downloading FFmpeg {currentPercent}%");
+                }
+            }
+
+            public void Report(ProgressInfo value)
+            {
+                var percent = (int)(value.DownloadedBytes / (double)value.TotalBytes * 100);
 
                 if (percent > _lastPercent)
                 {
                     _lastPercent = percent;
-                    Console.Write($"\r[INFO] - Downloading FFmpeg {percent}%");
+                    _percentQueue.Enqueue(percent);
                 }
+            }
+
+            public void Dispose()
+            {
+                _timer?.Dispose();
+                _percentQueue.Clear();
             }
         }
     }

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -1383,6 +1383,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Downloading FFmpeg {0}%.
+        /// </summary>
+        public static string StatusDownloaderFFmpeg {
+            get {
+                return ResourceManager.GetString("StatusDownloaderFFmpeg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Downloading.
         /// </summary>
         public static string StatusDownloading {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -775,4 +775,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -774,4 +774,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Vidéos par page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -774,4 +774,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -773,4 +773,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -774,4 +774,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -775,4 +775,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh.resx
@@ -773,4 +773,7 @@
   <data name="LabelVideosPerPage" xml:space="preserve">
     <value>Videos per page:</value>
   </data>
+  <data name="StatusDownloaderFFmpeg" xml:space="preserve">
+    <value>Downloading FFmpeg {0}%</value>
+  </data>
 </root>


### PR DESCRIPTION
Add FFmpeg download progress to WPF & move FFmpeg progress writing to a separate thread in CLI so the download isn't stalled by writing to the console