### PR TITLE
Improve readable colors algorithm and make it optional

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
@@ -105,6 +105,9 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("alternate-backgrounds", Default = false, HelpText = "Alternates the background color of every other chat message to help tell them apart.")]
         public bool AlternateMessageBackgrounds { get; set; }
 
+        [Option("readable-colors", Default = false, HelpText = "Increases the contrast of usernames against the background or outline color.")]
+        public bool AdjustUsernameVisibility { get; set; }
+
         [Option("offline", Default = false, HelpText = "Render completely offline using only embedded emotes, badges, and bits from the input json.")]
         public bool Offline { get; set; }
 

--- a/TwitchDownloaderCLI/Modes/RenderChat.cs
+++ b/TwitchDownloaderCLI/Modes/RenderChat.cs
@@ -91,7 +91,8 @@ namespace TwitchDownloaderCLI.Modes
                 AccentIndentScale = inputOptions.ScaleAccentIndent,
                 AccentStrokeScale = inputOptions.ScaleAccentStroke,
                 DisperseCommentOffsets = inputOptions.DisperseCommentOffsets,
-                AlternateMessageBackgrounds = inputOptions.AlternateMessageBackgrounds
+                AlternateMessageBackgrounds = inputOptions.AlternateMessageBackgrounds,
+                AdjustUsernameVisibility = inputOptions.AdjustUsernameVisibility,
             };
 
             if (renderOptions.GenerateMask && renderOptions.BackgroundColor.Alpha == 255 && !(renderOptions.AlternateMessageBackgrounds! && renderOptions.AlternateBackgroundColor.Alpha != 255))

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -272,6 +272,9 @@ Other = `1`, Broadcaster = `2`, Moderator = `4`, VIP = `8`, Subscriber = `16`, P
 **--alternate-backgrounds**
 (Default: `false`) Alternates the background color of every other chat message to help tell them apart.
 
+**--readable-colors**
+(Default: `false`) Increases the contrast of usernames against the background or outline color.
+
 **--offline**
 (Default: `false`) Render completely offline using only embedded emotes, badges, and bits from the input json.
 

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1465,16 +1465,16 @@ namespace TwitchDownloaderCore
             if (background.RelativeLuminance() > 0.5)
             {
                 // Bright background
-                if (fgLight > 65)
+                if (fgLight > 60)
                 {
-                    fgLight = 65;
+                    fgLight = 60;
                 }
 
                 if (bgSat <= 28)
                 {
                     fgHue = fgHue switch
                     {
-                        > 55 and < 90 => AdjustHue(fgHue, 55, 90), // Yellow-Lime
+                        > 48 and < 90 => AdjustHue(fgHue, 48, 90), // Yellow-Lime
                         > 164 and < 186 => AdjustHue(fgHue, 164, 186), // Turquoise
                         _ => fgHue
                     };
@@ -1483,9 +1483,9 @@ namespace TwitchDownloaderCore
             else
             {
                 // Dark background
-                if (fgLight < 35)
+                if (fgLight < 40)
                 {
-                    fgLight = 35;
+                    fgLight = 40;
                 }
 
                 if (bgSat <= 28)

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -588,14 +588,14 @@ namespace TwitchDownloaderCore
                     return null;
                 }
 
-                DrawAccentedMessage(comment, sectionImages, emoteSectionList, highlightType, ref drawPos, defaultPos);
+                DrawAccentedMessage(comment, sectionImages, emoteSectionList, highlightType, commentIndex, ref drawPos, defaultPos);
             }
             else
             {
-                DrawNonAccentedMessage(comment, sectionImages, emoteSectionList, false, ref drawPos, ref defaultPos);
+                DrawNonAccentedMessage(comment, sectionImages, emoteSectionList, false, commentIndex, ref drawPos, ref defaultPos);
             }
 
-            SKBitmap finalBitmap = CombineImages(sectionImages, highlightType);
+            SKBitmap finalBitmap = CombineImages(sectionImages, highlightType, commentIndex);
             newSection.Image = finalBitmap;
             newSection.Emotes = emoteSectionList;
             newSection.CommentIndex = commentIndex;
@@ -603,7 +603,7 @@ namespace TwitchDownloaderCore
             return newSection;
         }
 
