### PR TITLE
Catch exceptions when fetching images from third party emote providers

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -421,7 +421,7 @@ namespace TwitchDownloaderCore
 
                 // This is the exact same process as in ChatUpdater.cs but not in a task oriented manner
                 // TODO: Combine this with ChatUpdater in a different file
-                List<TwitchEmote> thirdPartyEmotes = await TwitchHelper.GetThirdPartyEmotes(chatRoot.comments, chatRoot.streamer.id, downloadOptions.TempFolder, bttv: downloadOptions.BttvEmotes, ffz: downloadOptions.FfzEmotes, stv: downloadOptions.StvEmotes, cancellationToken: cancellationToken);
+                List<TwitchEmote> thirdPartyEmotes = await TwitchHelper.GetThirdPartyEmotes(chatRoot.comments, chatRoot.streamer.id, downloadOptions.TempFolder, bttv: downloadOptions.BttvEmotes, ffz: downloadOptions.FfzEmotes, stv: downloadOptions.StvEmotes, progress: progress, cancellationToken: cancellationToken);
                 List<TwitchEmote> firstPartyEmotes = await TwitchHelper.GetEmotes(chatRoot.comments, downloadOptions.TempFolder, cancellationToken: cancellationToken);
                 List<ChatBadge> twitchBadges = await TwitchHelper.GetChatBadges(chatRoot.comments, chatRoot.streamer.id, downloadOptions.TempFolder, cancellationToken: cancellationToken);
                 List<CheerEmote> twitchBits = await TwitchHelper.GetBits(chatRoot.comments, downloadOptions.TempFolder, chatRoot.streamer.id.ToString(), cancellationToken: cancellationToken);

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1657,7 +1657,7 @@ namespace TwitchDownloaderCore
         private async Task<List<TwitchEmote>> GetScaledThirdEmotes(CancellationToken cancellationToken)
         {
             var emoteThirdTask = await TwitchHelper.GetThirdPartyEmotes(chatRoot.comments, chatRoot.streamer.id, renderOptions.TempFolder, chatRoot.embeddedData, renderOptions.BttvEmotes, renderOptions.FfzEmotes,
-                renderOptions.StvEmotes, renderOptions.AllowUnlistedEmotes, renderOptions.Offline, cancellationToken);
+                renderOptions.StvEmotes, renderOptions.AllowUnlistedEmotes, renderOptions.Offline, _progress, cancellationToken);
 
             foreach (var emote in emoteThirdTask)
             {

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -271,7 +271,7 @@ namespace TwitchDownloaderCore
 
         private async Task ThirdPartyEmoteTask(IProgress<ProgressReport> progress = null, CancellationToken cancellationToken = default)
         {
-            List<TwitchEmote> thirdPartyEmoteList = await TwitchHelper.GetThirdPartyEmotes(chatRoot.comments, chatRoot.streamer.id, _updateOptions.TempFolder, _updateOptions.ReplaceEmbeds ? null : chatRoot.embeddedData, _updateOptions.BttvEmotes, _updateOptions.FfzEmotes, _updateOptions.StvEmotes, cancellationToken: cancellationToken);
+            List<TwitchEmote> thirdPartyEmoteList = await TwitchHelper.GetThirdPartyEmotes(chatRoot.comments, chatRoot.streamer.id, _updateOptions.TempFolder, _updateOptions.ReplaceEmbeds ? null : chatRoot.embeddedData, _updateOptions.BttvEmotes, _updateOptions.FfzEmotes, _updateOptions.StvEmotes, progress: progress, cancellationToken: cancellationToken);
 
             int inputCount = chatRoot.embeddedData.thirdParty.Count;
             chatRoot.embeddedData.thirdParty = new List<EmbedEmoteData>();

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -390,7 +390,7 @@ namespace TwitchDownloaderCore
                 }
                 catch (HttpRequestException e) when (progress != null)
                 {
-                    progress.Report(new ProgressReport(ReportType.Log, $"BTTV returned HTTP {e.StatusCode}. BTTV emotes may not be present for this session."));
+                    progress.Report(new ProgressReport(ReportType.Log, $"BetterTTV returned HTTP {e.StatusCode}. BTTV emotes may not be present for this session."));
                 }
             }
 
@@ -404,7 +404,8 @@ namespace TwitchDownloaderCore
                 }
                 catch (HttpRequestException e) when (progress != null)
                 {
-                    progress.Report(new ProgressReport(ReportType.Log, $"FFZ returned HTTP {e.StatusCode}. FFZ emotes may not be present for this session."));
+                    // We use the BetterTTV proxy of the FFZ API
+                    progress.Report(new ProgressReport(ReportType.Log, $"BetterTTV returned HTTP {e.StatusCode}. FFZ emotes may not be present for this session."));
                 }
             }
 

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -390,7 +390,7 @@ namespace TwitchDownloaderCore
                 }
                 catch (HttpRequestException e) when (progress != null)
                 {
-                    progress.Report(new ProgressReport(ReportType.Log, $"BTTV returned HTTP {e.StatusCode}. BTTV emotes may be disabled for this session."));
+                    progress.Report(new ProgressReport(ReportType.Log, $"BTTV returned HTTP {e.StatusCode}. BTTV emotes may not be present for this session."));
                 }
             }
 
@@ -404,7 +404,7 @@ namespace TwitchDownloaderCore
                 }
                 catch (HttpRequestException e) when (progress != null)
                 {
-                    progress.Report(new ProgressReport(ReportType.Log, $"FFZ returned HTTP {e.StatusCode}. FFZ emotes may be disabled for this session."));
+                    progress.Report(new ProgressReport(ReportType.Log, $"FFZ returned HTTP {e.StatusCode}. FFZ emotes may not be present for this session."));
                 }
             }
 
