### PR TITLE
Add new options and fixes

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
@@ -15,10 +15,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("compression", Default = ChatCompression.None, HelpText = "Compresses an output json chat file using a specified compression, usually resulting in 40-90% size reductions. Valid values are: None, Gzip.")]
         public ChatCompression Compression { get; set; }
 
-        [Option('b', "beginning", HelpText = "Time in seconds to crop beginning.")]
+        [Option('b', "beginning", HelpText = "Time in seconds where the crop begins.")]
         public double CropBeginningTime { get; set; }
 
-        [Option('e', "ending", HelpText = "Time in seconds to crop ending.")]
+        [Option('e', "ending", HelpText = "Time in seconds where the crop ends.")]
         public double CropEndingTime { get; set; }
 
         [Option('E', "embed-images", Default = false, HelpText = "Embed first party emotes, badges, and cheermotes into the chat download for offline rendering.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -26,10 +26,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('h', "chat-height", Default = 600, HelpText = "Height of chat render.")]
         public int ChatHeight { get; set; }
 
-        [Option('b', "beginning", Default = -1, HelpText = "Time in seconds to crop beginning of the render.")]
+        [Option('b', "beginning", Default = -1, HelpText = "Time in seconds where the crop begins.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", Default = -1, HelpText = "Time in seconds to crop ending of the render.")]
+        [Option('e', "ending", Default = -1, HelpText = "Time in seconds where the crop ends.")]
         public int CropEndingTime { get; set; }
 
         [Option("bttv", Default = true, HelpText = "Enable BTTV emotes.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatUpdateArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatUpdateArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
@@ -21,10 +21,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('R', "replace-embeds", Default = false, HelpText = "Replace all embedded emotes, badges, and cheermotes in the file. All embedded images will be overwritten!")]
         public bool ReplaceEmbeds { get; set; }
 
-        [Option('b', "beginning", Default = -1, HelpText = "New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.")]
+        [Option('b', "beginning", Default = -1, HelpText = "New time in seconds where the chat begins. Comments may be added but not removed. -1 = No crop.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", Default = -1, HelpText = "New time in seconds for chat ending. Comments may be added but not removed. -1 = No crop.")]
+        [Option('e', "ending", Default = -1, HelpText = "New time in seconds where the chat ends. Comments may be added but not removed. -1 = No crop.")]
         public int CropEndingTime { get; set; }
 
         [Option("bttv", Default = true, HelpText = "Enable BTTV embedding in chat download.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -8,16 +8,25 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('u', "id", Required = true, HelpText = "The ID or URL of the VOD to download.")]
         public string Id { get; set; }
 
-        [Option('o', "output", Required = true, HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4 and .m4a.")]
+        [Option('o', "output", Required = false, HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4 and .m4a.")]
         public string OutputFile { get; set; }
 
         [Option('q', "quality", HelpText = "The quality the program will attempt to download.")]
         public string Quality { get; set; }
 
-        [Option('b', "beginning", HelpText = "Time in seconds to crop beginning.")]
+        [Option('K', "cache", Required = false, HelpText = "Keep entire cache folder. Overrides \"-k\".")]
+        public bool KeepCache { get; set; }
+
+        [Option('k', "cache-noparts", Required = false, HelpText = "Keep cache folder except .ts parts.")]
+        public bool KeepCacheNoParts { get; set; }
+
+        [Option('F', "skip-storagecheck", HelpText = "Skip checking for free storage space.")]
+        public bool SkipStorageCheck { get; set; }
+
+        [Option('b', "beginning", HelpText = "Time in seconds where the crop begins.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", HelpText = "Time in seconds to crop ending.")]
+        [Option('e', "ending", HelpText = "Time in seconds where the crop ends.")]
         public int CropEndingTime { get; set; }
 
         [Option('t', "threads", Default = 4, HelpText = "Number of download threads.")]

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
@@ -47,36 +47,28 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
-            if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
-            {
-                if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
-                    inputOptions.OutputFile += ".m4a";
-                else if (char.IsDigit(inputOptions.Quality[0])
-                         || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
-                         || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
-                    inputOptions.OutputFile += ".mp4";
-            }
-
             VideoDownloadOptions downloadOptions = new()
             {
                 DownloadThreads = inputOptions.DownloadThreads,
                 ThrottleKib = inputOptions.ThrottleKib,
                 Id = int.Parse(vodIdMatch.ValueSpan),
                 Oauth = inputOptions.Oauth,
-                Filename = inputOptions.OutputFile,
-                Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
-                {
-                    ".mp4" => inputOptions.Quality,
-                    ".m4a" => "Audio",
-                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
-                },
+                Quality = inputOptions.Quality,
+                KeepCache = inputOptions.KeepCache,
+                KeepCacheNoParts = inputOptions.KeepCacheNoParts,
+                SkipStorageCheck = inputOptions.SkipStorageCheck,
                 CropBeginning = inputOptions.CropBeginningTime > 0.0,
                 CropBeginningTime = inputOptions.CropBeginningTime,
                 CropEnding = inputOptions.CropEndingTime > 0.0,
                 CropEndingTime = inputOptions.CropEndingTime,
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
-                TempFolder = inputOptions.TempFolder
+                TempFolder = string.IsNullOrWhiteSpace(inputOptions.TempFolder) ? Path.GetTempPath() : inputOptions.TempFolder
             };
+
+            if (!string.IsNullOrWhiteSpace(inputOptions.OutputFile))
+            {
+                downloadOptions.Filename = inputOptions.OutputFile;
+            }
 
             return downloadOptions;
         }

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -53,7 +53,7 @@ namespace TwitchDownloaderCLI.Modes
                 ThrottleKib = inputOptions.ThrottleKib,
                 Id = int.Parse(vodIdMatch.ValueSpan),
                 Oauth = inputOptions.Oauth,
-                Quality = inputOptions.Quality,
+                Filename = inputOptions.OutputFile,
                 KeepCache = inputOptions.KeepCache,
                 KeepCacheNoParts = inputOptions.KeepCacheNoParts,
                 SkipStorageCheck = inputOptions.SkipStorageCheck,
@@ -62,12 +62,29 @@ namespace TwitchDownloaderCLI.Modes
                 CropEnding = inputOptions.CropEndingTime > 0.0,
                 CropEndingTime = inputOptions.CropEndingTime,
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
-                TempFolder = string.IsNullOrWhiteSpace(inputOptions.TempFolder) ? Path.GetTempPath() : inputOptions.TempFolder
+                TempFolder = inputOptions.TempFolder
             };
 
             if (!string.IsNullOrWhiteSpace(inputOptions.OutputFile))
             {
                 downloadOptions.Filename = inputOptions.OutputFile;
+
+                if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
+                {
+                    if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
+                        inputOptions.OutputFile += ".m4a";
+                    else if (char.IsDigit(inputOptions.Quality[0])
+                             || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
+                             || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+                        inputOptions.OutputFile += ".mp4";
+                }
+
+                downloadOptions.Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
+                {
+                    ".mp4" => inputOptions.Quality,
+                    ".m4a" => "Audio",
+                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
+                };
             }
 
             return downloadOptions;

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -47,6 +47,16 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
+            if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
+            {
+                if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
+                    inputOptions.OutputFile += ".m4a";
+                else if (char.IsDigit(inputOptions.Quality[0])
+                         || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
+                         || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+                    inputOptions.OutputFile += ".mp4";
+            }
+
             VideoDownloadOptions downloadOptions = new()
             {
                 DownloadThreads = inputOptions.DownloadThreads,
@@ -54,6 +64,12 @@ namespace TwitchDownloaderCLI.Modes
                 Id = int.Parse(vodIdMatch.ValueSpan),
                 Oauth = inputOptions.Oauth,
                 Filename = inputOptions.OutputFile,
+                Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
+                {
+                    ".mp4" => inputOptions.Quality,
+                    ".m4a" => "Audio",
+                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
+                },
                 KeepCache = inputOptions.KeepCache,
                 KeepCacheNoParts = inputOptions.KeepCacheNoParts,
                 SkipStorageCheck = inputOptions.SkipStorageCheck,
@@ -64,28 +80,6 @@ namespace TwitchDownloaderCLI.Modes
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
                 TempFolder = inputOptions.TempFolder
             };
-
-            if (!string.IsNullOrWhiteSpace(inputOptions.OutputFile))
-            {
-                downloadOptions.Filename = inputOptions.OutputFile;
-
-                if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
-                {
-                    if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
-                        inputOptions.OutputFile += ".m4a";
-                    else if (char.IsDigit(inputOptions.Quality[0])
-                             || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
-                             || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
-                        inputOptions.OutputFile += ".mp4";
-                }
-
-                downloadOptions.Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
-                {
-                    ".mp4" => inputOptions.Quality,
-                    ".m4a" => "Audio",
-                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
-                };
-            }
 
             return downloadOptions;
         }

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -22,17 +22,26 @@ Also can concatenate/combine/merge Transport Stream files, either those parts do
 **-u / --id (REQUIRED)**
 The ID or URL of the VOD to download.
 
-**-o / --output (REQUIRED)**
+**-o / --output**
 File the program will output to. File extension will be used to determine download type. Valid extensions are: `.mp4` and `.m4a`.
 
 **-q / --quality**
 The quality the program will attempt to download, for example "1080p60", if not found will download highest quality stream.
 
+**-K / --cache**
+Keep entire cache folder. Overrides "-k".
+
+**-k / --cache-noparts**
+Keep cache folder except .ts parts.
+
+**-F / --skip-storagecheck**
+Skip checking for free storage space.
+
 **-b / --beginning**
-Time in seconds to crop beginning. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
+Time in seconds where the crop begins. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
 
 **-e / --ending**
-Time in seconds to crop ending. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
+Time in seconds where the crop ends. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
 
 Extra example, if I wanted only seconds 3-6 in a 10 second stream I would do `-b 3 -e 6`
 
@@ -94,10 +103,10 @@ File the program will output to. File extension will be used to determine downlo
 (Default: `None`) Compresses an output json chat file using a specified compression, usually resulting in 40-90% size reductions. Valid values are: `None`, `Gzip`. More formats will be supported in the future.
 
 **-b / --beginning**
-Time in seconds to crop beginning. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
+Time in seconds where the crop begins. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
 
 **-e / --ending**
-Time in seconds to crop ending. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
+Time in seconds where the crop ends. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
 
 **-E / --embed-images**
 (Default: `false`) Embed first party emotes, badges, and cheermotes into the download file for offline rendering. Useful for archival purposes, file size will be larger.
@@ -145,10 +154,10 @@ Path to output file. File extension will be used to determine new chat type. Val
 (Default: `false`) Replace all embedded emotes, badges, and cheermotes in the file. All embedded data will be overwritten!
 
 **b / --beginning**
-(Default: `-1`) New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.
+(Default: `-1`) New time in seconds where the chat begins. Comments may be added but not removed. -1 = No crop.
 
 **-e / --ending**
-(Default: `-1`) New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.
+(Default: `-1`) New time in seconds where chat ends. Comments may be added but not removed. -1 = No crop.
 
 **--bttv**
 (Default: `true`) Enable embedding BTTV emotes.
@@ -193,10 +202,10 @@ File the program will output to.
 (Default: `600`) Height of chat render.
 
 **-b / --beginning**
-(Default: `-1`) Time in seconds to crop the beginning of the render.
+(Default: `-1`) Time in seconds where the crop of the render begins.
 
 **-e / --ending**
-(Default: `-1`) Time in seconds to crop the ending of the render.
+(Default: `-1`) Time in seconds where the crop of the render ends.
 
 **--bttv**
 (Default: `true`) Enable BTTV emotes.
@@ -433,6 +442,8 @@ Default true boolean flags must be assigned: `--default-true-flag=false`. Defaul
 For Linux users, ensure both `fontconfig` and `libfontconfig1` are installed. `apt-get install fontconfig libfontconfig1` on Ubuntu.
 
 Some distros, like Linux Alpine, lack fonts for some languages (Arabic, Persian, Thai, etc.) If this is the case for you, install additional fonts families such as [Noto](https://fonts.google.com/noto/specimen/Noto+Sans) or check your distro's wiki page on fonts as it may have an install command for this specific scenario, such as the [Linux Alpine](https://wiki.alpinelinux.org/wiki/Fonts) font page.
+
+When cropping, the part of the file to be retained is the one after the crop starts and before the crop ends. The rest is discarded.
 
 The list file for `tsmerge` may contain relative or absolute paths, with one path per line.
 Alternatively, the list file may also be an M3U8 playlist file.

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -23,7 +23,7 @@ Also can concatenate/combine/merge Transport Stream files, either those parts do
 The ID or URL of the VOD to download.
 
 **-o / --output**
-File the program will output to. File extension will be used to determine download type. Valid extensions are: `.mp4` and `.m4a`.
+File the program will output to. File extension will be used to determine download type if the extension is present. Valid extensions are: `.mp4` and `.m4a`. 
 
 **-q / --quality**
 The quality the program will attempt to download, for example "1080p60", if not found will download highest quality stream.

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -202,10 +202,10 @@ File the program will output to.
 (Default: `600`) Height of chat render.
 
 **-b / --beginning**
-(Default: `-1`) Time in seconds where the crop of the render begins.
+(Default: `-1`) Time in seconds where the crop begins.
 
 **-e / --ending**
-(Default: `-1`) Time in seconds where the crop of the render ends.
+(Default: `-1`) Time in seconds where the crop ends.
 
 **--bttv**
 (Default: `true`) Enable BTTV emotes.

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -23,7 +23,7 @@ Also can concatenate/combine/merge Transport Stream files, either those parts do
 The ID or URL of the VOD to download.
 
 **-o / --output**
-File the program will output to. File extension will be used to determine download type if the extension is present. Valid extensions are: `.mp4` and `.m4a`. 
+File the program will output to. File extension will be used to determine download type if the extension is present. Valid extensions are: `.mp4` and `.m4a`.
 
 **-q / --quality**
 The quality the program will attempt to download, for example "1080p60", if not found will download highest quality stream.

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -530,6 +530,8 @@ namespace TwitchDownloaderCore
                 default:
                     throw new NotSupportedException($"{downloadOptions.DownloadFormat} is not a supported output format.");
             }
+
+            Console.WriteLine();
         }
     }
 }

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -82,6 +82,7 @@ namespace TwitchDownloaderCore
 
                 _progress.Report(new ProgressReport(ReportType.SameLineStatus, "Encoding Clip Metadata 100%"));
                 _progress.Report(new ProgressReport(100));
+                Console.WriteLine();
             }
             finally
             {

--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace TwitchDownloaderCore.Options
@@ -8,6 +8,9 @@ namespace TwitchDownloaderCore.Options
         public int Id { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
+        public bool KeepCache { get; set; }
+        public bool KeepCacheNoParts { get; set; }
+        public bool SkipStorageCheck { get; set; }
         public bool CropBeginning { get; set; }
         public double CropBeginningTime { get; set; }
         public bool CropEnding { get; set; }

--- a/TwitchDownloaderCore/TsMerger.cs
+++ b/TwitchDownloaderCore/TsMerger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -57,6 +57,7 @@ namespace TwitchDownloaderCore
             await CombineVideoParts(fileList, cancellationToken);
 
             _progress.Report(new ProgressReport(100));
+            Console.WriteLine();
         }
 
         private async Task VerifyVideoParts(IReadOnlyCollection<string> fileList, CancellationToken cancellationToken)

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -679,29 +679,29 @@ namespace TwitchDownloaderCore
             switch (throttleKib)
             {
                 case -1:
-                    {
-                        await using var fs = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.Read);
-                        await response.Content.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
-                        break;
-                    }
+                {
+                    await using var fs = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.Read);
+                    await response.Content.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
                 default:
+                {
+                    try
                     {
-                        try
-                        {
-                            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-                            await using var throttledStream = new ThrottledStream(contentStream, throttleKib);
-                            await using var fs = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.Read);
-                            await throttledStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (IOException e) when (e.Message.Contains("EOF"))
-                        {
-                            // If we get an exception for EOF, it may be related to the throttler. Try again without it.
-                            // TODO: Log this somehow
-                            await Task.Delay(2_000, cancellationToken);
-                            goto case -1;
-                        }
-                        break;
+                        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                        await using var throttledStream = new ThrottledStream(contentStream, throttleKib);
+                        await using var fs = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.Read);
+                        await throttledStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
                     }
+                    catch (IOException e) when (e.Message.Contains("EOF"))
+                    {
+                        // If we get an exception for EOF, it may be related to the throttler. Try again without it.
+                        // TODO: Log this somehow
+                        await Task.Delay(2_000, cancellationToken);
+                        goto case -1;
+                    }
+                    break;
+                }
             }
 
             // Reset the cts timer so it can be reused for the next download on this thread.

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -149,7 +149,7 @@ namespace TwitchDownloaderCore
         {
             /*
             Real size of output.ts is higher than videoSizeInBytes the smaller is the duration and the crop percentage,
-            but it's at least 100% of it (above 2.5 hours of duration).
+            but it's at least 100% of it (above 2.5 hours of duration can be considered he same size).
             Real size of output.mp4 is generally 98% of videoSizeInBytes but can be up to 105% for 1 second crop.
             Percentages for output.m4a can be different.
 

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -134,6 +134,7 @@ namespace TwitchDownloaderCore
 
                 _progress.Report(new ProgressReport(ReportType.SameLineStatus, "Finalizing Video 100% [5/5]"));
                 _progress.Report(new ProgressReport(100));
+                Console.WriteLine();
             }
             finally
             {

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -34,7 +34,6 @@ namespace TwitchDownloaderCore
                 string.IsNullOrWhiteSpace(downloadOptions.TempFolder) ? Path.GetTempPath() : downloadOptions.TempFolder,
                 "TwitchDownloader");
             _progress = progress;
-
             _shouldClearCache = !(downloadOptions.KeepCacheNoParts || downloadOptions.KeepCache);
             _shouldGenerateOutputFile = !string.IsNullOrWhiteSpace(downloadOptions.Filename);
             _shouldSkipStorageCheck = downloadOptions.SkipStorageCheck;

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -730,7 +730,6 @@ namespace TwitchDownloaderCore
                         await fs.CopyToAsync(outputStream, cancellationToken).ConfigureAwait(false);
                     }
 
-
                     if (!downloadOptions.KeepCache && downloadOptions.KeepCacheNoParts)
                     {
                         try
@@ -739,7 +738,6 @@ namespace TwitchDownloaderCore
                         }
                         catch { /* If we can't delete, oh well. It could get cleanup up later anyways */ }
                     }
-
                 }
 
                 doneCount++;

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -189,8 +189,8 @@ namespace TwitchDownloaderCore
              */
 
             var videoSizeInBytes = VideoSizeEstimator.EstimateVideoSize(bandwidth,
-                                                                        downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
-                                                                        downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : videoLength);
+                downloadOptions.CropBeginning ? TimeSpan.FromSeconds(downloadOptions.CropBeginningTime) : TimeSpan.Zero,
+                downloadOptions.CropEnding ? TimeSpan.FromSeconds(downloadOptions.CropEndingTime) : videoLength);
             bool keepAllTsParts = downloadOptions.KeepCache;
             var tempFolderDrive = DriveHelper.GetOutputDrive(downloadOptions.TempFolder);
             DriveInfo destinationDrive = _shouldGenerateOutputFile ? DriveHelper.GetOutputDrive(downloadOptions.Filename) : null;


### PR DESCRIPTION
Changes to videodownload:

- Add `-K` option to keep complete cache folder
- Add `-k` option to keep cache folder but .ts parts
- Make `-o` optional to skip converting output.ts to another file
- Add `-F` to skip free space check
- Update space check function but not accurate in certain cases. A few samples included in comment.

Other:

- Explain better `crop beginning` and `crop ending`
- Add a newline after 100% progress to VideoDownloader.cs and TsMerger.cs, other modes may need this. This is to put the shell prompt in a new line after TwitchDownloaderCLI ends, may happen in some cases only.