-        private SKBitmap CombineImages(List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, HighlightType highlightType)
+        private SKBitmap CombineImages(List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, HighlightType highlightType, int commentIndex)
         {
             SKBitmap finalBitmap = new SKBitmap(renderOptions.ChatWidth, sectionImages.Sum(x => x.info.Height));
             var finalBitmapInfo = finalBitmap.Info;
@@ -621,8 +621,9 @@ namespace TwitchDownloaderCore
                 else if (highlightType is not HighlightType.None)
                 {
                     const int OPAQUE_THRESHOLD = 245;
-                    if (!(renderOptions.BackgroundColor.Alpha < OPAQUE_THRESHOLD ||
-                        (renderOptions.AlternateMessageBackgrounds && renderOptions.AlternateBackgroundColor.Alpha < OPAQUE_THRESHOLD)))
+                    var useAlternateBackground = renderOptions.AlternateMessageBackgrounds && commentIndex % 2 == 1;
+                    if (!((!useAlternateBackground && renderOptions.BackgroundColor.Alpha < OPAQUE_THRESHOLD) ||
+                          (useAlternateBackground && renderOptions.AlternateBackgroundColor.Alpha < OPAQUE_THRESHOLD)))
                     {
                         // Draw the highlight background only if the message background is opaque enough
                         var backgroundColor = new SKColor(0x1A6B6B6E); // AARRGGBB
@@ -652,7 +653,7 @@ namespace TwitchDownloaderCore
             return string.Join(' ', codepointList);
         }
 
-        private void DrawNonAccentedMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, bool highlightWords, ref Point drawPos, ref Point defaultPos)
+        private void DrawNonAccentedMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, bool highlightWords, int commentIndex, ref Point drawPos, ref Point defaultPos)
         {
             if (renderOptions.Timestamp)
             {
@@ -662,7 +663,7 @@ namespace TwitchDownloaderCore
             {
                 DrawBadges(comment, sectionImages, ref drawPos);
             }
-            DrawUsername(comment, sectionImages, ref drawPos, defaultPos);
+            DrawUsername(comment, sectionImages, ref drawPos, defaultPos, commentIndex: commentIndex);
             DrawMessage(comment, sectionImages, emotePositionList, highlightWords, ref drawPos, defaultPos);
 
             foreach (var (_, bitmap) in sectionImages)
@@ -671,7 +672,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private void DrawAccentedMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, HighlightType highlightType, ref Point drawPos, Point defaultPos)
+        private void DrawAccentedMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, HighlightType highlightType, int commentIndex, ref Point drawPos, Point defaultPos)
         {
             drawPos.X += renderOptions.AccentIndentWidth;
             defaultPos.X = drawPos.X;
@@ -688,13 +689,13 @@ namespace TwitchDownloaderCore
             {
                 case HighlightType.SubscribedTier:
                 case HighlightType.SubscribedPrime:
-                    DrawSubscribeMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
+                    DrawSubscribeMessage(comment, sectionImages, emotePositionList, commentIndex, ref drawPos, defaultPos, highlightIcon, iconPoint);
                     break;
                 case HighlightType.BitBadgeTierNotification:
                     DrawBitsBadgeTierMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
                     break;
                 case HighlightType.WatchStreak:
-                    DrawWatchStreakMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
+                    DrawWatchStreakMessage(comment, sectionImages, emotePositionList, commentIndex, ref drawPos, defaultPos, highlightIcon, iconPoint);
                     break;
                 case HighlightType.CharityDonation:
                     DrawCharityDonationMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
@@ -705,7 +706,7 @@ namespace TwitchDownloaderCore
                     DrawGiftMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
                     break;
                 case HighlightType.ChannelPointHighlight:
-                    DrawNonAccentedMessage(comment, sectionImages, emotePositionList, true, ref drawPos, ref defaultPos);
+                    DrawNonAccentedMessage(comment, sectionImages, emotePositionList, true, commentIndex, ref drawPos, ref defaultPos);
                     break;
                 case HighlightType.ContinuingGift:
                 case HighlightType.PayingForward:
@@ -721,7 +722,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private void DrawSubscribeMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
+        private void DrawSubscribeMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, int commentIndex, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
         {
             using SKCanvas canvas = new(sectionImages.Last().bitmap);
             canvas.DrawImage(highlightIcon, iconPoint.X, iconPoint.Y);
@@ -757,7 +758,7 @@ namespace TwitchDownloaderCore
             AddImageSection(sectionImages, ref drawPos, defaultPos);
             drawPos = customMessagePos;
             defaultPos = customMessagePos;
-            DrawNonAccentedMessage(customResubMessage, sectionImages, emotePositionList, false, ref drawPos, ref defaultPos);
+            DrawNonAccentedMessage(customResubMessage, sectionImages, emotePositionList, false, commentIndex, ref drawPos, ref defaultPos);
         }
 
         private void DrawBitsBadgeTierMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
@@ -795,7 +796,7 @@ namespace TwitchDownloaderCore
             DrawMessage(comment, sectionImages, emotePositionList, false, ref drawPos, defaultPos);
         }
 
-        private void DrawWatchStreakMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
+        private void DrawWatchStreakMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, int commentIndex, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
         {
             using SKCanvas canvas = new(sectionImages.Last().bitmap);
             canvas.DrawImage(highlightIcon, iconPoint.X, iconPoint.Y);
@@ -831,7 +832,7 @@ namespace TwitchDownloaderCore
             AddImageSection(sectionImages, ref drawPos, defaultPos);
             drawPos = customMessagePos;
             defaultPos = customMessagePos;
-            DrawNonAccentedMessage(customMessage, sectionImages, emotePositionList, false, ref drawPos, ref defaultPos);
+            DrawNonAccentedMessage(customMessage, sectionImages, emotePositionList, false, commentIndex, ref drawPos, ref defaultPos);
         }
 
         private void DrawCharityDonationMessage(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, ref Point drawPos, Point defaultPos, SKImage highlightIcon, Point iconPoint)
@@ -1417,11 +1418,15 @@ namespace TwitchDownloaderCore
             return measure.Width;
         }
 
