### PR TITLE
Rename chat connections to download threads

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -38,7 +38,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         public TimestampFormat TimeFormat { get; set; }
 
         [Option('t', "threads", Default = 4, HelpText = "Number of parallel download threads. Large values may result in IP rate limiting.")]
-        public int ChatConnections { get; set; }
+        public int DownloadThreads { get; set; }
 
         [Option("silent", Default = false, HelpText = "Suppresses progress console output")]
         public bool Silent { get; set; }

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -37,7 +37,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("timestamp-format", Default = TimestampFormat.Relative, HelpText = "Sets the timestamp format for .txt chat logs. Valid values are: Utc, UtcFull, Relative, and None")]
         public TimestampFormat TimeFormat { get; set; }
 
-        [Option("chat-connections", Default = 4, HelpText = "Number of downloading connections for chat")]
+        [Option('t', "threads", Default = 4, HelpText = "Number of parallel download threads. Large values may result in IP rate limiting.")]
         public int ChatConnections { get; set; }
 
         [Option("silent", Default = false, HelpText = "Suppresses progress console output")]

--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -21,7 +21,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('e', "ending", HelpText = "Time to trim ending. Can be milliseconds (#ms), seconds (#s), minutes (#m), hours (#h), or time (##:##:##).")]
         public TimeDuration TrimEndingTime { get; set; }
 
-        [Option('t', "threads", Default = 4, HelpText = "Number of download threads.")]
+        [Option('t', "threads", Default = 4, HelpText = "Number of parallel download threads. Large values may result in IP rate limiting.")]
         public int DownloadThreads { get; set; }
 
         [Option("bandwidth", Default = -1, HelpText = "The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or -1 for no maximum.")]

--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -59,7 +59,7 @@ namespace TwitchDownloaderCLI.Modes
                     : inputOptions.OutputFile,
                 Compression = inputOptions.Compression,
                 TimeFormat = inputOptions.TimeFormat,
