### PR TITLE
Fix VOD download trimming and quality selection

### DIFF
--- a/TwitchDownloaderCore.Tests/M3U8ExtensionTests.cs
+++ b/TwitchDownloaderCore.Tests/M3U8ExtensionTests.cs
@@ -100,6 +100,30 @@ namespace TwitchDownloaderCore.Tests
         }
 
         [Theory]
+        [InlineData("1080", "1080p60")]
+        [InlineData("1080p", "1080p60")]
+        [InlineData("1080p60", "1080p60")]
+        [InlineData("720p60", "720p60")]
+        [InlineData("foo", "1080p60")]
+        public static void CorrectlyFindsStreamOfQualityFromM3U8ResponseWithoutFramerate(string qualityString, string expectedPath)
+        {
+            var m3u8 = new M3U8(new M3U8.Metadata(), new[]
+            {
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "Source", true, true),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, "avc1.4D401F,mp4a.40.2", (1920, 1080), "chunked", 0),
+                    "1080p60"),
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, "avc1.4D401F,mp4a.40.2", (1280, 720), "720p60", 58.644M),
+                    "720p60"),
+            });
+
+            var selectedQuality = m3u8.GetStreamOfQuality(qualityString);
+            Assert.Equal(expectedPath, selectedQuality.Path);
+        }
+
+        [Theory]
         [InlineData("480p60", "1080p60")]
         [InlineData("852x480p60", "1080p60")]
         [InlineData("Source", "1080p60")]

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -125,7 +125,7 @@ namespace TwitchDownloaderCore.Extensions
         public static M3U8.Stream BestQualityStream(this M3U8 m3u8)
         {
             var source = Array.Find(
-                m3u8.Streams, x => x.MediaInfo.Name.Equals("source", StringComparison.OrdinalIgnoreCase) ||
+                m3u8.Streams, x => x.MediaInfo.Name.Contains("source", StringComparison.OrdinalIgnoreCase) ||
                     x.MediaInfo.GroupId.Equals("chunked", StringComparison.OrdinalIgnoreCase));
             return source ?? m3u8.Streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate);
         }

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -34,7 +34,7 @@ namespace TwitchDownloaderCore.Extensions
 
             if (qualityString is null)
             {
-                return streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate);
+                return m3u8.BestQualityStream();
             }
 
             if (qualityString.Contains("audio", StringComparison.OrdinalIgnoreCase) &&
@@ -57,7 +57,7 @@ namespace TwitchDownloaderCore.Extensions
             var qualityStringMatch = UserQualityStringRegex.Match(qualityString);
             if (!qualityStringMatch.Success)
             {
-                return streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate);
+                return m3u8.BestQualityStream();
             }
 
             var desiredWidth = qualityStringMatch.Groups["Width"];
@@ -74,7 +74,7 @@ namespace TwitchDownloaderCore.Extensions
             {
                 1 => filteredStreams[0],
                 2 when !desiredFramerate.Success => filteredStreams.First(x => Math.Abs(x.StreamInfo.Framerate - 30) <= 2),
-                _ => streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate)
+                _ => m3u8.BestQualityStream()
             };
         }
 
@@ -117,6 +117,15 @@ namespace TwitchDownloaderCore.Extensions
             var frameRate = (uint)(Math.Round(streamInfo.Framerate / 10) * 10);
 
             return $"{frameHeight}p{frameRate}";
+        }
+
+        /// <summary>
+        /// Returns the best quality stream from the provided M3U8.
+        /// </summary>
+        public static M3U8.Stream BestQualityStream(this M3U8 m3u8)
+        {
+            var source = Array.Find(m3u8.Streams, x => x.MediaInfo.Name.Equals("source", StringComparison.OrdinalIgnoreCase));
+            return source ?? m3u8.Streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate);
         }
     }
 }

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -124,7 +124,9 @@ namespace TwitchDownloaderCore.Extensions
         /// </summary>
         public static M3U8.Stream BestQualityStream(this M3U8 m3u8)
         {
-            var source = Array.Find(m3u8.Streams, x => x.MediaInfo.Name.Equals("source", StringComparison.OrdinalIgnoreCase));
+            var source = Array.Find(
+                m3u8.Streams, x => x.MediaInfo.Name.Equals("source", StringComparison.OrdinalIgnoreCase) ||
+                    x.MediaInfo.GroupId.Equals("chunked", StringComparison.OrdinalIgnoreCase));
             return source ?? m3u8.Streams.MaxBy(x => x.StreamInfo.Resolution.Width * x.StreamInfo.Resolution.Height * x.StreamInfo.Framerate);
         }
     }

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -88,7 +88,7 @@ namespace TwitchDownloaderCore
                     .Take(videoListCrop.Start.Value)
                     .Sum(x => x.PartInfo.Duration);
 
-                startOffsetSeconds -= downloadOptions.CropBeginningTime;
+                startOffsetSeconds = downloadOptions.CropBeginningTime - startOffsetSeconds;
                 double seekDuration = Math.Round(downloadOptions.CropEndingTime - downloadOptions.CropBeginningTime);
 
                 string metadataPath = Path.Combine(downloadFolder, "metadata.txt");


### PR DESCRIPTION
Fixes #935, see that for a more detailed discussion.

This also fixes a separate bug with stream quality selection when downloading VODs. Twitch's Usher endpoint to list stream qualities sometimes returns a `1080p60` stream quality with full framerate info, but sometimes that stream is returned as `Source` with no framerate info. Because there was no exact match for the stream name between the quality dropdown and the response when downloading, the logic would fall through to this: https://github.com/lay295/TwitchDownloader/blob/e48a04b2dd07c089cec63380c9814af17a4f36f4/TwitchDownloaderCore/Extensions/M3U8Extensions.cs#L77

However, in this case the framerate is 0 for the `Source` stream, which breaks this calculation. The other streams in the response do have framerate info when this happens, so the second-best quality would be chosen instead (720p60 in my case). This adds a manual override for these `Source` streams so they're always selected as the best quality.