-        private void DrawUsername(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, ref Point drawPos, Point defaultPos, bool appendColon = true, SKColor? colorOverride = null)
+        private void DrawUsername(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, ref Point drawPos, Point defaultPos, bool appendColon = true, SKColor? colorOverride = null, int commentIndex = 0)
         {
             var userColor = colorOverride ?? SKColor.Parse(comment.message.user_color ?? DefaultUsernameColors[Math.Abs(comment.commenter.display_name.GetHashCode()) % DefaultUsernameColors.Length]);
             if (colorOverride is null && renderOptions.AdjustUsernameVisibility)
-                userColor = AdjustUsernameVisibility(userColor, renderOptions.BackgroundColor);
+            {
+                var useAlternateBackground = renderOptions.AlternateMessageBackgrounds && commentIndex % 2 == 1;
+                var backgroundColor = useAlternateBackground ? renderOptions.AlternateBackgroundColor : renderOptions.BackgroundColor;
+                userColor = AdjustUsernameVisibility(userColor, backgroundColor);
+            }
 
             using SKPaint userPaint = comment.commenter.display_name.Any(IsNotAscii)
                 ? GetFallbackFont(comment.commenter.display_name.First(IsNotAscii)).Clone()

--- a/TwitchDownloaderCore/Extensions/SKColorExtensions.cs
+++ b/TwitchDownloaderCore/Extensions/SKColorExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Numerics;
+using SkiaSharp;
+
+namespace TwitchDownloaderCore.Extensions
+{
+    // ReSharper disable once InconsistentNaming
+    public static class SKColorExtensions
+    {
+        public static SKColor Lerp(this SKColor from, SKColor to, float factor)
+        {
+            var result = Vector4.Lerp(ToVector4(from), ToVector4(to), factor);
+            return FromVector4(result);
+
+            static Vector4 ToVector4(SKColor color)
+            {
+                var colorF = color.ToSKColorF();
+                return new Vector4(colorF.Red, colorF.Green, colorF.Blue, colorF.Alpha);
+            }
+
+            static SKColor FromVector4(Vector4 color)
+            {
+                var colorF = new SKColorF(color.X, color.Y, color.Z, color.W);
+                return colorF.ToSKColor();
+            }
+        }
+
+        // ReSharper disable once InconsistentNaming
+        public static SKColorF ToSKColorF(this SKColor color)
+        {
+            return new SKColorF((float)color.Red / byte.MaxValue, (float)color.Green / byte.MaxValue, (float)color.Blue / byte.MaxValue, (float)color.Alpha / byte.MaxValue);
+        }
+
+        // ReSharper disable once InconsistentNaming
+        public static SKColor ToSKColor(this SKColorF color)
+        {
+            return new SKColor((byte)(color.Red * byte.MaxValue), (byte)(color.Green * byte.MaxValue), (byte)(color.Blue * byte.MaxValue), (byte)(color.Alpha * byte.MaxValue));
+        }
+
+        // https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+        public static double RelativeLuminance(this SKColor color)
+        {
+            var colorF = color.ToSKColorF();
+            return 0.2126 * ConvertColor(colorF.Red) + 0.7152 * ConvertColor(colorF.Green) + 0.0722 * ConvertColor(colorF.Blue);
+
+            static double ConvertColor(float v)
+            {
+                return v <= 0.04045
+                    ? v / 12.92
+                    : Math.Pow((v + 0.055) / 1.055, 2.4);
+            }
+        }
+    }
+}
+

--- a/TwitchDownloaderCore/Options/ChatRenderOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatRenderOptions.cs
@@ -91,5 +91,6 @@ namespace TwitchDownloaderCore.Options
         public bool SkipDriveWaiting { get; set; } = false;
         public EmojiVendor EmojiVendor { get; set; } = EmojiVendor.GoogleNotoColor;
         public int[] TimestampWidths { get; set; }
+        public bool AdjustUsernameVisibility { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Resources/chat-template.html
+++ b/TwitchDownloaderCore/Resources/chat-template.html
@@ -99,26 +99,31 @@ var Flexible=void 0===Flexible?{}:Flexible;Flexible.Pagination=function(e){var g
 <script>
 /* https://stackoverflow.com/a/63270816 */
 /* I am lazy, seriously if you want to have better solution to contrast PRs are welcome :) */
+const convertColor = (v) => {
+    const val = v / 255;
+    return val <= 0.03928
+        ? val / 12.92
+        : Math.pow((val + 0.055) / 1.055, 2.4);
+}
+
 const getLuminance = (values) => {
-    const rgb = values.map((v) => {
-        const val = v / 255;
-        return val <= 0.03928 ? val / 12.92 : ((val + 0.055) / 1.055) ** 2.4;
-    });
-    return Number((0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]).toFixed(3));
+    const r = convertColor(values[0]);
+    const g = convertColor(values[1]);
+    const b = convertColor(values[2]);
+
+    return Number(0.2126 * r + 0.7152 * g + 0.0722 * b);
 };
 
-const getContrastRatio = (colorA, colorB) => {
-    const lumA = getLuminance(colorA);
-    const lumB = getLuminance(colorB);
-
+const getContrastRatio = (lumA, lumB) => {
     return (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
 };
 
 const back_color = [255, 255, 255];
+const back_luminance = getLuminance(back_color);
 $('.comment-author').each(function (i, obj) {
     let colorRgb = $(obj).css("color");
     let color = colorRgb.substring(4, colorRgb.length - 1).replace(/ /g, '').split(',');
-    if (getContrastRatio(back_color, color) < 1.2) {
+    if (getContrastRatio(back_luminance, getLuminance(color)) < 1.2) {
         $(obj).css("color", "black");
     }
 });

--- a/TwitchDownloaderWPF/App.config
+++ b/TwitchDownloaderWPF/App.config
@@ -229,6 +229,9 @@
             <setting name="LogLevels" serializeAs="String">
                 <value>30</value>
             </setting>
+            <setting name="AdjustUsernameVisibility" serializeAs="String">
+                <value>False</value>
+            </setting>
         </TwitchDownloaderWPF.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -82,6 +82,7 @@
                             <TextBlock Text="{lex:Loc UpdateRate}" HorizontalAlignment="Right" Margin="0,13,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock HorizontalAlignment="Right" Margin="0,12,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc MessageDispersion}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc MessageDispersionTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                             <TextBlock HorizontalAlignment="Right" Margin="0,6,0,0" MaxWidth="120" TextWrapping="Wrap" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc AlternateMessageBackgrounds}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc AlternateMessageBackgroundsTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                            <TextBlock Text="Increase Username Readability:" HorizontalAlignment="Right" Margin="0,6,0,0" MaxWidth="120" TextWrapping="Wrap" Foreground="{DynamicResource AppText}"/>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="0,10,0,5">
                             <CheckBox x:Name="checkOutline" HorizontalAlignment="Left" Margin="0,0,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
@@ -90,7 +91,8 @@
                             <CheckBox x:Name="checkBadge" HorizontalAlignment="Left" Margin="0,6,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
                             <TextBox x:Name="textUpdateTime" Text="0.5" Width="50" HorizontalAlignment="Left" Margin="0,7,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                             <CheckBox x:Name="checkDispersion" HorizontalAlignment="Left" Margin="0,6,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
-                            <CheckBox x:Name="checkAlternateMessageBackgrounds" HorizontalAlignment="Left" Margin="0,21,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
+                            <CheckBox x:Name="checkAlternateMessageBackgrounds" HorizontalAlignment="Left" Margin="0,22,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
+                            <CheckBox x:Name="checkAdjustUsernameVisibility" HorizontalAlignment="Left" Margin="0,22,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="15,10,5,2">
                             <TextBlock Text="{lex:Loc BttvEmotes}" HorizontalAlignment="Right" Margin="0,0,0,0" Foreground="{DynamicResource AppText}"/>

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -82,7 +82,7 @@
                             <TextBlock Text="{lex:Loc UpdateRate}" HorizontalAlignment="Right" Margin="0,13,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock HorizontalAlignment="Right" Margin="0,12,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc MessageDispersion}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc MessageDispersionTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                             <TextBlock HorizontalAlignment="Right" Margin="0,6,0,0" MaxWidth="120" TextWrapping="Wrap" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc AlternateMessageBackgrounds}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc AlternateMessageBackgroundsTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
-                            <TextBlock Text="Increase Username Readability:" HorizontalAlignment="Right" Margin="0,6,0,0" MaxWidth="120" TextWrapping="Wrap" Foreground="{DynamicResource AppText}"/>
+                            <TextBlock Text="{lex:Loc IncreaseUsernameReadability}" HorizontalAlignment="Right" Margin="0,6,0,0" MaxWidth="120" TextWrapping="Wrap" Foreground="{DynamicResource AppText}"/>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="0,10,0,5">
                             <CheckBox x:Name="checkOutline" HorizontalAlignment="Left" Margin="0,0,0,0" BorderBrush="{DynamicResource AppElementBorder}"/>

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -136,6 +136,7 @@ namespace TwitchDownloaderWPF
                 Offline = checkOffline.IsChecked.GetValueOrDefault(),
                 AllowUnlistedEmotes = true,
                 DisperseCommentOffsets = checkDispersion.IsChecked.GetValueOrDefault(),
+                AdjustUsernameVisibility = checkAdjustUsernameVisibility.IsChecked.GetValueOrDefault(),
             };
             if (RadioEmojiNotoColor.IsChecked == true)
                 options.EmojiVendor = EmojiVendor.GoogleNotoColor;
