### PR TITLE
Use int64 for video IDs (fixes #1057)

### DIFF
--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -54,7 +54,7 @@ namespace TwitchDownloaderCLI.Modes
             {
                 DownloadThreads = inputOptions.DownloadThreads,
                 ThrottleKib = inputOptions.ThrottleKib,
-                Id = int.Parse(vodIdMatch.ValueSpan),
+                Id = long.Parse(vodIdMatch.ValueSpan),
                 Oauth = inputOptions.Oauth,
                 Filename = inputOptions.OutputFile,
                 Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -274,7 +274,7 @@ namespace TwitchDownloaderCore
 
             if (downloadType == DownloadType.Video)
             {
-                GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(int.Parse(videoId));
+                GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(long.Parse(videoId));
                 if (videoInfoResponse.data.video == null)
                 {
                     throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
@@ -291,7 +291,7 @@ namespace TwitchDownloaderCore
                 viewCount = videoInfoResponse.data.video.viewCount;
                 game = videoInfoResponse.data.video.game?.displayName ?? "Unknown";
 
-                GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(int.Parse(videoId), videoInfoResponse.data.video);
+                GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(long.Parse(videoId), videoInfoResponse.data.video);
                 chatRoot.video.chapters.EnsureCapacity(videoChapterResponse.data.video.moments.edges.Count);
                 foreach (var responseChapter in videoChapterResponse.data.video.moments.edges)
                 {

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -97,7 +97,7 @@ namespace TwitchDownloaderCore
 
             if (chatRoot.video.id.All(char.IsDigit))
             {
-                var videoId = int.Parse(chatRoot.video.id);
+                var videoId = long.Parse(chatRoot.video.id);
                 VideoInfo videoInfo = null;
                 try
                 {

--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -5,7 +5,7 @@ namespace TwitchDownloaderCore.Options
 {
     public class VideoDownloadOptions
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
         public bool TrimBeginning { get; set; }

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -27,7 +27,7 @@ namespace TwitchDownloaderCore
         private static readonly HttpClient httpClient = new HttpClient();
         private static readonly string[] BttvZeroWidth = { "SoSnowy", "IceCold", "SantaHat", "TopHat", "ReinDeer", "CandyCane", "cvMask", "cvHazmat" };
 
-        public static async Task<GqlVideoResponse> GetVideoInfo(int videoId)
+        public static async Task<GqlVideoResponse> GetVideoInfo(long videoId)
         {
             var request = new HttpRequestMessage()
             {
@@ -41,7 +41,7 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlVideoResponse>();
         }
 
-        public static async Task<GqlVideoTokenResponse> GetVideoToken(int videoId, string authToken)
+        public static async Task<GqlVideoTokenResponse> GetVideoToken(long videoId, string authToken)
         {
             var request = new HttpRequestMessage()
             {
@@ -57,7 +57,7 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlVideoTokenResponse>();
         }
 
-        public static async Task<string> GetVideoPlaylist(int videoId, string token, string sig)
+        public static async Task<string> GetVideoPlaylist(long videoId, string token, string sig)
         {
             HttpRequestMessage request;
             HttpResponseMessage response;
@@ -1032,7 +1032,7 @@ namespace TwitchDownloaderCore
         }
 
         /// <remarks>When a given video has only 1 chapter, data.video.moments.edges will be empty.</remarks>
-        public static async Task<GqlVideoChapterResponse> GetVideoChapters(int videoId)
+        public static async Task<GqlVideoChapterResponse> GetVideoChapters(long videoId)
         {
             var request = new HttpRequestMessage()
             {
@@ -1056,7 +1056,7 @@ namespace TwitchDownloaderCore
             return chapterResponse;
         }
 
-        public static async Task<GqlVideoChapterResponse> GetOrGenerateVideoChapters(int videoId, VideoInfo videoInfo)
+        public static async Task<GqlVideoChapterResponse> GetOrGenerateVideoChapters(long videoId, VideoInfo videoInfo)
         {
             var chapterResponse = await GetVideoChapters(videoId);
 

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -115,7 +115,7 @@ namespace TwitchDownloaderWPF
             {
                 if (downloadType == DownloadType.Video)
                 {
-                    GqlVideoResponse videoInfo = await TwitchHelper.GetVideoInfo(int.Parse(downloadId));
+                    GqlVideoResponse videoInfo = await TwitchHelper.GetVideoInfo(long.Parse(downloadId));
 
                     var thumbUrl = videoInfo.data.video.thumbnailURLs.FirstOrDefault();
                     if (!ThumbnailService.TryGetThumb(thumbUrl, out var image))

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -117,7 +117,7 @@ namespace TwitchDownloaderWPF
             {
                 if (VideoId.All(char.IsDigit))
                 {
-                    GqlVideoResponse videoInfo = await TwitchHelper.GetVideoInfo(int.Parse(VideoId));
+                    GqlVideoResponse videoInfo = await TwitchHelper.GetVideoInfo(long.Parse(VideoId));
                     if (videoInfo.data.video == null)
                     {
                         AppendLog(Translations.Strings.ErrorLog + Translations.Strings.UnableToFindThumbnail + ": " + Translations.Strings.VodExpiredOrIdCorrupt);

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -32,7 +32,7 @@ namespace TwitchDownloaderWPF
     public partial class PageVodDownload : Page
     {
         public readonly Dictionary<string, (string url, int bandwidth)> videoQualities = new();
-        public int currentVideoId;
+        public long currentVideoId;
         public DateTime currentVideoTime;
         public TimeSpan vodLength;
         public int viewCount;
@@ -82,7 +82,7 @@ namespace TwitchDownloaderWPF
 
         private async Task GetVideoInfo()
         {
-            int videoId = ValidateUrl(textUrl.Text.Trim());
+            long videoId = ValidateUrl(textUrl.Text.Trim());
             if (videoId <= 0)
             {
                 MessageBox.Show(Translations.Strings.InvalidVideoLinkIdMessage.Replace(@"\n", Environment.NewLine), Translations.Strings.InvalidVideoLinkId, MessageBoxButton.OK, MessageBoxImage.Error);
@@ -275,10 +275,10 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private static int ValidateUrl(string text)
+        private static long ValidateUrl(string text)
         {
             var vodIdMatch = TwitchRegex.MatchVideoId(text);
-            if (vodIdMatch is {Success: true} && int.TryParse(vodIdMatch.ValueSpan, out var vodId))
+            if (vodIdMatch is {Success: true} && long.TryParse(vodIdMatch.ValueSpan, out var vodId))
             {
                 return vodId;
             }

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -464,7 +464,7 @@ namespace TwitchDownloaderWPF
                         {
                             Oauth = Settings.Default.OAuth,
                             TempFolder = Settings.Default.TempPath,
-                            Id = int.Parse(taskData.Id),
+                            Id = long.Parse(taskData.Id),
                             Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
                             FfmpegPath = "ffmpeg",
                             TrimBeginning = false,

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -61,7 +61,7 @@ namespace TwitchDownloaderWPF
             {
                 if (id.All(char.IsDigit))
                 {
-                    Task<GqlVideoResponse> task = TwitchHelper.GetVideoInfo(int.Parse(id));
+                    Task<GqlVideoResponse> task = TwitchHelper.GetVideoInfo(long.Parse(id));
                     taskVideoList.Add(task);
                     taskDict[task.Id] = id;
                 }


### PR DESCRIPTION
Twitch video IDs broke the int32 barrier yesterday.