-                ConnectionCount = inputOptions.ChatConnections,
+                DownloadThreads = inputOptions.DownloadThreads,
                 Silent = inputOptions.Silent,
                 BttvEmotes = (bool)inputOptions.BttvEmotes!,
                 FfzEmotes = (bool)inputOptions.FfzEmotes!,

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -52,7 +52,7 @@ Time to trim beginning. See [Time durations](#time-durations) for a more detaile
 Time to trim ending. See [Time durations](#time-durations) for a more detailed explanation.
 
 **-t / --threads**
-(Default: `4`) Number of download threads.
+(Default: `4`) Number of parallel download threads. Large values may result in IP rate limiting.
 
 **--bandwidth**
 (Default: `-1`) The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or `-1` for no maximum.
@@ -123,8 +123,8 @@ Time to trim ending. See [Time durations](#time-durations) for a more detailed e
 **--timestamp-format**
 (Default: `Relative`) Sets the timestamp format for .txt chat logs. Valid values are: `Utc`, `UtcFull`, `Relative`, and `None`.
 
-**--chat-connections**
-(Default: `4`) The number of parallel downloads for chat.
+**-t / --threads**
+(Default: `4`) Number of parallel download threads. Large values may result in IP rate limiting.
 
 **--temp-path**
 Path to temporary folder for cache.

--- a/TwitchDownloaderCLI/Tools/PreParseArgs.cs
+++ b/TwitchDownloaderCLI/Tools/PreParseArgs.cs
@@ -9,7 +9,7 @@ namespace TwitchDownloaderCLI.Tools
     {
         internal static string[] Parse(string[] args, string processFileName)
         {
-            if (args.Any(x => x is "-m" or "--mode" or "--embed-emotes" or "--silent" or "--verbose-ffmpeg"))
+            if (args.Any(x => x is "-m" or "--mode" or "--embed-emotes" or "--silent" or "--verbose-ffmpeg" or "--chat-connections"))
             {
                 // A legacy syntax was used, convert to new syntax
                 return Process(ConvertFromOldSyntax(args, processFileName));
@@ -56,17 +56,23 @@ namespace TwitchDownloaderCLI.Tools
                         Console.WriteLine("[INFO] The program has switched from --verbose-ffmpeg to log levels, consider using log levels instead. '--log-level Status,Info,Warning,Error,Ffmpeg' will be applied to the current session. Run \'{0} help\' for more information.", processFileName);
                         ConvertVerboseFfmpegSyntax(processedArgs, i);
                         break;
+                    case "--chat-connections":
+                        Console.WriteLine("[INFO] The program has switched from --chat-connections to -t / --threads, consider using those instead. Run \'{0} help\' for more information.", processFileName);
+                        ConvertChatConnectionsSyntax(processedArgs, i);
+                        break;
                 }
             }
 
             return processedArgs.ToArray();
         }
 
+        // Added at 2022-11-20T21:58:54Z (1668981534)
         private static void ConvertEmbedEmoteSyntax(IList<string> args, int index)
         {
             args[index] = "-E";
         }
 
+        // Added at 2022-11-13T06:02:21Z (1668319341000)
         private static void ConvertModeSyntax(IList<string> args, int index)
         {
             // --mode
@@ -78,12 +84,14 @@ namespace TwitchDownloaderCLI.Tools
             args.Insert(0, runMode);
         }
 
+        // Added at 2024-03-31T20:09:53Z (1711915793000)
         private static void ConvertSilentSyntax(IList<string> args, int index)
         {
             args[index] = "--log-level";
             args.Insert(index + 1, nameof(LogLevel.None));
         }
 
+        // Added at 2024-04-06T04:18:40Z (1712377120000)
         private static void ConvertVerboseFfmpegSyntax(IList<string> args, int index)
         {
             // If the user is still using --verbose-ffmpeg they probably aren't using log levels yet, so its safe to assume that there won't be a double-parse error
@@ -93,6 +101,12 @@ namespace TwitchDownloaderCLI.Tools
                 .Where(x => x is not nameof(LogLevel.None) and not nameof(LogLevel.Verbose));
 
             args.Insert(index + 1, string.Join(',', logLevels));
+        }
+
+        // Added at 2024-05-03T00:06:05Z (1714694765400)
+        private static void ConvertChatConnectionsSyntax(IList<string> args, int index)
+        {
+            args[index] = "--threads";
         }
     }
 }

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -270,7 +270,7 @@ namespace TwitchDownloaderCore
             double videoTotalLength;
             int viewCount;
             string game;
-            int connectionCount = downloadOptions.ConnectionCount;
+            int connectionCount = downloadOptions.DownloadThreads;
 
             if (downloadType == DownloadType.Video)
             {

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -444,7 +444,7 @@ namespace TwitchDownloaderCore
                 TrimBeginningTime = sectionStart,
                 TrimEnding = true,
                 TrimEndingTime = sectionEnd,
-                ConnectionCount = 4,
+                DownloadThreads = 4,
                 EmbedData = false,
                 BttvEmotes = false,
                 FfzEmotes = false,

--- a/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
@@ -16,7 +16,7 @@ namespace TwitchDownloaderCore.Options
         public bool BttvEmotes { get; set; }
         public bool FfzEmotes { get; set; }
         public bool StvEmotes { get; set; }
-        public int ConnectionCount { get; set; } = 1;
+        public int DownloadThreads { get; set; } = 1;
         public bool Silent { get; set; } = false;
         public TimestampFormat TimeFormat { get; set; }
         public string FileExtension

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -74,7 +74,7 @@
                     <TextBlock HorizontalAlignment="Right" Margin="0,8,0,0" Foreground="{DynamicResource AppText}" ><Run Text="{lex:Loc EmbedImages}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc EmbedImagesTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                     <TextBlock HorizontalAlignment="Right" Margin="0,8,0,0" Foreground="{DynamicResource AppText}" ><Run Text="{lex:Loc ThirdPartyEmotes}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc ThirdPartyEmotesTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                 </StackPanel>
-                <TextBlock HorizontalAlignment="Right" Text="{lex:Loc DownloadThreads}" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" />
+                <TextBlock HorizontalAlignment="Right" Text="{lex:Loc ChatDownloadThreads}" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" />
             </StackPanel>
             <StackPanel>
                 <TextBlock x:Name="labelLength" Text="0:0:0" Margin="5,0,0,0" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -74,7 +74,7 @@
                     <TextBlock HorizontalAlignment="Right" Margin="0,8,0,0" Foreground="{DynamicResource AppText}" ><Run Text="{lex:Loc EmbedImages}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc EmbedImagesTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                     <TextBlock HorizontalAlignment="Right" Margin="0,8,0,0" Foreground="{DynamicResource AppText}" ><Run Text="{lex:Loc ThirdPartyEmotes}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc ThirdPartyEmotesTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                 </StackPanel>
-                <TextBlock HorizontalAlignment="Right" Text="{lex:Loc DownloadConnections}" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" />
+                <TextBlock HorizontalAlignment="Right" Text="{lex:Loc DownloadThreads}" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" />
             </StackPanel>
             <StackPanel>
                 <TextBlock x:Name="labelLength" Text="0:0:0" Margin="5,0,0,0" Foreground="{DynamicResource AppText}" />
@@ -117,7 +117,7 @@
                         <CheckBox IsEnabled="False" x:Name="checkStvEmbed" Margin="0,0,10,0" Checked="checkStvEmbed_Checked" Unchecked="checkStvEmbed_Unchecked" Content="7TV" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                     </StackPanel>
                 </StackPanel>
-                <hc:NumericUpDown Margin="5,8,0,0" Minimum="1" Value="1" Maximum="20" x:Name="numChatDownloadConnections" HorizontalAlignment="Left" ValueChanged="numChatDownloadConnections_ValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                <hc:NumericUpDown Margin="5,8,0,0" Minimum="1" Value="1" Maximum="20" x:Name="NumChatDownloadThreads" HorizontalAlignment="Left" ValueChanged="NumChatDownloadThreads_ValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" Margin="0,0,0,10" VerticalAlignment="Bottom">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -51,7 +51,7 @@ namespace TwitchDownloaderWPF
             checkBttvEmbed.IsChecked = Settings.Default.BTTVEmotes;
             checkFfzEmbed.IsChecked = Settings.Default.FFZEmotes;
             checkStvEmbed.IsChecked = Settings.Default.STVEmotes;
-            numChatDownloadConnections.Value = Settings.Default.ChatDownloadThreads;
+            NumChatDownloadThreads.Value = Settings.Default.ChatDownloadThreads;
             _ = (ChatFormat)Settings.Default.ChatDownloadType switch
             {
                 ChatFormat.Text => radioText.IsChecked = true,
@@ -260,7 +260,7 @@ namespace TwitchDownloaderWPF
             options.FfzEmotes = checkFfzEmbed.IsChecked.GetValueOrDefault();
             options.StvEmotes = checkStvEmbed.IsChecked.GetValueOrDefault();
             options.Filename = filename;
-            options.ConnectionCount = (int)numChatDownloadConnections.Value;
+            options.ConnectionCount = (int)NumChatDownloadThreads.Value;
             return options;
         }
 
@@ -302,12 +302,12 @@ namespace TwitchDownloaderWPF
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
         }
 
-        private void numChatDownloadConnections_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
+        private void NumChatDownloadThreads_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
         {
             if (this.IsInitialized)
             {
-                numChatDownloadConnections.Value = Math.Clamp((int)numChatDownloadConnections.Value, 1, 50);
-                Settings.Default.ChatDownloadThreads = (int)numChatDownloadConnections.Value;
+                NumChatDownloadThreads.Value = Math.Clamp((int)NumChatDownloadThreads.Value, 1, 50);
+                Settings.Default.ChatDownloadThreads = (int)NumChatDownloadThreads.Value;
                 Settings.Default.Save();
             }
         }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -260,7 +260,7 @@ namespace TwitchDownloaderWPF
             options.FfzEmotes = checkFfzEmbed.IsChecked.GetValueOrDefault();
             options.StvEmotes = checkStvEmbed.IsChecked.GetValueOrDefault();
             options.Filename = filename;
-            options.ConnectionCount = (int)NumChatDownloadThreads.Value;
+            options.DownloadThreads = (int)NumChatDownloadThreads.Value;
             return options;
         }
 

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -69,7 +69,7 @@
                 <TextBlock Text="{lex:Loc Length}" HorizontalAlignment="Right" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc Quality}" HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc TrimVideo}" HorizontalAlignment="Right" Margin="0,17,0,0" Foreground="{DynamicResource AppText}" />