@@ -189,6 +190,7 @@ namespace TwitchDownloaderWPF
                 checkOffline.IsChecked = Settings.Default.Offline;
                 checkDispersion.IsChecked = Settings.Default.DisperseCommentOffsets;
                 checkAlternateMessageBackgrounds.IsChecked = Settings.Default.AlternateMessageBackgrounds;
+                checkAdjustUsernameVisibility.IsChecked = Settings.Default.AdjustUsernameVisibility;
                 RadioEmojiNotoColor.IsChecked = (EmojiVendor)Settings.Default.RenderEmojiVendor == EmojiVendor.GoogleNotoColor;
                 RadioEmojiTwemoji.IsChecked = (EmojiVendor)Settings.Default.RenderEmojiVendor == EmojiVendor.TwitterTwemoji;
                 RadioEmojiNone.IsChecked = (EmojiVendor)Settings.Default.RenderEmojiVendor == EmojiVendor.None;

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -294,6 +294,7 @@ namespace TwitchDownloaderWPF
             Settings.Default.Offline = checkOffline.IsChecked.GetValueOrDefault();
             Settings.Default.DisperseCommentOffsets = checkDispersion.IsChecked.GetValueOrDefault();
             Settings.Default.AlternateMessageBackgrounds = checkAlternateMessageBackgrounds.IsChecked.GetValueOrDefault();
