### PR TITLE
[CLI] New options, fixes, update README

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
@@ -15,10 +15,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("compression", Default = ChatCompression.None, HelpText = "Compresses an output json chat file using a specified compression, usually resulting in 40-90% size reductions. Valid values are: None, Gzip.")]
         public ChatCompression Compression { get; set; }
 
-        [Option('b', "beginning", HelpText = "Time in seconds to crop beginning.")]
+        [Option('b', "beginning", HelpText = "Time in seconds where the crop begins.")]
         public double CropBeginningTime { get; set; }
 
-        [Option('e', "ending", HelpText = "Time in seconds to crop ending.")]
+        [Option('e', "ending", HelpText = "Time in seconds where the crop ends.")]
         public double CropEndingTime { get; set; }
 
         [Option('E', "embed-images", Default = false, HelpText = "Embed first party emotes, badges, and cheermotes into the chat download for offline rendering.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -26,10 +26,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('h', "chat-height", Default = 600, HelpText = "Height of chat render.")]
         public int ChatHeight { get; set; }
 
-        [Option('b', "beginning", Default = -1, HelpText = "Time in seconds to crop beginning of the render.")]
+        [Option('b', "beginning", Default = -1, HelpText = "Time in seconds where the crop begins.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", Default = -1, HelpText = "Time in seconds to crop ending of the render.")]
+        [Option('e', "ending", Default = -1, HelpText = "Time in seconds where the crop ends.")]
         public int CropEndingTime { get; set; }
 
         [Option("bttv", Default = true, HelpText = "Enable BTTV emotes.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatUpdateArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatUpdateArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
@@ -21,10 +21,10 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('R', "replace-embeds", Default = false, HelpText = "Replace all embedded emotes, badges, and cheermotes in the file. All embedded images will be overwritten!")]
         public bool ReplaceEmbeds { get; set; }
 
-        [Option('b', "beginning", Default = -1, HelpText = "New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.")]
+        [Option('b', "beginning", Default = -1, HelpText = "New time in seconds where the chat begins. Comments may be added but not removed. -1 = No crop.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", Default = -1, HelpText = "New time in seconds for chat ending. Comments may be added but not removed. -1 = No crop.")]
+        [Option('e', "ending", Default = -1, HelpText = "New time in seconds where the chat ends. Comments may be added but not removed. -1 = No crop.")]
         public int CropEndingTime { get; set; }
 
         [Option("bttv", Default = true, HelpText = "Enable BTTV embedding in chat download.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ClipDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ClipDownloadArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -19,6 +19,9 @@ namespace TwitchDownloaderCLI.Modes.Arguments
 
         [Option("encode-metadata", Default = true, HelpText = "Uses FFmpeg to add metadata to the clip output file.")]
         public bool? EncodeMetadata { get; set; }
+
+        [Option("tbn", HelpText = "Set specific TBN (time base in AVStream) for output.")]
+        public int SetTbnValue { get; set; }
 
         [Option("ffmpeg-path", HelpText = "Path to FFmpeg executable.")]
         public string FfmpegPath { get; set; }

--- a/TwitchDownloaderCLI/Modes/Arguments/TsMergeArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/TsMergeArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -10,6 +10,9 @@ namespace TwitchDownloaderCLI.Modes.Arguments
 
         [Option('o', "output", Required = true, HelpText = "Path to output file.")]
         public string OutputFile { get; set; }
+
+        [Option('f', "ignore-missing", HelpText = "Ignore missing files listed inside input. Useful when the stream was trimmed.")]
+        public bool IgnoreMissingParts { get; set; }
 
         [Option("banner", Default = true, HelpText = "Displays a banner containing version and copyright information.")]
         public bool? ShowBanner { get; set; }

--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -8,31 +8,46 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('u', "id", Required = true, HelpText = "The ID or URL of the VOD to download.")]
         public string Id { get; set; }
 
-        [Option('o', "output", Required = true, HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4 and .m4a.")]
+        [Option('o', "output", HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4, .m4a.")]
         public string OutputFile { get; set; }
 
-        [Option('q', "quality", HelpText = "The quality the program will attempt to download.")]
+        [Option('q', "quality", HelpText = "The quality the program will attempt to download, like '1080p60'. If '-o' and '-q' are missing will be 'best'.")]
         public string Quality { get; set; }
 
-        [Option('b', "beginning", HelpText = "Time in seconds to crop beginning.")]
+        [Option('p', "parts", HelpText = "Only download playlist.m3u8, metadata.txt and .ts parts to cache folder, and exit. Overrides '-k', '-K', '-o'.")]
+        public bool TsPartsOnly { get; set; }
+
+        [Option('K', "cache", HelpText = "Keep entire cache folder. Overrides '-k'.")]
+        public bool KeepCache { get; set; }
+
+        [Option('k', "cache-noparts", HelpText = "Keep cache folder except .ts parts. Merged 'output.ts' is not considered a part.")]
+        public bool KeepCacheNoParts { get; set; }
+
+        [Option('F', "skip-storagecheck", HelpText = "Skip checking for free storage space.")]
+        public bool SkipStorageCheck { get; set; }
+
+        [Option('b', "beginning", HelpText = "Time in seconds where the crop of the ID begins. May break first GOP.")]
         public int CropBeginningTime { get; set; }
 
-        [Option('e', "ending", HelpText = "Time in seconds to crop ending.")]
+        [Option('e', "ending", HelpText = "Time in seconds where the crop of the ID ends. May break last GOP.")]
         public int CropEndingTime { get; set; }
 
-        [Option('t', "threads", Default = 4, HelpText = "Number of download threads.")]
+        [Option("tbn", HelpText = "Set specific TBN (time base in AVStream) for output.")]
+        public int SetTbnValue { get; set; }
+
+        [Option('t', "threads", Default = 4, HelpText = "Number of simultaneous download threads.")]
         public int DownloadThreads { get; set; }
 
         [Option("bandwidth", Default = -1, HelpText = "The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or -1 for no maximum.")]
         public int ThrottleKib { get; set; }
 
-        [Option("oauth", HelpText = "OAuth access token to download subscriber only VODs. DO NOT SHARE THIS WITH ANYONE.")]
+        [Option('a', "oauth", HelpText = "OAuth access token to download subscriber only VODs. DO NOT SHARE THIS WITH ANYONE.")]
         public string Oauth { get; set; }
 
         [Option("ffmpeg-path", HelpText = "Path to FFmpeg executable.")]
         public string FfmpegPath { get; set; }
 
-        [Option("temp-path", Default = "", HelpText = "Path to temporary caching folder.")]
+        [Option('c', "temp-path", Default = "", HelpText = "Set custom path to temp/cache folder instead of provided by system. Recommended for '-k', '-K', '-p'.")]
         public string TempFolder { get; set; }
 
         [Option("banner", Default = true, HelpText = "Displays a banner containing version and copyright information.")]

--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
@@ -50,6 +50,8 @@ namespace TwitchDownloaderCLI.Modes
                 ThrottleKib = inputOptions.ThrottleKib,
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
                 EncodeMetadata = inputOptions.EncodeMetadata!.Value,
+                SetTbn = inputOptions.SetTbnValue > 0.0,
+                SetTbnValue = inputOptions.SetTbnValue,
                 TempFolder = inputOptions.TempFolder
             };
 

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
@@ -47,36 +47,53 @@ namespace TwitchDownloaderCLI.Modes
                 Environment.Exit(1);
             }
 
-            if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
-            {
-                if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
-                    inputOptions.OutputFile += ".m4a";
-                else if (char.IsDigit(inputOptions.Quality[0])
-                         || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
-                         || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
-                    inputOptions.OutputFile += ".mp4";
-            }
-
             VideoDownloadOptions downloadOptions = new()
             {
                 DownloadThreads = inputOptions.DownloadThreads,
                 ThrottleKib = inputOptions.ThrottleKib,
                 Id = int.Parse(vodIdMatch.ValueSpan),
                 Oauth = inputOptions.Oauth,
-                Filename = inputOptions.OutputFile,
-                Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
-                {
-                    ".mp4" => inputOptions.Quality,
-                    ".m4a" => "Audio",
-                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
-                },
+                TsPartsOnly = inputOptions.TsPartsOnly,
+                KeepCache = inputOptions.KeepCache,
+                KeepCacheNoParts = inputOptions.KeepCacheNoParts,
+                SkipStorageCheck = inputOptions.SkipStorageCheck,
                 CropBeginning = inputOptions.CropBeginningTime > 0.0,
                 CropBeginningTime = inputOptions.CropBeginningTime,
                 CropEnding = inputOptions.CropEndingTime > 0.0,
                 CropEndingTime = inputOptions.CropEndingTime,
+                SetTbn = inputOptions.SetTbnValue > 0.0,
+                SetTbnValue = inputOptions.SetTbnValue,
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
                 TempFolder = inputOptions.TempFolder
             };
+
+            if (!string.IsNullOrWhiteSpace(inputOptions.OutputFile))
+            {
+                if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
+                {
+                    if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
+                        inputOptions.OutputFile += ".m4a";
+                    else if (char.IsDigit(inputOptions.Quality[0])
+                             || inputOptions.Quality.Contains("source", StringComparison.OrdinalIgnoreCase)
+                             || inputOptions.Quality.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+                        inputOptions.OutputFile += ".mp4";
+                }
+
+                downloadOptions.Filename = inputOptions.OutputFile;
+
+                downloadOptions.Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
+                {
+                    ".mp4" => inputOptions.Quality,
+                    ".m4a" => "Audio",
+                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
+                };
+            }
+            else if (string.IsNullOrWhiteSpace(inputOptions.Quality))
+                downloadOptions.Quality = "best";
+            else if (inputOptions.Quality.Contains("audio", StringComparison.OrdinalIgnoreCase))
+                downloadOptions.Quality = "Audio";
+            else
+                downloadOptions.Quality = inputOptions.Quality;
 
             return downloadOptions;
         }

--- a/TwitchDownloaderCLI/Modes/MergeTs.cs
+++ b/TwitchDownloaderCLI/Modes/MergeTs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
@@ -26,7 +26,8 @@ namespace TwitchDownloaderCLI.Modes
             TsMergeOptions mergeOptions = new()
             {
                 OutputFile = inputOptions.OutputFile,
-                InputFile = inputOptions.InputList
+                InputFile = inputOptions.InputList,
+                IgnoreMissingParts = inputOptions.IgnoreMissingParts
             };
 
             return mergeOptions;

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -14,6 +14,16 @@ Also can concatenate/combine/merge Transport Stream files, either those parts do
   - [Example Commands](#example-commands)
   - [Additional Notes](#additional-notes)
 
+### Global arguments
+
+The mode in use must support also the global arguments which are passed to the CLI.
+
+**--banner**
+(Default: `true`) Displays a banner containing version and copyright information.
+
+**--silent**
+(Default: `false`) Suppresses progress console output. `--silent true` implies `--banner false`.
+
 ---
 
 ## Arguments for mode videodownload
@@ -22,34 +32,49 @@ Also can concatenate/combine/merge Transport Stream files, either those parts do
 **-u / --id (REQUIRED)**
 The ID or URL of the VOD to download.
 
-**-o / --output (REQUIRED)**
-File the program will output to. File extension will be used to determine download type. Valid extensions are: `.mp4` and `.m4a`.
+**-o / --output**
+Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4, .m4a.
 
 **-q / --quality**
-The quality the program will attempt to download, for example "1080p60", if not found will download highest quality stream.
+The quality the program will attempt to download, like '1080p60'. If '-o' and '-q' are missing will be 'best'.
+
+**-p / --parts**
+Only download playlist.m3u8, metadata.txt and .ts parts to cache folder, and exit. Overrides '-k', '-K', '-o'.
+
+**-K / --cache**
+Keep entire cache folder. Overrides '-k'.
+
+**-k / --cache-noparts**
+Keep cache folder except .ts parts. Merged 'output.ts' is not considered a part.
+
+**-F / --skip-storagecheck**
+Skip checking for free storage space.
 
 **-b / --beginning**
-Time in seconds to crop beginning. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
+Time in seconds where the crop of the ID begins. May break first GOP. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
 
 **-e / --ending**
-Time in seconds to crop ending. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
+Time in seconds where the crop of the ID ends. May break last GOP. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
 
 Extra example, if I wanted only seconds 3-6 in a 10 second stream I would do `-b 3 -e 6`
 
+**--tbn**
+Set specific TBN (time base in AVStream) for output.
+
 **-t / --threads**
-(Default: `4`) Number of download threads.
+(Default: `4`) Number of simultaneous download threads.
 
 **--bandwidth**
 (Default: `-1`) The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or `-1` for no maximum.
 
-**--oauth**
+**-a / --oauth**
 OAuth access token to download subscriber only VODs. <ins>**DO NOT SHARE YOUR OAUTH TOKEN WITH ANYONE.**</ins>
 
 **--ffmpeg-path**
 Path to FFmpeg executable.
 
-**--temp-path**
-Path to temporary folder for cache.
+**-c / --temp-path**
+Set custom path to temp/cache folder instead of provided by system. Recommended for '-k', '-K', '-p'.
 
 **--banner**
 (Default: `true`) Displays a banner containing version and copyright information.
@@ -71,6 +96,9 @@ The quality the program will attempt to download, for example "1080p60", if not 
 
 **--encode-metadata**
 (Default: `true`) Uses FFmpeg to add metadata to the clip output file.
+
+**--tbn**
+Set specific TBN (time base in AVStream) for output.
 
 **--ffmpeg-path**
 Path to FFmpeg executable.
@@ -94,10 +122,10 @@ File the program will output to. File extension will be used to determine downlo
 (Default: `None`) Compresses an output json chat file using a specified compression, usually resulting in 40-90% size reductions. Valid values are: `None`, `Gzip`. More formats will be supported in the future.
 
 **-b / --beginning**
-Time in seconds to crop beginning. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
+Time in seconds where the crop begins. For example if I had a 10 second stream but only wanted the last 7 seconds of it I would use `-b 3` to skip the first 3 seconds.
 
 **-e / --ending**
-Time in seconds to crop ending. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
+Time in seconds where the crop ends. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
 
 **-E / --embed-images**
 (Default: `false`) Embed first party emotes, badges, and cheermotes into the download file for offline rendering. Useful for archival purposes, file size will be larger.
@@ -145,10 +173,10 @@ Path to output file. File extension will be used to determine new chat type. Val
 (Default: `false`) Replace all embedded emotes, badges, and cheermotes in the file. All embedded data will be overwritten!
 
 **b / --beginning**
-(Default: `-1`) New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.
+(Default: `-1`) New time in seconds where the chat begins. Comments may be added but not removed. -1 = No crop.
 
 **-e / --ending**
-(Default: `-1`) New time in seconds for chat beginning. Comments may be added but not removed. -1 = No crop.
+(Default: `-1`) New time in seconds where chat ends. Comments may be added but not removed. -1 = No crop.
 
 **--bttv**
 (Default: `true`) Enable embedding BTTV emotes.
@@ -193,10 +221,10 @@ File the program will output to.
 (Default: `600`) Height of chat render.
 
 **-b / --beginning**
-(Default: `-1`) Time in seconds to crop the beginning of the render.
+(Default: `-1`) Time in seconds where the crop begins.
 
 **-e / --ending**
-(Default: `-1`) Time in seconds to crop the ending of the render.
+(Default: `-1`) Time in seconds where the crop ends.
 
 **--bttv**
 (Default: `true`) Enable BTTV emotes.
@@ -354,6 +382,9 @@ Path a text file containing the absolute paths of the files to concatenate, sepa
 **-o / --output (REQUIRED)**
 File the program will output to.
 
+**-f / --ignore-missing**
+(Default: `false`) Ignore missing files listed inside input. Useful when the stream was trimmed.
+
 **--banner**
 (Default: `true`) Displays a banner containing version and copyright information.
 
@@ -423,8 +454,9 @@ Print the available options for the VOD downloader
 ---
 
 ## Additional Notes
+#### General
 
-All `--id` inputs will accept either video/clip IDs or full video/clip URLs. i.e. `--id 612942303` or `--id https://twitch.tv/videos/612942303`.
+All `--id` inputs will accept either video/clip IDs or full video/clip URLs. i.e. `--id 612942303`, `--id https://twitch.tv/videos/612942303` or `--id https://www.twitch.tv/videos/799499623?filter=all&sort=views`.
 
 String arguments that contain spaces should be wrapped in either single quotes <kbd>'</kbd> or double quotes <kbd>"</kbd>. i.e. `--output 'my output file.mp4'` or `--output "my output file.mp4"`
 
@@ -434,5 +466,43 @@ For Linux users, ensure both `fontconfig` and `libfontconfig1` are installed. `a
 
 Some distros, like Linux Alpine, lack fonts for some languages (Arabic, Persian, Thai, etc.) If this is the case for you, install additional fonts families such as [Noto](https://fonts.google.com/noto/specimen/Noto+Sans) or check your distro's wiki page on fonts as it may have an install command for this specific scenario, such as the [Linux Alpine](https://wiki.alpinelinux.org/wiki/Fonts) font page.
 
+When cropping, the part of the file to be retained is the one after the crop starts and before the crop ends. The rest is discarded. So in this context 'crop' means 'crop in', while in others could mean 'crop out' and that's the opposite.
+
+The location of the `temp`, `temporary` or `cache` folder, is automatically assigned by the operating system by default. In some operating systems can be difficult or impossible to access by a program different than `TwitchDownloader`, if it's in a private or encrypted area, or if the permissions are limited. Also could cause excessive wear of the internal flash storage. This is why it's recommended to manually set it to a specific place.
+
 The list file for `tsmerge` may contain relative or absolute paths, with one path per line.
 Alternatively, the list file may also be an M3U8 playlist file.
+
+The `Quality` keywords available for the `videodownload` mode are:
+
+- best, source, chunked
+- 1080, 1080p, 1080p60, 1920x1080, 1920x1080p, 1920x1080p60
+- 900, 900p, 900p60, 1600x900, 1600x900p, 1600x900p60
+- 720, 720p, 720p60, 1280x720, 1280x720p, 1280x720p60
+- 480, 480p, 480p60, 640x480, 640x480p, 640x480p60
+- 360, 360p, 360p60, 480x360, 480x360p, 480x360p60
+- 160, 160p, 160p60, 284x160, 284x160p, 284x160p60
+- 144, 144p, 144p60. 256x144, 256x144p, 256x144p60
+- worst
+- audio
+
+The framerate is detected based on the resolution, which is prioritized. If the framerate (like 30, 50, 60, 120 or any other) is manually set, will look for a stream that matches the provided parameters. If that stream does not exist, will default to best.
+The audio stream is also the same audio stream for all video tracks. Twitch does not allow different audio tracks with different qualities for the same VOD ID. But there are different audio qualities to choose from before starting the stream.
+
+#### Trimming and chapters
+
+The mode `videodownload` has the options `-b` and `-e` to trim the output file at the beginning and/or at the end. The values are in whole seconds and relative to the full ID duration. The mode `clipdownload` doesn't have these options.
+
+This trim splits the compressed video outside of I-frames (in copy mode) most of the time, and doesn't recode the affected GOPs, for the sake of speed and simplicity. Twitch streams don't always have I-frames placed at whole second marks (can be like 2.9899 seconds). Sometimes the GOPs can be spaced more than 10 seconds from each other, but usually it's 1.5-2.
+
+As a result of this, the GOP at the beginning and/or the end will be split, leaving that part of it unplayable, until the next I-frame (Intra-Frame or key-Frame) is reached. The audio is not affected, either if it is alone or with video.
+
+This is because Twitch streams use the H.264 (AVC) codec, which is a consumer-only video format designed for efficiency.
+
+So when it's not cut by I-frame, although the audio and the video have the same duration, the playable video is less than the audio, and starts to play after the audio has been already reproducing for a while. Depending on the video player and its version:
+
+- If the output file is only .m4a there's no issue, plays from beginning to end.
+- Some video players play from the very start of the whole file, if at least one of the tracks is playable. They put a black frame on screen while the audio plays until everything is back in sync. `Quick Look` (Mac Spacebar Preview) does this. This is the most conversative approach and it's when people realize their video is broken.
+- Other video players start playing from the timestamp when all tracks can be decoded properly, so they wait until the video can be played, and skip that portion of audio. Some people may never know that there's more audio inside. Forcing to play audio only, like `mpv --no-video output.mp4`, forces to play the entire audio stream.
+
+To avoid losing video content, trim the beginning earlier, and the end later, so all the desired content falls into full GOPs. Chapters are not adjusted relative to trimmed file, `ffmpeg` can't do that automatically.

--- a/TwitchDownloaderCLI/Tools/ProgressHandler.cs
+++ b/TwitchDownloaderCLI/Tools/ProgressHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using TwitchDownloaderCore;
 
 namespace TwitchDownloaderCLI.Tools
@@ -13,6 +13,9 @@ namespace TwitchDownloaderCLI.Tools
             {
                 case ReportType.Log:
                     ReportLog(e);
+                    break;
+                case ReportType.LogWithoutNewlineFirst:
+                    LogWithoutNewlineFirst(e);
                     break;
                 case ReportType.NewLineStatus:
                     ReportNewLineStatus(e);
@@ -31,6 +34,13 @@ namespace TwitchDownloaderCLI.Tools
             var currentStatus = Environment.NewLine + "[LOG] - " + e.Data + Environment.NewLine;
             _previousMessage = currentStatus;
             Console.Write(currentStatus);
+        }
+
+        private static void LogWithoutNewlineFirst(ProgressReport e)
+        {
+            var currentMessage = "[LOG] - " + e.Data;
+            Console.Write(currentMessage + Environment.NewLine);
+            _previousMessage = currentMessage;
         }
 
         private static void ReportNewLineStatus(ProgressReport e)

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -530,6 +530,8 @@ namespace TwitchDownloaderCore
                 default:
                     throw new NotSupportedException($"{downloadOptions.DownloadFormat} is not a supported output format.");
             }
+
+            Console.WriteLine();
         }
     }
 }

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -82,6 +82,7 @@ namespace TwitchDownloaderCore
 
                 _progress.Report(new ProgressReport(ReportType.SameLineStatus, "Encoding Clip Metadata 100%"));
                 _progress.Report(new ProgressReport(100));
+                Console.WriteLine();
             }
             finally
             {
@@ -160,7 +161,7 @@ namespace TwitchDownloaderCore
                     StartInfo =
                     {
                         FileName = downloadOptions.FfmpegPath,
-                        Arguments = $"-i \"{inputFile}\" -i \"{metadataFile}\" -map_metadata 1 -y -c copy \"{destinationFile}\"",
+                        Arguments = $"-i \"{inputFile}\" -i \"{metadataFile}\" -map_metadata 1 -y -c copy {(downloadOptions.SetTbn ? $"-video_track_timescale {downloadOptions.SetTbnValue} " : "")}\"{destinationFile}\"",
                         UseShellExecute = false,
                         CreateNoWindow = true,
                         RedirectStandardInput = false,

--- a/TwitchDownloaderCore/Options/ClipDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ClipDownloadOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace TwitchDownloaderCore.Options
+namespace TwitchDownloaderCore.Options
 {
     public class ClipDownloadOptions
     {
@@ -8,6 +8,8 @@
         public int ThrottleKib { get; set; }
         public string TempFolder { get; set; }
         public bool EncodeMetadata { get; set; }
+        public bool SetTbn { get; set; }
+        public int SetTbnValue { get; set; }
         public string FfmpegPath { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Options/TsMergeOptions.cs
+++ b/TwitchDownloaderCore/Options/TsMergeOptions.cs
@@ -1,8 +1,9 @@
-﻿namespace TwitchDownloaderCore.Options
+namespace TwitchDownloaderCore.Options
 {
     public class TsMergeOptions
     {
         public string OutputFile { get; set; }
         public string InputFile { get; set; }
+        public bool IgnoreMissingParts { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace TwitchDownloaderCore.Options
@@ -8,10 +8,16 @@ namespace TwitchDownloaderCore.Options
         public int Id { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
+        public bool TsPartsOnly { get; set; }
+        public bool KeepCache { get; set; }
+        public bool KeepCacheNoParts { get; set; }
+        public bool SkipStorageCheck { get; set; }
         public bool CropBeginning { get; set; }
         public double CropBeginningTime { get; set; }
         public bool CropEnding { get; set; }
         public double CropEndingTime { get; set; }
+        public bool SetTbn { get; set; }
+        public int SetTbnValue { get; set; }
         public int DownloadThreads { get; set; }
         public int ThrottleKib { get; set; }
         public string Oauth { get; set; }

--- a/TwitchDownloaderCore/ProgressReport.cs
+++ b/TwitchDownloaderCore/ProgressReport.cs
@@ -1,8 +1,9 @@
-﻿namespace TwitchDownloaderCore
+namespace TwitchDownloaderCore
 {
     public enum ReportType
     {
         Log,
+        LogWithoutNewlineFirst,
         Percent,
         NewLineStatus,
         SameLineStatus,


### PR DESCRIPTION
This PR fixes several issues reported by users and adds requested features.

Changes to mode `tsmerge`:

- Fix bug that adds all lines in .m3u8 as files
- Add new option `-f` to ignore files from the playlist that are missing in the filesystem.

Changes to mode `videodownload`:

- Add `-K` option to keep complete cache folder
- Add `-k` option to keep cache folder but .ts parts
- Make `-o` optional to skip converting output.ts to another file
- Add `-F` option to skip free space check
- Add `-p` option to download only .ts parts, metadata.txt and playlist.m3u8 to cache folder
- Add `--tbn` option to set specific tbn to output
- Add short option `-c` for `--temp-path`
- Add short option `-a` for `--oauth`
- Update space check function to report how much space is required when is less than required. Not accurate in certain cases. A few samples included in comment
- Create `playlist.m3u8` and `metadata.txt` during `"Fetching Video Info"`, before downloading any .ts part
- Dynamically adjust the the number of progress bars according to options involved

Changes to mode `clipdownload`:

- Add `--tbn` option to set specific tbn to output

Add a newline after operation is completed, to put the shell prompt in a new line after TwitchDownloaderCLI ends ([starship](https://github.com/starship/starship) adds a new line if needed but this is not standard this is why some people don't realize there's a bug):

- VideoDownloader.cs
- TsMerger.cs
- ChatDownloader.cs
- ChatDownloader.cs

TwitchDownloaderCLI/README.md:

- Explain better crop, crop beginning and crop ending
- Explain better cache storage
- Add global arguments section
- An explanation is still missing to explain that `-b` and `-e` don't cut always by I-frame and what's the issue with that
- An explanation is still missing to explain that `-b` and `-e` don't adjust chapters relative to output mp4/m4a file instead of the whole VOD.

TwitchDownloaderCore/Extensions/M3U8Extensions.cs:

- Add `best` quality to return the same as `chunked` or `source`.
- Add `worst` quality to select the lowest video quality.