-                <TextBlock Text="{lex:Loc DownloadThreads}" HorizontalAlignment="Right" Margin="0,46,0,0" Foreground="{DynamicResource AppText}" />
+                <TextBlock Text="{lex:Loc VideoDownloadThreads}" HorizontalAlignment="Right" Margin="0,46,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock HorizontalAlignment="Right" Margin="0,21,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc Oauth}"/><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc OauthTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
             </StackPanel>
             <StackPanel>

--- a/TwitchDownloaderWPF/README.md
+++ b/TwitchDownloaderWPF/README.md
@@ -41,7 +41,7 @@ To get started, input a valid link or ID to a VOD or highlight. If the VOD or hi
 
 **Trim**: Sets the start and end time to trim the video download in the format \[hours\] \[minutes\] \[seconds\]. Trimming the video will result in a smaller total download.
 
-**Download Threads**: The amount of download threads to be dispatched.
+**Download Threads**: The amount of parallel download threads to be dispatched.
 
 **OAuth**: The authorization token to allow downloading sub-only and private VODs or highlights. It is required by us and Twitch in order to prevent unauthorized downloads of paid or private content. Learn how to get your OAuth token at the following video: [https://youtu.be/1MBsUoFGuls](https://www.youtube.com/watch?v=1MBsUoFGuls). <ins>**DO NOT SHARE YOUR OAUTH TOKEN WITH ANYONE**</ins>
 
@@ -87,7 +87,7 @@ To get started, input a valid link or ID to a VOD, highlight, or clip. From ther
 
 **3rd Party Emotes** (JSON & HTML only): Also download emotes from the specified 3rd party providers and save them inside the chat. If the streamer is not registered on a given provider then it is skipped.
 
-**Connections**: The amount of download threads to be dispatched. On some internet connections, Twitch servers may refuse using more than 1 chat download thread.
+**Download Threads**: The amount of parallel download threads to be dispatched. On some internet connections, Twitch servers may refuse using more than 1 chat download thread.
 
 **Download**: Starts the download job. If instead you open the dropdown, you can send it to the [Task Queue](#task-queue) with the *Enqueue* option. The current download settings will be used in both scenarios.
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -321,6 +321,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Download Threads:.
+        /// </summary>
+        public static string ChatDownloadThreads {
+            get {
+                return ResourceManager.GetString("ChatDownloadThreads", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Font:.
         /// </summary>
         public static string ChatFont {
@@ -555,15 +564,6 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connections:.
-        /// </summary>
-        public static string DownloadConnections {
-            get {
-                return ResourceManager.GetString("DownloadConnections", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Download Filename Templates:.
         /// </summary>
         public static string DownloadFilenameTemplates {
@@ -587,15 +587,6 @@ namespace TwitchDownloaderWPF.Translations {
         public static string DownloadFormat {
             get {
                 return ResourceManager.GetString("DownloadFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Download Threads:.
-        /// </summary>
-        public static string DownloadThreads {
-            get {
-                return ResourceManager.GetString("DownloadThreads", resourceCulture);
             }
         }
         
@@ -2198,6 +2189,15 @@ namespace TwitchDownloaderWPF.Translations {
         public static string VideoCreatedAt {
             get {
                 return ResourceManager.GetString("VideoCreatedAt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download Threads:.
+        /// </summary>
+        public static string VideoDownloadThreads {
+            get {
+                return ResourceManager.GetString("VideoDownloadThreads", resourceCulture);
             }
         }
         

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -239,8 +239,8 @@
   <data name="Download" xml:space="preserve">
     <value>Descarga</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
-    <value>Conexiones:</value>
+  <data name="ChatDownloadThreads" xml:space="preserve">
+    <value>Hilos de descarga:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
     <value>Descargar plantillas de archivos:</value>
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Formato de la descarga:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Hilos de descarga:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -239,7 +239,7 @@
   <data name="Download" xml:space="preserve">
     <value>Télécharger</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>Connexions:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Format de téléchargement:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Connexions:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -239,8 +239,8 @@
   <data name="Download" xml:space="preserve">
     <value>Scarica</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
-    <value>Connessioni:</value>
+  <data name="ChatDownloadThreads" xml:space="preserve">
+    <value>Threads di Download:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
     <value>Scarica i modelli di file:</value>
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Formato del download:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Threads di Download:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -239,7 +239,7 @@
   <data name="Download" xml:space="preserve">
     <value>Pobierz</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>Połączenia:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Format Pobierania:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Wątki Pobierania:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -239,8 +239,8 @@
   <data name="Download" xml:space="preserve">
     <value>Download</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
-    <value>Conexões:</value>
+  <data name="ChatDownloadThreads" xml:space="preserve">
+    <value>Processos do Download:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
     <value>Templates de Nomes do Arquivo de Download:</value>
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Formato de Download:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Processos do Download:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -239,8 +239,8 @@
   <data name="Download" xml:space="preserve">
     <value>Download</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
-    <value>Connections:</value>
+  <data name="ChatDownloadThreads" xml:space="preserve">
+    <value>Download Threads:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
     <value>Download Filename Templates:</value>
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Download Format:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Download Threads:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -239,7 +239,7 @@
   <data name="Download" xml:space="preserve">
     <value>Загрузка</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>Подключения:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Формат:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Потоков:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -240,7 +240,7 @@
   <data name="Download" xml:space="preserve">
     <value>İndir</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>Bağlantılar:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -249,7 +249,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>İndirme Formatı:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>İndirme Parçacığı:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -239,7 +239,7 @@
   <data name="Download" xml:space="preserve">
     <value>Завантажити</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>З'єднання:</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>Формат завантаження:</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>Потоків завантаження:</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -239,7 +239,7 @@
   <data name="Download" xml:space="preserve">
     <value>下载</value>
   </data>
-  <data name="DownloadConnections" xml:space="preserve">
+  <data name="ChatDownloadThreads" xml:space="preserve">
     <value>连接：</value>
   </data>
   <data name="DownloadFilenameTemplates" xml:space="preserve">
@@ -248,7 +248,7 @@
   <data name="DownloadFormat" xml:space="preserve">
     <value>下载格式：</value>
   </data>
-  <data name="DownloadThreads" xml:space="preserve">
+  <data name="VideoDownloadThreads" xml:space="preserve">
     <value>下载线程：</value>
   </data>
   <data name="EmbedImages" xml:space="preserve">


### PR DESCRIPTION
I got some feedback from some users that "Download Threads" (from the Vod page) is more clear than "Connections" on the chat download page.