### PR TITLE
Add preferred quality selector to the mass downloaders

### DIFF
--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -1194,6 +1194,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Preferred Quality:.
+        /// </summary>
+        public static string PreferredQuality {
+            get {
+                return ResourceManager.GetString("PreferredQuality", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Quality:.
         /// </summary>
         public static string Quality {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -815,4 +815,7 @@
     <value>Open folder
 </value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -813,4 +813,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Qualité préférée:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -815,4 +815,7 @@
     <value>Open folder
 </value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -813,4 +813,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -812,4 +812,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -813,4 +813,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -814,4 +814,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -813,4 +813,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh.resx
@@ -812,4 +812,7 @@
   <data name="ContextMenuOpenTaskFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="PreferredQuality" xml:space="preserve">
+    <value>Preferred Quality:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -35,7 +35,7 @@
             </WrapPanel>
             <CheckBox x:Name="checkVideo" Content="{lex:Loc DownloadVideo}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="CheckVideo_OnChecked" Unchecked="CheckVideo_OnChecked" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
             <StackPanel Orientation="Horizontal" Margin="20,5,0,0">
-                <TextBlock x:Name="TextPreferredQuality" Text="{lex:Loc PreferredQuality}" HorizontalAlignment="Right" Margin="5,4,0,0" Foreground="{DynamicResource AppTextDisabled}" />
+                <TextBlock x:Name="TextPreferredQuality" Text="{lex:Loc PreferredQuality}" HorizontalAlignment="Right" Margin="5,5,0,0" Foreground="{DynamicResource AppTextDisabled}" />
                 <ComboBox SelectedIndex="0" x:Name="ComboPreferredQuality" IsEnabled="False" Margin="5,0,0,0" MinWidth="90" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}">
                     <ComboBoxItem Content="Source" />
                     <ComboBoxItem Content="1440p" />

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -35,7 +35,7 @@
             </WrapPanel>
             <CheckBox x:Name="checkVideo" Content="{lex:Loc DownloadVideo}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="CheckVideo_OnChecked" Unchecked="CheckVideo_OnChecked" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
             <StackPanel Orientation="Horizontal" Margin="20,5,0,0">
-                <TextBlock x:Name="TextPreferredQuality" Text="Preferred Quality:" HorizontalAlignment="Right" Margin="5,4,0,0" Foreground="{DynamicResource AppTextDisabled}" />
+                <TextBlock x:Name="TextPreferredQuality" Text="{lex:Loc PreferredQuality}" HorizontalAlignment="Right" Margin="5,4,0,0" Foreground="{DynamicResource AppTextDisabled}" />
                 <ComboBox SelectedIndex="0" x:Name="ComboPreferredQuality" IsEnabled="False" Margin="5,0,0,0" MinWidth="90" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}">
                     <ComboBoxItem Content="Source" />
                     <ComboBoxItem Content="1440p" />

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -48,19 +48,19 @@
                 </ComboBox>
             </StackPanel>
             <CheckBox x:Name="checkChat" Content="{lex:Loc DownloadChat}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="checkChat_Checked" Unchecked="checkChat_Unchecked" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-            <StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="20,5,0,0" Visibility="Visible">
+            <StackPanel Margin="20,0,0,0">
+                <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                     <TextBlock x:Name="TextDownloadFormat" Text="{lex:Loc DownloadFormat}" IsEnabled="False" Margin="5,0,0,0" Foreground="{DynamicResource AppTextDisabled}"/>
                     <RadioButton x:Name="radioJson" IsEnabled="False" IsChecked="True" Content="JSON" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Checked="radioJson_Checked" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     <RadioButton x:Name="radioTxt" IsEnabled="False" Content="TXT" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Checked="radioTxt_Checked" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     <RadioButton x:Name="radioHTML" IsEnabled="False" Content="HTML" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Checked="radioHTML_Checked" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 </StackPanel>
-                <StackPanel x:Name="StackChatCompression" Orientation="Horizontal" Margin="20,5,0,0">
+                <StackPanel x:Name="StackChatCompression" Orientation="Horizontal" Margin="0,5,0,0">
                     <TextBlock x:Name="TextCompression" Text="{lex:Loc ChatCompression}" Margin="5,0,0,0" Foreground="{DynamicResource AppTextDisabled}"/>
                     <RadioButton x:Name="RadioCompressionNone" IsEnabled="False" IsChecked="True" Content="{lex:Loc ChatCompressionNone}" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     <RadioButton x:Name="RadioCompressionGzip" IsEnabled="False" Content="{lex:Loc ChatCompressionGzip}" HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" Background="{DynamicResource AppRadio}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 </StackPanel>
-                <CheckBox x:Name="checkEmbed" IsEnabled="False" Content="{lex:Loc EmbedImages}" HorizontalAlignment="Left" Margin="25,5,0,0" VerticalAlignment="Top" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <CheckBox x:Name="checkEmbed" IsEnabled="False" Content="{lex:Loc EmbedImages}" HorizontalAlignment="Left" Margin="5,5,0,0" VerticalAlignment="Top" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
             </StackPanel>
             <CheckBox x:Name="checkRender" IsEnabled="False" Content="{lex:Loc RenderChat}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <Button x:Name="btnQueue" Content="{lex:Loc AddToQueue}" HorizontalAlignment="Left" Margin="182,-18,0,0" VerticalAlignment="Top" MinWidth="105" Height="45" Click="btnQueue_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -10,7 +10,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="Queue Options" MinHeight="240" Height="240" MinWidth="500" Width="500" Loaded="Window_loaded">
+        Title="Queue Options" MinHeight="280" Height="280" MinWidth="500" Width="500" Loaded="Window_loaded">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />
@@ -33,7 +33,20 @@
                 <TextBox x:Name="textFolder" HorizontalAlignment="Left" Height="23" Margin="3,0,0,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" MinWidth="300" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 <Button x:Name="btnFolder" Content="{lex:Loc Browse}" HorizontalAlignment="Left" Margin="3,0,0,0" VerticalAlignment="Top" MinWidth="60" Click="btnFolder_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
             </WrapPanel>
-            <CheckBox x:Name="checkVideo" Content="{lex:Loc DownloadVideo}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <CheckBox x:Name="checkVideo" Content="{lex:Loc DownloadVideo}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="CheckVideo_OnChecked" Unchecked="CheckVideo_OnChecked" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
+            <StackPanel Orientation="Horizontal" Margin="20,5,0,0">
+                <TextBlock x:Name="TextPreferredQuality" Text="Preferred Quality:" HorizontalAlignment="Right" Margin="5,4,0,0" Foreground="{DynamicResource AppTextDisabled}" />
+                <ComboBox SelectedIndex="0" x:Name="ComboPreferredQuality" IsEnabled="False" Margin="5,0,0,0" MinWidth="90" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}">
+                    <ComboBoxItem Content="Source" />
+                    <ComboBoxItem Content="1440p" />
+                    <ComboBoxItem Content="1080p" />
+                    <ComboBoxItem Content="720p" />
+                    <ComboBoxItem Content="480p" />
+                    <ComboBoxItem Content="360p" />
+                    <ComboBoxItem Content="160p" />
+                    <ComboBoxItem Content="144p" />
+                </ComboBox>
+            </StackPanel>
             <CheckBox x:Name="checkChat" Content="{lex:Loc DownloadChat}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="checkChat_Checked" Unchecked="checkChat_Unchecked" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,5,0,0" Visibility="Visible">

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Tools;
 using TwitchDownloaderWPF.Properties;
@@ -32,6 +31,9 @@ namespace TwitchDownloaderWPF
             string queueFolder = Settings.Default.QueueFolder;
             if (Directory.Exists(queueFolder))
                 textFolder.Text = queueFolder;
+
+            TextPreferredQuality.Visibility = Visibility.Collapsed;
+            ComboPreferredQuality.Visibility = Visibility.Collapsed;
 
             if (page is PageVodDownload or PageClipDownload)
             {
@@ -463,6 +465,7 @@ namespace TwitchDownloaderWPF
                             Oauth = Settings.Default.OAuth,
                             TempFolder = Settings.Default.TempPath,
                             Id = int.Parse(taskData.Id),
+                            Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
                             FfmpegPath = "ffmpeg",
                             CropBeginning = false,
                             CropEnding = false,
@@ -497,6 +500,7 @@ namespace TwitchDownloaderWPF
                         ClipDownloadOptions downloadOptions = new ClipDownloadOptions
                         {
                             Id = taskData.Id,
+                            Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
                             Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, taskData.Title, taskData.Id, taskData.Time, taskData.Streamer,
                                 TimeSpan.Zero, TimeSpan.FromSeconds(taskData.Length), taskData.Views.ToString(), taskData.Game) + ".mp4"),
                             ThrottleKib = Settings.Default.DownloadThrottleEnabled
@@ -682,6 +686,20 @@ namespace TwitchDownloaderWPF
         {
             Title = Translations.Strings.TitleEnqueueOptions;
             App.RequestTitleBarChange();
+        }
+
+        private void CheckVideo_OnChecked(object sender, RoutedEventArgs e)
+        {
+            if (this.IsInitialized)
+            {
+                ComboPreferredQuality.IsEnabled = checkVideo.IsChecked.GetValueOrDefault();
+                try
+                {
+                    var newBrush = (Brush)Application.Current.Resources[checkVideo.IsChecked.GetValueOrDefault() ? "AppText" : "AppTextDisabled"];
+                    TextPreferredQuality.Foreground = newBrush;
+                }
+                catch { /* Ignored */ }
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds a combobox with a handful of predefined quality options to choose from
![image](https://github.com/lay295/TwitchDownloader/assets/72096833/1cddaafd-77f6-4fe6-a207-54297ab64b31)
- If the chosen quality is not found for a given VOD/Clip then it will default to source (like the CLI)
- The quality picker is only available for the VOD/Clip/URL mass downloaders because the pages already have a quality picker that is accurate to the specific video
![image](https://github.com/lay295/TwitchDownloader/assets/72096833/badb1d8d-084a-490a-b8d7-dda058fd8315)
- Resolves #581 