@@ -418,7 +418,7 @@ namespace TwitchDownloaderCore
                 }
                 catch (HttpRequestException e) when (progress != null)
                 {
-                    progress.Report(new ProgressReport(ReportType.Log, $"7TV returned HTTP {e.StatusCode}. 7TV emotes may be disabled for this session."));
+                    progress.Report(new ProgressReport(ReportType.Log, $"7TV returned HTTP {e.StatusCode}. 7TV emotes may not be present for this session."));
                 }
             }
 

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -388,8 +388,13 @@ namespace TwitchDownloaderCore
                 {
                     await FetchEmoteImages(comments, emoteDataResponse.BTTV, returnList, alreadyAdded, bttvFolder, cancellationToken);
                 }
-                catch (HttpRequestException e) when (progress != null)
+                catch (HttpRequestException e)
                 {
+                    if (progress is null)
+                    {
+                        throw new Exception($"BTTV returned HTTP {e.StatusCode}. See inner exception.", e);
+                    }
+
                     progress.Report(new ProgressReport(ReportType.Log, $"BetterTTV returned HTTP {e.StatusCode}. BTTV emotes may not be present for this session."));
                 }
             }
@@ -402,10 +407,14 @@ namespace TwitchDownloaderCore
                 {
                     await FetchEmoteImages(comments, emoteDataResponse.FFZ, returnList, alreadyAdded, ffzFolder, cancellationToken);
                 }
-                catch (HttpRequestException e) when (progress != null)
+                catch (HttpRequestException e)
                 {
-                    // We use the BetterTTV proxy of the FFZ API
-                    progress.Report(new ProgressReport(ReportType.Log, $"BetterTTV returned HTTP {e.StatusCode}. FFZ emotes may not be present for this session."));
+                    if (progress is null)
+                    {
+                        throw new Exception($"FFZ returned HTTP {e.StatusCode}. See inner exception.", e);
+                    }
+
+                    progress.Report(new ProgressReport(ReportType.Log, $"FFZ returned HTTP {e.StatusCode}. FFZ emotes may not be present for this session."));
                 }
             }
 
@@ -417,8 +426,13 @@ namespace TwitchDownloaderCore
                 {
                     await FetchEmoteImages(comments, emoteDataResponse.STV, returnList, alreadyAdded, stvFolder, cancellationToken);
                 }
-                catch (HttpRequestException e) when (progress != null)
+                catch (HttpRequestException e)
                 {
+                    if (progress is null)
+                    {
+                        throw new Exception($"7TV returned HTTP {e.StatusCode}. See inner exception.", e);
+                    }
+
                     progress.Report(new ProgressReport(ReportType.Log, $"7TV returned HTTP {e.StatusCode}. 7TV emotes may not be present for this session."));
                 }
             }

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -344,7 +344,7 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
-        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(List<Comment> comments, int streamerId, string cacheFolder, EmbeddedData embeddedData = null, bool bttv = true, bool ffz = true, bool stv = true, bool allowUnlistedEmotes = true, bool offline = false, CancellationToken cancellationToken = new())
+        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(List<Comment> comments, int streamerId, string cacheFolder, EmbeddedData embeddedData = null, bool bttv = true, bool ffz = true, bool stv = true, bool allowUnlistedEmotes = true, bool offline = false, IProgress<ProgressReport> progress = null, CancellationToken cancellationToken = default)
         {
             List<TwitchEmote> returnList = new List<TwitchEmote>();
             List<string> alreadyAdded = new List<string>();
@@ -384,21 +384,42 @@ namespace TwitchDownloaderCore
 
             if (bttv)
             {
-                await FetchEmoteImages(comments, emoteDataResponse.BTTV, returnList, alreadyAdded, bttvFolder, cancellationToken);
+                try
+                {
+                    await FetchEmoteImages(comments, emoteDataResponse.BTTV, returnList, alreadyAdded, bttvFolder, cancellationToken);
+                }
+                catch (HttpRequestException e) when (progress != null)
+                {
+                    progress.Report(new ProgressReport(ReportType.Log, $"BTTV returned HTTP {e.StatusCode}. BTTV emotes may be disabled for this session."));
+                }
             }
 
             cancellationToken.ThrowIfCancellationRequested();
 
             if (ffz)
             {
-                await FetchEmoteImages(comments, emoteDataResponse.FFZ, returnList, alreadyAdded, ffzFolder, cancellationToken);
+                try
+                {
+                    await FetchEmoteImages(comments, emoteDataResponse.FFZ, returnList, alreadyAdded, ffzFolder, cancellationToken);
+                }
+                catch (HttpRequestException e) when (progress != null)
+                {
+                    progress.Report(new ProgressReport(ReportType.Log, $"FFZ returned HTTP {e.StatusCode}. FFZ emotes may be disabled for this session."));
+                }
             }
 
             cancellationToken.ThrowIfCancellationRequested();
 
             if (stv)
             {
-                await FetchEmoteImages(comments, emoteDataResponse.STV, returnList, alreadyAdded, stvFolder, cancellationToken);
+                try
+                {
+                    await FetchEmoteImages(comments, emoteDataResponse.STV, returnList, alreadyAdded, stvFolder, cancellationToken);
+                }
+                catch (HttpRequestException e) when (progress != null)
+                {
+                    progress.Report(new ProgressReport(ReportType.Log, $"7TV returned HTTP {e.StatusCode}. 7TV emotes may be disabled for this session."));
+                }
             }
 
             return returnList;


### PR DESCRIPTION
~~Due to an abundance of 403s from 7TV,~~ instead of outright failing, we will instead log a message that a given provider returned HTTP 400-500 and continue execution.

- Fixes #1013 