### PR TITLE
Fix NRE when downloading clips from deleted channels

### DIFF
--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -150,7 +150,7 @@ namespace TwitchDownloaderCore
             Process process = null;
             try
             {
-                await FfmpegMetadata.SerializeAsync(metadataFile, clipMetadata.broadcaster.displayName, downloadOptions.Id, clipMetadata.title, clipMetadata.createdAt, clipMetadata.viewCount,
+                await FfmpegMetadata.SerializeAsync(metadataFile, clipMetadata.broadcaster?.displayName, downloadOptions.Id, clipMetadata.title, clipMetadata.createdAt, clipMetadata.viewCount,
                     videoMomentEdges: new[] { clipChapter }, cancellationToken: cancellationToken);
 
                 process = new Process

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -30,7 +30,8 @@ namespace TwitchDownloaderCore.Tools
         {
             await sw.WriteLineAsync(";FFMETADATA1");
             await sw.WriteLineAsync($"title={SanitizeKeyValue(videoTitle)} ({SanitizeKeyValue(videoId)})");
-            await sw.WriteLineAsync($"artist={SanitizeKeyValue(streamerName)}");
+            if (!string.IsNullOrWhiteSpace(streamerName))
+                await sw.WriteLineAsync($"artist={SanitizeKeyValue(streamerName)}");
             await sw.WriteLineAsync($"date={videoCreation:yyyy}"); // The 'date' key becomes 'year' in most formats
             await sw.WriteAsync(@"comment=");
             if (!string.IsNullOrWhiteSpace(videoDescription))

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -133,7 +133,7 @@ namespace TwitchDownloaderWPF
                     currentVideoTime = Settings.Default.UTCVideoTime ? videoTime : videoTime.ToLocalTime();
                     streamerId = int.Parse(videoInfo.data.video.owner.id);
                     viewCount = videoInfo.data.video.viewCount;
-                    game = videoInfo.data.video.game?.displayName ?? "Unknown";
+                    game = videoInfo.data.video.game?.displayName ?? Translations.Strings.UnknownGame;
                     var urlTimeCodeMatch = TwitchRegex.UrlTimeCode.Match(textUrl.Text);
                     if (urlTimeCodeMatch.Success)
                     {
@@ -172,7 +172,7 @@ namespace TwitchDownloaderWPF
                     imgThumbnail.Source = image;
 
                     TimeSpan clipLength = TimeSpan.FromSeconds(clipInfo.data.clip.durationSeconds);
-                    textStreamer.Text = clipInfo.data.clip.broadcaster?.displayName ?? "Unknown User";
+                    textStreamer.Text = clipInfo.data.clip.broadcaster?.displayName ?? Translations.Strings.UnknownUser;
                     var clipCreatedAt = clipInfo.data.clip.createdAt;
                     textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                     currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -172,12 +172,12 @@ namespace TwitchDownloaderWPF
                     imgThumbnail.Source = image;
 
                     TimeSpan clipLength = TimeSpan.FromSeconds(clipInfo.data.clip.durationSeconds);
-                    textStreamer.Text = clipInfo.data.clip.broadcaster.displayName;
+                    textStreamer.Text = clipInfo.data.clip.broadcaster?.displayName ?? "Unknown User";
                     var clipCreatedAt = clipInfo.data.clip.createdAt;
                     textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                     currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();
                     textTitle.Text = clipInfo.data.clip.title;
-                    streamerId = int.Parse(clipInfo.data.clip.broadcaster.id);
+                    streamerId = int.Parse(clipInfo.data.clip.broadcaster?.id ?? "-1");
                     labelLength.Text = clipLength.ToString("c");
                     SetEnabled(true, true);
                     SetEnabledTrimStart(false);

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -107,11 +107,11 @@ namespace TwitchDownloaderWPF
             VideoLength = TimeSpan.FromSeconds(double.IsNegative(ChatJsonInfo.video.length) ? 0.0 : ChatJsonInfo.video.length);
             labelLength.Text = VideoLength.Seconds > 0
                 ? VideoLength.ToString("c")
-                : Translations.Strings.Unknown;
+                : Translations.Strings.UnknownVideoLength;
 
             VideoId = ChatJsonInfo.video.id ?? ChatJsonInfo.comments.FirstOrDefault()?.content_id ?? "-1";
             ViewCount = ChatJsonInfo.video.viewCount;
-            Game = ChatJsonInfo.video.game ?? ChatJsonInfo.video.chapters.FirstOrDefault()?.gameDisplayName ?? "Unknown";
+            Game = ChatJsonInfo.video.game ?? ChatJsonInfo.video.chapters.FirstOrDefault()?.gameDisplayName ?? Translations.Strings.UnknownGame;
 
             try
             {

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -71,7 +71,7 @@ namespace TwitchDownloaderWPF
                 imgThumbnail.Source = image;
 
                 clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
-                textStreamer.Text = clipData.data.clip.broadcaster.displayName;
+                textStreamer.Text = clipData.data.clip.broadcaster?.displayName ?? "Unknown User";
                 var clipCreatedAt = clipData.data.clip.createdAt;
                 textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                 currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -71,14 +71,14 @@ namespace TwitchDownloaderWPF
                 imgThumbnail.Source = image;
 
                 clipLength = TimeSpan.FromSeconds(taskClipInfo.Result.data.clip.durationSeconds);
-                textStreamer.Text = clipData.data.clip.broadcaster?.displayName ?? "Unknown User";
+                textStreamer.Text = clipData.data.clip.broadcaster?.displayName ?? Translations.Strings.UnknownUser;
                 var clipCreatedAt = clipData.data.clip.createdAt;
                 textCreatedAt.Text = Settings.Default.UTCVideoTime ? clipCreatedAt.ToString(CultureInfo.CurrentCulture) : clipCreatedAt.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                 currentVideoTime = Settings.Default.UTCVideoTime ? clipCreatedAt : clipCreatedAt.ToLocalTime();
                 textTitle.Text = clipData.data.clip.title;
                 labelLength.Text = clipLength.ToString("c");
                 viewCount = taskClipInfo.Result.data.clip.viewCount;
-                game = taskClipInfo.Result.data.clip.game?.displayName ?? "Unknown";
+                game = taskClipInfo.Result.data.clip.game?.displayName ?? Translations.Strings.UnknownGame;
 
                 foreach (var quality in taskLinks.Result.data.clip.videoQualities)
                 {

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -163,7 +163,7 @@ namespace TwitchDownloaderWPF
                 numEndSecond.Value = vodLength.Seconds;
                 labelLength.Text = vodLength.ToString("c");
                 viewCount = taskVideoInfo.Result.data.video.viewCount;
-                game = taskVideoInfo.Result.data.video.game?.displayName ?? "Unknown";
+                game = taskVideoInfo.Result.data.video.game?.displayName ?? Translations.Strings.UnknownGame;
 
                 UpdateVideoSizeEstimates();
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -2112,6 +2112,33 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unknown Game.
+        /// </summary>
+        public static string UnknownGame {
+            get {
+                return ResourceManager.GetString("UnknownGame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown User.
+        /// </summary>
+        public static string UnknownUser {
+            get {
+                return ResourceManager.GetString("UnknownUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown.
+        /// </summary>
+        public static string UnknownVideoLength {
+            get {
+                return ResourceManager.GetString("UnknownVideoLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update.
         /// </summary>
         public static string Update {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -862,4 +862,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -861,4 +861,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -862,4 +862,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -860,4 +860,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>フォルダを開く</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -861,4 +861,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -860,4 +860,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -860,4 +860,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -861,4 +861,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -862,4 +862,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -861,4 +861,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh.resx
@@ -860,4 +860,13 @@
   <data name="ContextMenuOpenFolder" xml:space="preserve">
     <value>Open folder</value>
   </data>
+  <data name="UnknownUser" xml:space="preserve">
+    <value>Unknown User</value>
+  </data>
+  <data name="UnknownGame" xml:space="preserve">
+    <value>Unknown Game</value>
+  </data>
+  <data name="UnknownVideoLength" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -103,7 +103,7 @@ namespace TwitchDownloaderWPF
                             Time = Settings.Default.UTCVideoTime ? video.node.createdAt : video.node.createdAt.ToLocalTime(),
                             Views = video.node.viewCount,
                             Streamer = currentChannel,
-                            Game = video.node.game?.displayName ?? "Unknown",
+                            Game = video.node.game?.displayName ?? Translations.Strings.UnknownGame,
                             Thumbnail = thumbnail
                         });
                     }
@@ -145,7 +145,7 @@ namespace TwitchDownloaderWPF
                             Time = Settings.Default.UTCVideoTime ? clip.node.createdAt : clip.node.createdAt.ToLocalTime(),
                             Views = clip.node.viewCount,
                             Streamer = currentChannel,
-                            Game = clip.node.game?.displayName ?? "Unknown",
+                            Game = clip.node.game?.displayName ?? Translations.Strings.UnknownGame,
                             Thumbnail = thumbnail
                         });
                     }

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -101,7 +101,7 @@ namespace TwitchDownloaderWPF
                         Streamer = videoInfo.owner.displayName,
                         Time = Settings.Default.UTCVideoTime ? videoInfo.createdAt : videoInfo.createdAt.ToLocalTime(),
                         Views = videoInfo.viewCount,
-                        Game = videoInfo.game?.displayName ?? "Unknown",
+                        Game = videoInfo.game?.displayName ?? Translations.Strings.UnknownGame,
                         Length = videoInfo.lengthSeconds
                     });
                 }
@@ -139,7 +139,7 @@ namespace TwitchDownloaderWPF
                         Streamer = clipInfo.broadcaster.displayName,
                         Time = Settings.Default.UTCVideoTime ? clipInfo.createdAt : clipInfo.createdAt.ToLocalTime(),
                         Views = clipInfo.viewCount,
-                        Game = clipInfo.game?.displayName ?? "Unknown",
+                        Game = clipInfo.game?.displayName ?? Translations.Strings.UnknownGame,
                         Length = clipInfo.durationSeconds
                     });
                 }


### PR DESCRIPTION
Apparently Twitch doesn't purge clips from deleted channels.