+            Settings.Default.AdjustUsernameVisibility = checkAdjustUsernameVisibility.IsChecked.GetValueOrDefault();
             if (comboFormat.SelectedItem != null)
             {
                 Settings.Default.VideoContainer = ((VideoContainer)comboFormat.SelectedItem).Name;

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -909,5 +909,17 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LogLevels"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AdjustUsernameVisibility {
+            get {
+                return ((bool)(this["AdjustUsernameVisibility"]));
+            }
+            set {
+                this["AdjustUsernameVisibility"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -224,6 +224,9 @@
     <Setting Name="LogLevels" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">30</Value>
     </Setting>
+    <Setting Name="AdjustUsernameVisibility" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -933,6 +933,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Increase Username Readability:.
+        /// </summary>
+        public static string IncreaseUsernameReadability {
+            get {
+                return ResourceManager.GetString("IncreaseUsernameReadability", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Insufficient access. OAuth may be required..
         /// </summary>
         public static string InsufficientAccessMayNeedOauth {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -871,4 +871,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -870,4 +870,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -871,4 +871,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -869,4 +869,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -870,4 +870,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -869,4 +869,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -869,4 +869,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -870,4 +870,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -871,4 +871,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -870,4 +870,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -872,4 +872,7 @@
   <data name="UnknownVideoLength" xml:space="preserve">
     <value>未知</value>
   </data>
+  <data name="IncreaseUsernameReadability" xml:space="preserve">
+    <value>Increase Username Readability:</value>
+  </data>
 </root>


### PR DESCRIPTION
- Fixes #1047 

<details><summary>Image comparison</summary>
<p>

| Before | After |
|--------|--------|
| ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/da28775c-ef31-43a1-bf1e-5516d2e1eaf6) | ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/f087cd6d-4f19-4ae6-a861-485573f62a03) |
| ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/c393d923-1033-4561-aee5-4c783dab0bd3) | ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/511c2252-1477-44b5-bd0e-fd0874e58bb1) |
| ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/68482d54-08c3-4742-b2a0-ea7f0e48c353) | ![image](https://github.com/lay295/TwitchDownloader/assets/72096833/72fb48d6-b156-4986-bd66-1aa89d58d2f9) |

Works with alternating background colors too
![image](https://github.com/lay295/TwitchDownloader/assets/72096833/c3622b8d-0a15-4a76-b7fa-f17bee7543cb)

</p>
</details> 

Light and dark backgrounds are the best supported, however colored backgrounds get some adjustment too. In some cases with colored backgrounds, the only way to increase readability is to increase the bitrate.