### PR TITLE
Improve WPF dark titlebar handling

### DIFF
--- a/TwitchDownloaderWPF/App.xaml
+++ b/TwitchDownloaderWPF/App.xaml
@@ -41,7 +41,7 @@
             <SolidColorBrush x:Key="StatusBarText" Color="#212121" />
             <SolidColorBrush x:Key="ProgressBarForeground" Color="#326CF3" />
 
-            <Style TargetType="{x:Type Window}">
+            <Style TargetType="{x:Type local:MainWindow}">
                 <Setter Property="behave:WindowIntegrityCheckBehavior.IntegrityCheck" Value="True"></Setter>
             </Style>
         </ResourceDictionary>

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -54,8 +54,8 @@ namespace TwitchDownloaderWPF
             Current?.Shutdown();
         }
 
-        public static void RequestAppThemeChange()
-            => ThemeServiceSingleton.ChangeAppTheme();
+        public static void RequestAppThemeChange(bool forceRepaint = false)
+            => ThemeServiceSingleton.ChangeAppTheme(forceRepaint);
 
         public static void RequestTitleBarChange()
             => ThemeServiceSingleton.SetTitleBarTheme(Current.Windows);

--- a/TwitchDownloaderWPF/MainWindow.xaml
+++ b/TwitchDownloaderWPF/MainWindow.xaml
@@ -9,7 +9,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="Twitch Downloader" MinHeight="440" Height="500" MinWidth="700" Width="850" Loaded="Window_Loaded">
+        Title="Twitch Downloader" MinHeight="440" Height="500" MinWidth="700" Width="850" Loaded="Window_Loaded" SourceInitialized="Window_OnSourceInitialized">
     <Grid Background="{DynamicResource AppBackground}">
         <Grid.RowDefinitions>
             <RowDefinition Height="2" />

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -63,10 +63,13 @@ namespace TwitchDownloaderWPF
             Main.Content = pageQueue;
         }
 
-        private async void Window_Loaded(object sender, RoutedEventArgs e)
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestAppThemeChange();
+        }
 
+        private async void Window_Loaded(object sender, RoutedEventArgs e)
+        {
             Main.Content = pageVodDownload;
             if (Settings.Default.UpgradeRequired)
             {

--- a/TwitchDownloaderWPF/Services/ThemeService.cs
+++ b/TwitchDownloaderWPF/Services/ThemeService.cs
@@ -66,11 +66,11 @@ namespace TwitchDownloaderWPF.Services
 
             if (Settings.Default.GuiTheme.Equals("System", StringComparison.OrdinalIgnoreCase))
             {
-                ChangeAppTheme();
+                ChangeAppTheme(true);
             }
         }
 
-        public void ChangeAppTheme()
+        public void ChangeAppTheme(bool forceRepaint = false)
         {
             var newTheme = Settings.Default.GuiTheme;
             if (newTheme.Equals("System", StringComparison.OrdinalIgnoreCase))
@@ -86,6 +86,20 @@ namespace TwitchDownloaderWPF.Services
             if (_wpfApplication.Windows.Count > 0)
             {
                 SetTitleBarTheme(_wpfApplication.Windows);
+            }
+
+            if (forceRepaint)
+            {
+                // Cause an NC repaint by changing focus
+                var wnd = new Window
+                {
+                    SizeToContent = SizeToContent.WidthAndHeight,
+                    Top = int.MinValue + 1,
+                    WindowStyle = WindowStyle.None,
+                    ShowInTaskbar = false
+                };
+                wnd.Show();
+                wnd.Close();
             }
         }
 

--- a/TwitchDownloaderWPF/Services/ThemeService.cs
+++ b/TwitchDownloaderWPF/Services/ThemeService.cs
@@ -111,19 +111,6 @@ namespace TwitchDownloaderWPF.Services
                     _ = NativeFunctions.SetWindowAttribute(windowHandle, darkTitleBarAttribute, &shouldUseDarkTitleBar, sizeof(int));
                 }
             }
-
-            Window wnd = new()
-            {
-                SizeToContent = SizeToContent.WidthAndHeight,
-                Top = int.MinValue + 1,
-                WindowStyle = WindowStyle.None,
-                ShowInTaskbar = false
-            };
-            wnd.Show();
-            wnd.Close();
-            // Dark title bar is a bit buggy, requires window redraw (focus change, resize, transparency change) to fully apply.
-            // We *could* send a repaint message to win32.dll, but this solution works and is way easier.
-            // Win11 might not have this issue but Win10 does so please leave this
         }
 
         private void ChangeThemePath(string newTheme)

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -13,7 +13,7 @@
         xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
         xmlns:gif="http://wpfanimatedgif.codeplex.com"
         mc:Ignorable="d"
-        Title="Mass Downloader" MinHeight="250" Height="700" MinWidth="775" Width="1100" Loaded="Window_Loaded">
+        Title="Mass Downloader" MinHeight="250" Height="700" MinWidth="775" Width="1100" Loaded="Window_Loaded" SourceInitialized="Window_OnSourceInitialized">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -254,12 +254,16 @@ namespace TwitchDownloaderWPF
             textCount.Text = selectedItems.Count.ToString();
         }
 
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
+        {
+            App.RequestTitleBarChange();
+        }
+
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             Title = downloaderType == DownloadType.Video
                 ? Translations.Strings.TitleVideoMassDownloader
                 : Translations.Strings.TitleClipMassDownloader;
