### PR TITLE
Emit debug symbols alongside CI builds and embedded within release builds

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderWPF
     - name: Build Windows GUI
-      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=Portable
     
     - name: Download FFmpeg To Workspace
       # You may pin to the exact commit or the version.
@@ -61,15 +61,15 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build Windows CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=Portable
     - name: Build Linux CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=Portable
     - name: Build LinuxAlpine CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=Portable
     - name: Build LinuxArm CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=Portable
     - name: Build LinuxArm64 CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm64 -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm64 -p:DebugType=Portable
         
     - name: Zip Windows CLI
       uses: vimtor/action-zip@v1
@@ -143,9 +143,9 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build MacOS CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=Portable
     - name: Build MacOSArm64 CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOSArm64 -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOSArm64 -p:DebugType=Portable
 
     - name: Zip MacOS CLI
       uses: vimtor/action-zip@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderWPF
     - name: Build Windows GUI
-      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderWPF -p:PublishProfile=Windows -p:DebugType=Embedded
     
     - name: Download FFmpeg To Workspace
       # You may pin to the exact commit or the version.
@@ -102,15 +102,15 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build Windows CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Windows -p:DebugType=Embedded
     - name: Build Linux CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=Linux -p:DebugType=Embedded
     - name: Build LinuxAlpine CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxAlpine -p:DebugType=Embedded
     - name: Build LinuxArm CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm -p:DebugType=Embedded
     - name: Build LinuxArm64 CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm64 -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=LinuxArm64 -p:DebugType=Embedded
         
     - name: Zip Windows CLI
       uses: vimtor/action-zip@v1
@@ -215,9 +215,9 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore TwitchDownloaderCLI
     - name: Build MacOS CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOS -p:DebugType=Embedded
     - name: Build MacOSArm64 CLI
-      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOSArm64 -p:DebugType=None -p:DebugSymbols=false
+      run: dotnet publish TwitchDownloaderCLI -p:PublishProfile=MacOSArm64 -p:DebugType=Embedded
       
     - name: Zip MacOS CLI
       uses: vimtor/action-zip@v1


### PR DESCRIPTION
It's not like we're distributing obfuscated closed source code, may as well include the debug symbols for easier diagnosing of field reports.