### PR TITLE
Fix M3U8 failing to parse when the application is using certain languages

### DIFF
--- a/TwitchDownloaderCore.Tests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/M3U8Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Globalization;
+using System.Text;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCore.Tests
@@ -7,9 +8,11 @@ namespace TwitchDownloaderCore.Tests
     public class M3U8Tests
     {
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CorrectlyParsesTwitchM3U8OfTransportStreams(bool useStream)
+        [InlineData(false, "en-US")]
+        [InlineData(true, "en-US")]
+        [InlineData(false, "ru-RU")]
+        [InlineData(true, "ru-RU")]
+        public void CorrectlyParsesTwitchM3U8OfTransportStreams(bool useStream, string culture)
         {
             const string ExampleM3U8Twitch =
                 "#EXTM3U" +
@@ -28,6 +31,9 @@ namespace TwitchDownloaderCore.Tests
                 "\n#EXTINF:10.000,\n40.ts\n#EXTINF:10.000,\n41.ts\n#EXTINF:10.000,\n42.ts\n#EXTINF:10.000,\n43.ts\n#EXTINF:10.000,\n44.ts\n#EXTINF:10.000,\n45.ts\n#EXTINF:10.000,\n46.ts\n#EXTINF:10.000,\n47.ts" +
                 "\n#EXTINF:10.000,\n48.ts\n#EXTINF:10.000,\n49.ts\n#EXT-X-ENDLIST";
 
+            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
             M3U8 m3u8;
             if (useStream)
             {
@@ -39,6 +45,8 @@ namespace TwitchDownloaderCore.Tests
             {
                 m3u8 = M3U8.Parse(ExampleM3U8Twitch);
             }
+
+            CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(3u, m3u8.FileMetadata.Version);
             Assert.Equal(10u, m3u8.FileMetadata.StreamTargetDuration);
@@ -59,9 +67,11 @@ namespace TwitchDownloaderCore.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CorrectlyParsesTwitchM3U8OfLiveStreams(bool useStream)
+        [InlineData(false, "en-US")]
+        [InlineData(true, "en-US")]
+        [InlineData(false, "ru-RU")]
+        [InlineData(true, "ru-RU")]
+        public void CorrectlyParsesTwitchM3U8OfLiveStreams(bool useStream, string culture)
         {
             const string ExampleM3U8Twitch =
                 "#EXTM3U" +
@@ -113,6 +123,9 @@ namespace TwitchDownloaderCore.Tests
                 (DateTimeOffset.Parse("2023-09-17T02:32:16.242Z"), 2.000m, true, "https://video-edge-foo.bar.abs.hls.ttvnw.net/v1/segment/hij-567KLM_890.ts")
             };
 
+            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
             M3U8 m3u8;
             if (useStream)
             {
@@ -124,6 +137,8 @@ namespace TwitchDownloaderCore.Tests
             {
                 m3u8 = M3U8.Parse(ExampleM3U8Twitch);
             }
+
+            CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(3u, m3u8.FileMetadata.Version);
             Assert.Equal(5u, m3u8.FileMetadata.StreamTargetDuration);
@@ -146,9 +161,11 @@ namespace TwitchDownloaderCore.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CorrectlyParsesTwitchM3U8OfPlaylists(bool useStream)
+        [InlineData(false, "en-US")]
+        [InlineData(true, "en-US")]
+        [InlineData(false, "ru-RU")]
+        [InlineData(true, "ru-RU")]
+        public void CorrectlyParsesTwitchM3U8OfPlaylists(bool useStream, string culture)
         {
             const string ExampleM3U8Twitch =
                 "#EXTM3U" +
@@ -194,6 +211,9 @@ namespace TwitchDownloaderCore.Tests
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8")
             };
 
+            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
             M3U8 m3u8;
             if (useStream)
             {
@@ -205,6 +225,8 @@ namespace TwitchDownloaderCore.Tests
             {
                 m3u8 = M3U8.Parse(ExampleM3U8Twitch);
             }
+
+            CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(streams.Length, m3u8.Streams.Length);
             Assert.Equivalent(streams[0], m3u8.Streams[0], true);
@@ -252,9 +274,11 @@ namespace TwitchDownloaderCore.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CorrectlyParsesKickM3U8OfTransportStreams(bool useStream)
+        [InlineData(false, "en-US")]
+        [InlineData(true, "en-US")]
+        [InlineData(false, "ru-RU")]
+        [InlineData(true, "ru-RU")]
+        public void CorrectlyParsesKickM3U8OfTransportStreams(bool useStream, string culture)
         {
             const string ExampleM3U8Kick =
                 "#EXTM3U" +
@@ -313,6 +337,9 @@ namespace TwitchDownloaderCore.Tests
                 (DateTimeOffset.Parse("2023-11-16T05:35:07.97Z"), (1506068, 6462876), "506.ts")
             };
 
+            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
             M3U8 m3u8;
             if (useStream)
             {
@@ -324,6 +351,8 @@ namespace TwitchDownloaderCore.Tests
             {
                 m3u8 = M3U8.Parse(ExampleM3U8Kick);
             }
+
+            CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(4u, m3u8.FileMetadata.Version);
             Assert.Equal(2u, m3u8.FileMetadata.StreamTargetDuration);
@@ -343,9 +372,11 @@ namespace TwitchDownloaderCore.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CorrectlyParsesKickM3U8OfPlaylists(bool useStream)
+        [InlineData(false, "en-US")]
+        [InlineData(true, "en-US")]
+        [InlineData(false, "ru-RU")]
+        [InlineData(true, "ru-RU")]
+        public void CorrectlyParsesKickM3U8OfPlaylists(bool useStream, string culture)
         {
             const string ExampleM3U8Kick =
                 "#EXTM3U" +
@@ -386,6 +417,9 @@ namespace TwitchDownloaderCore.Tests
                     "160p30/playlist.m3u8")
             };
 
+            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
             M3U8 m3u8;
             if (useStream)
             {
@@ -397,6 +431,8 @@ namespace TwitchDownloaderCore.Tests
             {
                 m3u8 = M3U8.Parse(ExampleM3U8Kick);
             }
+
+            CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(streams.Length, m3u8.Streams.Length);
             Assert.Equivalent(streams[0], m3u8.Streams[0], true);

--- a/TwitchDownloaderCore/Tools/M3U8.cs
+++ b/TwitchDownloaderCore/Tools/M3U8.cs
@@ -339,10 +339,10 @@ namespace TwitchDownloaderCore.Tools
                     if (separatorIndex == -1)
                         throw new FormatException($"Unable to parse ByteRange from {text}.");
 
-                    if (!uint.TryParse(text[..separatorIndex], out var start))
+                    if (!uint.TryParse(text[..separatorIndex], NumberStyles.Integer, CultureInfo.InvariantCulture, out var start))
                         throw new FormatException($"Unable to parse ByteRange from {text}.");
 
-                    if (!uint.TryParse(text[(separatorIndex + 1)..], out var end))
+                    if (!uint.TryParse(text[(separatorIndex + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var end))
                         throw new FormatException($"Unable to parse ByteRange from {text}.");
 
                     return new ExtByteRange(start, end);
@@ -488,10 +488,10 @@ namespace TwitchDownloaderCore.Tools
                         if (separatorIndex == -1 || separatorIndex == text.Length)
                             throw new FormatException($"Unable to parse Resolution from {text}.");
 
-                        if (!uint.TryParse(text[..separatorIndex], out var width))
+                        if (!uint.TryParse(text[..separatorIndex], NumberStyles.Integer, CultureInfo.InvariantCulture, out var width))
                             throw new FormatException($"Unable to parse Resolution from {text}.");
 
-                        if (!uint.TryParse(text[(separatorIndex + 1)..], out var height))
+                        if (!uint.TryParse(text[(separatorIndex + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var height))
                             throw new FormatException($"Unable to parse Resolution from {text}.");
 
                         return new StreamResolution(width, height);
@@ -716,7 +716,7 @@ namespace TwitchDownloaderCore.Tools
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
 
-                if (int.TryParse(temp, out var intValue))
+                if (int.TryParse(temp, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                     return intValue;
 
                 throw new FormatException($"Unable to parse integer from: {text}");
@@ -727,7 +727,7 @@ namespace TwitchDownloaderCore.Tools
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
 
-                if (uint.TryParse(temp, out var uIntValue))
+                if (uint.TryParse(temp, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uIntValue))
                     return uIntValue;
 
                 throw new FormatException($"Unable to parse integer from: {text}");
@@ -738,7 +738,7 @@ namespace TwitchDownloaderCore.Tools
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
 
-                if (decimal.TryParse(temp, out var decimalValue))
+                if (decimal.TryParse(temp, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue))
                     return decimalValue;
 
                 throw new FormatException($"Unable to parse decimal from: {text}");

--- a/TwitchDownloaderCore/Tools/M3U8.cs
+++ b/TwitchDownloaderCore/Tools/M3U8.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -149,7 +151,7 @@ namespace TwitchDownloaderCore.Tools
             }
             else if (text.StartsWith(PROGRAM_DATE_TIME_KEY))
             {
-                extProgramDateTime = ParsingHelpers.ParseDateTimeOffset(text, PROGRAM_DATE_TIME_KEY);
+                extProgramDateTime = ParsingHelpers.ParseDateTimeOffset(text, PROGRAM_DATE_TIME_KEY, false);
             }
             else if (text.StartsWith(Stream.ExtByteRange.BYTE_RANGE_KEY))
             {
@@ -588,11 +590,11 @@ namespace TwitchDownloaderCore.Tools
 
                         if (text.StartsWith(KEY_PROGRAM_ID))
                         {
-                            streamInfo.ProgramId = ParsingHelpers.ParseIntValue(text, KEY_PROGRAM_ID);
+                            streamInfo.ProgramId = ParsingHelpers.ParseIntValue(text, KEY_PROGRAM_ID, false);
                         }
                         else if (text.StartsWith(KEY_BANDWIDTH))
                         {
-                            streamInfo.Bandwidth = ParsingHelpers.ParseIntValue(text, KEY_BANDWIDTH);
+                            streamInfo.Bandwidth = ParsingHelpers.ParseIntValue(text, KEY_BANDWIDTH, false);
                         }
                         else if (text.StartsWith(KEY_CODECS))
                         {
@@ -608,7 +610,7 @@ namespace TwitchDownloaderCore.Tools
                         }
                         else if (text.StartsWith(KEY_FRAMERATE))
                         {
-                            streamInfo.Framerate = ParsingHelpers.ParseDecimalValue(text, KEY_FRAMERATE);
+                            streamInfo.Framerate = ParsingHelpers.ParseDecimalValue(text, KEY_FRAMERATE, false);
                         }
 
                         var nextIndex = text.UnEscapedIndexOf(',');
@@ -711,7 +713,7 @@ namespace TwitchDownloaderCore.Tools
                 return temp[..closeQuote].ToString();
             }
 
-            public static int ParseIntValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName)
+            public static int ParseIntValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName, bool strict = true)
             {
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
@@ -719,10 +721,13 @@ namespace TwitchDownloaderCore.Tools
                 if (int.TryParse(temp, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                     return intValue;
 
+                if (!strict)
+                    return default;
+
                 throw new FormatException($"Unable to parse integer from: {text}");
             }
 
-            public static uint ParseUIntValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName)
+            public static uint ParseUIntValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName, bool strict = true)
             {
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
@@ -730,10 +735,13 @@ namespace TwitchDownloaderCore.Tools
                 if (uint.TryParse(temp, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uIntValue))
                     return uIntValue;
 
+                if (!strict)
+                    return default;
+
                 throw new FormatException($"Unable to parse integer from: {text}");
             }
 
-            public static decimal ParseDecimalValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName)
+            public static decimal ParseDecimalValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName, bool strict = true)
             {
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
@@ -741,10 +749,13 @@ namespace TwitchDownloaderCore.Tools
                 if (decimal.TryParse(temp, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue))
                     return decimalValue;
 
+                if (!strict)
+                    return default;
+
                 throw new FormatException($"Unable to parse decimal from: {text}");
             }
 
-            public static bool ParseBooleanValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName)
+            public static bool ParseBooleanValue(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName, bool strict = true)
             {
                 var temp = text[keyName.Length..];
 
@@ -759,6 +770,9 @@ namespace TwitchDownloaderCore.Tools
                 if (bool.TryParse(temp, out var booleanValue))
                     return booleanValue;
 
+                if (!strict)
+                    return default;
+
                 throw new FormatException($"Unable to parse boolean from: {text}");
             }
 
@@ -770,13 +784,16 @@ namespace TwitchDownloaderCore.Tools
                 return Stream.ExtStreamInfo.StreamResolution.Parse(temp);
             }
 
-            public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName)
+            public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> text, ReadOnlySpan<char> keyName, bool strict = true)
             {
                 var temp = text[keyName.Length..];
                 temp = temp[..NextKeyStart(temp)];
 
                 if (DateTimeOffset.TryParse(temp, out var dateTimeOffset))
                     return dateTimeOffset;
+
+                if (!strict)
+                    return default;
 
                 throw new FormatException($"Unable to parse DateTimeOffset from: {text}");
             }


### PR DESCRIPTION
- Culture-invariant int/uint/decimal parsing + tests
  - Fixes #933 
- Non-throwing value parsing for non-critical metadata