### PR TITLE
Fix clip downloader sometimes getting stuck when encoding metadata

### DIFF
--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -77,7 +77,7 @@ namespace TwitchDownloaderCore
                 if (!File.Exists(downloadOptions.Filename))
                 {
                     File.Move(tempFile, downloadOptions.Filename);
-                    throw new FileNotFoundException("Unable to serialize metadata (is FFmpeg missing?). The download has been completed without custom metadata.");
+                    _progress.Report(new ProgressReport(ReportType.Log, "Unable to serialize metadata. The download has been completed without custom metadata."));
                 }
 
                 _progress.Report(new ProgressReport(ReportType.SameLineStatus, "Encoding Clip Metadata 100%"));

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -169,6 +169,7 @@ namespace TwitchDownloaderCore
                 };
 
                 process.Start();
+                process.BeginErrorReadLine();
 
                 // If the process has exited before we call WaitForExitAsync, the thread locks up.
                 // This was probably not intended by the .NET team, but it's an issue regardless.


### PR DESCRIPTION
Actually fixes #914 this time, I promise