### PR TITLE
Make all windows start in the center of the screen or their parent window

### DIFF
--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -31,7 +31,10 @@ namespace TwitchDownloaderWPF
             var windowsThemeService = new WindowsThemeService();
             ThemeServiceSingleton = new ThemeService(this, windowsThemeService);
 
-            MainWindow = new MainWindow();
+            MainWindow = new MainWindow
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen
+            };
             MainWindow.Show();
         }
 

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -290,7 +290,11 @@ namespace TwitchDownloaderWPF
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -572,7 +576,11 @@ namespace TwitchDownloaderWPF
 
         private void MenuItemEnqueue_Click(object sender, RoutedEventArgs e)
         {
-            WindowQueueOptions queueOptions = new WindowQueueOptions(this);
+            var queueOptions = new WindowQueueOptions(this)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             queueOptions.ShowDialog();
         }
 

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -495,7 +495,11 @@ namespace TwitchDownloaderWPF
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
             SaveSettings();
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -616,7 +620,11 @@ namespace TwitchDownloaderWPF
 
                 if (ReferenceEquals(sender, MenuItemPartialRender))
                 {
-                    WindowRangeSelect window = new WindowRangeSelect(currentRender);
+                    var window = new WindowRangeSelect(currentRender)
+                    {
+                        Owner = Application.Current.MainWindow,
+                        WindowStartupLocation = WindowStartupLocation.CenterOwner
+                    };
                     window.ShowDialog();
 
                     if (window.OK)
@@ -711,7 +719,11 @@ namespace TwitchDownloaderWPF
 
         private void EnqueueRender()
         {
-            var queueOptions = new WindowQueueOptions(this);
+            var queueOptions = new WindowQueueOptions(this)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             queueOptions.ShowDialog();
         }
 

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -354,7 +354,11 @@ namespace TwitchDownloaderWPF
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -645,7 +649,11 @@ namespace TwitchDownloaderWPF
 
         private void MenuItemEnqueue_Click(object sender, RoutedEventArgs e)
         {
-            WindowQueueOptions queueOptions = new WindowQueueOptions(this);
+            var queueOptions = new WindowQueueOptions(this)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             queueOptions.ShowDialog();
         }
     }

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -178,7 +178,11 @@ namespace TwitchDownloaderWPF
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -271,7 +275,11 @@ namespace TwitchDownloaderWPF
 
         private void MenuItemEnqueue_Click(object sender, RoutedEventArgs e)
         {
-            WindowQueueOptions queueOptions = new WindowQueueOptions(this);
+            var queueOptions = new WindowQueueOptions(this)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             queueOptions.ShowDialog();
         }
 

--- a/TwitchDownloaderWPF/PageQueue.xaml.cs
+++ b/TwitchDownloaderWPF/PageQueue.xaml.cs
@@ -119,7 +119,11 @@ namespace TwitchDownloaderWPF
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -167,19 +171,31 @@ namespace TwitchDownloaderWPF
 
         private void btnUrlList_Click(object sender, RoutedEventArgs e)
         {
-            WindowUrlList window = new WindowUrlList();
+            var window = new WindowUrlList
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             window.ShowDialog();
         }
 
         private void btnVods_Click(object sender, RoutedEventArgs e)
         {
-            WindowMassDownload window = new WindowMassDownload(DownloadType.Video);
+            var window = new WindowMassDownload(DownloadType.Video)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             window.ShowDialog();
         }
 
         private void btnClips_Click(object sender, RoutedEventArgs e)
         {
-            WindowMassDownload window = new WindowMassDownload(DownloadType.Clip);
+            var window = new WindowMassDownload(DownloadType.Clip)
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             window.ShowDialog();
         }
 

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -363,7 +363,11 @@ namespace TwitchDownloaderWPF
 
         private void btnSettings_Click(object sender, RoutedEventArgs e)
         {
-            WindowSettings settings = new WindowSettings();
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
@@ -474,7 +478,11 @@ namespace TwitchDownloaderWPF
 
             if (ValidateInputs())
             {
-                WindowQueueOptions queueOptions = new WindowQueueOptions(this);
+                var queueOptions = new WindowQueueOptions(this)
+                {
+                    Owner = Application.Current.MainWindow,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner
+                };
                 queueOptions.ShowDialog();
             }
             else

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -210,7 +210,11 @@ namespace TwitchDownloaderWPF
         {
             if (selectedItems.Count > 0)
             {
-                WindowQueueOptions queue = new WindowQueueOptions(selectedItems);
+                var queue = new WindowQueueOptions(selectedItems)
+                {
+                    Owner = this,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner
+                };
                 if (queue.ShowDialog().GetValueOrDefault())
                     this.Close();
             }

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -156,7 +156,11 @@ namespace TwitchDownloaderWPF
                 return;
             }
 
-            WindowQueueOptions queue = new WindowQueueOptions(dataList);
+            var queue = new WindowQueueOptions(dataList)
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
             if (queue.ShowDialog().GetValueOrDefault())
                 this.Close();
 


### PR DESCRIPTION
This change feels so good to use.

Setting the window owner also fixes another issue where the main window could be brought to the foreground on top of another application but the currently open dialog remained behind said other application.