### PR TITLE
Fix chat download fail due to null `CommentVideo.creator`

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -145,7 +145,7 @@ namespace TwitchDownloaderCore
                 {
                     _id = oldComment.id,
                     created_at = oldComment.createdAt,
-                    channel_id = video.creator.id,
+                    channel_id = video.creator?.id ?? "", // Deliberate empty string for ChatJson.UpgradeChatJson
                     content_type = "video",
                     content_id = video.id,
                     content_offset_seconds = oldComment.contentOffsetSeconds,


### PR DESCRIPTION
- Fixes #1009 