-            App.RequestTitleBarChange();
         }
 
         private async void TextChannel_OnKeyDown(object sender, KeyEventArgs e)

--- a/TwitchDownloaderWPF/WindowOldVideoCacheManager.xaml
+++ b/TwitchDownloaderWPF/WindowOldVideoCacheManager.xaml
@@ -11,7 +11,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleWindowOldVideoCacheManager}" MinHeight="350" MinWidth="500" Height="450" Width="800" Loaded="OnLoaded" Closing="OnClosing" d:DataContext="{d:DesignInstance local:WindowOldVideoCacheManager}">
+        Title="{lex:Loc TitleWindowOldVideoCacheManager}" MinHeight="350" MinWidth="500" Height="450" Width="800" Loaded="OnLoaded" SourceInitialized="OnSourceInitialized" Closing="OnClosing" d:DataContext="{d:DesignInstance local:WindowOldVideoCacheManager}">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowOldVideoCacheManager.xaml.cs
+++ b/TwitchDownloaderWPF/WindowOldVideoCacheManager.xaml.cs
@@ -37,16 +37,17 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private void OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestTitleBarChange();
+        }
 
-            // For some stupid reason, this does not work unless I manually set it, even though its a binding
-            DataGrid.ItemsSource = GridItems;
-
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
             // Do this the dumb way because bindings are annoying without view models
             var sizeString = VideoSizeEstimator.StringifyByteCount(_totalSize);
             TextTotalSize.Text = string.IsNullOrEmpty(sizeString) ? "0B" : sizeString;
+            DataGrid.ItemsSource = GridItems;
         }
 
         private void OnClosing(object sender, CancelEventArgs e)

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -10,7 +10,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleEnqueueOptions}" MinHeight="280" Height="280" MinWidth="500" Width="500" SizeToContent="WidthAndHeight" Loaded="Window_loaded" Background="{DynamicResource AppBackground}">
+        Title="{lex:Loc TitleEnqueueOptions}" MinHeight="280" Height="280" MinWidth="500" Width="500" SizeToContent="WidthAndHeight" SourceInitialized="Window_OnSourceInitialized" Background="{DynamicResource AppBackground}">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -682,7 +682,7 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void Window_loaded(object sender, RoutedEventArgs e)
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestTitleBarChange();
         }

--- a/TwitchDownloaderWPF/WindowRangeSelect.xaml
+++ b/TwitchDownloaderWPF/WindowRangeSelect.xaml
@@ -10,7 +10,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleRenderRange}" Height="150" Width="400" Background="#FFEFEFEF" Initialized="Window_Initialized" Loaded="Window_Loaded">
+        Title="{lex:Loc TitleRenderRange}" Height="150" Width="400" Background="#FFEFEFEF" Initialized="Window_Initialized" SourceInitialized="Window_OnSourceInitialized">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowRangeSelect.xaml.cs
+++ b/TwitchDownloaderWPF/WindowRangeSelect.xaml.cs
@@ -75,7 +75,7 @@ namespace TwitchDownloaderWPF
             catch (OverflowException) { }
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestTitleBarChange();
         }

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -12,7 +12,7 @@
         xmlns:hc="https://handyorg.github.io/handycontrol"
         xmlns:fa="http://schemas.fontawesome.com/icons/"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleGlobalSettings}" MinWidth="400" MinHeight="500" Width="500" Height="592" SizeToContent="Height" Initialized="Window_Initialized" Closing="Window_Closing" Loaded="Window_Loaded" Background="{DynamicResource AppBackground}">
+        Title="{lex:Loc TitleGlobalSettings}" MinWidth="400" MinHeight="500" Width="500" Height="592" SizeToContent="Height" Initialized="Window_Initialized" Closing="Window_Closing" SourceInitialized="Window_OnSourceInitialized" Background="{DynamicResource AppBackground}">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -162,7 +162,7 @@ namespace TwitchDownloaderWPF
             {
                 _refreshThemeOnCancel = true;
                 Settings.Default.GuiTheme = (string)ComboTheme.SelectedItem;
-                App.RequestAppThemeChange();
+                App.RequestAppThemeChange(true);
             }
         }
 

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -118,7 +118,7 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestTitleBarChange();
         }

--- a/TwitchDownloaderWPF/WindowUrlList.xaml
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml
@@ -10,7 +10,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleUrlList}" MinHeight="590" Height="600" MinWidth="485" Width="500" Loaded="Window_Loaded">
+        Title="{lex:Loc TitleUrlList}" MinHeight="590" Height="600" MinWidth="485" Width="500" SourceInitialized="Window_OnSourceInitialized">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />

--- a/TwitchDownloaderWPF/WindowUrlList.xaml.cs
+++ b/TwitchDownloaderWPF/WindowUrlList.xaml.cs
@@ -167,7 +167,7 @@ namespace TwitchDownloaderWPF
             btnQueue.IsEnabled = true;
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private void Window_OnSourceInitialized(object sender, EventArgs e)
         {
             App.RequestTitleBarChange();
         }


### PR DESCRIPTION
By setting the dark titlebar during `SourceInitialized`, we don't need to force a repaint by spawning a virtually invisible window.

Forcing a repaint is still necessary to change the titlebar theme after first present though, such as reacting to system theme changes.