### PR TITLE
Add `Safe` video trim mode to circumvent rare encoding issues

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/VideoDownloadArgs.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using TwitchDownloaderCLI.Models;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
@@ -26,6 +27,9 @@ namespace TwitchDownloaderCLI.Modes.Arguments
 
         [Option("bandwidth", Default = -1, HelpText = "The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or -1 for no maximum.")]
         public int ThrottleKib { get; set; }
+
+        [Option("trim-mode", Default = VideoTrimMode.Exact, HelpText = "Sets the trim handling. Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video. Valid values are: Safe, Exact")]
+        public VideoTrimMode TrimMode { get; set; }
 
         [Option("oauth", HelpText = "OAuth access token to download subscriber only VODs. DO NOT SHARE THIS WITH ANYONE.")]
         public string Oauth { get; set; }

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -68,6 +68,7 @@ namespace TwitchDownloaderCLI.Modes
                 TrimBeginningTime = inputOptions.TrimBeginningTime,
                 TrimEnding = inputOptions.TrimEndingTime > TimeSpan.Zero,
                 TrimEndingTime = inputOptions.TrimEndingTime,
+                TrimMode = inputOptions.TrimMode,
                 FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
                 TempFolder = inputOptions.TempFolder,
                 CacheCleanerCallback = directoryInfos =>

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -57,6 +57,9 @@ Time to trim ending. See [Time durations](#time-durations) for a more detailed e
 **--bandwidth**
 (Default: `-1`) The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or `-1` for no maximum.
 
+**--trim-mode**
+(Default: `Exact`) Sets the video trim handling. Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video. Valid values are: `Safe`, `Exact`.
+
 **--oauth**
 OAuth access token to download subscriber only VODs. <ins>**DO NOT SHARE YOUR OAUTH TOKEN WITH ANYONE.**</ins>
 

--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCore.Options
 {
@@ -19,5 +20,6 @@ namespace TwitchDownloaderCore.Options
         public string TempFolder { get; set; }
         public Func<DirectoryInfo[], DirectoryInfo[]> CacheCleanerCallback { get; set; }
         public Func<FileInfo, FileInfo> FileCollisionCallback { get; set; } = info => info;
+        public VideoTrimMode TrimMode { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Tools/Enums.cs
+++ b/TwitchDownloaderCore/Tools/Enums.cs
@@ -21,4 +21,10 @@
         None,
         UtcFull
     }
+
+    public enum VideoTrimMode
+    {
+        Safe,
+        Exact
+    }
 }

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -483,6 +483,11 @@ namespace TwitchDownloaderCore
                 }
             }
 
+            if (downloadOptions.TrimMode == VideoTrimMode.Safe)
+            {
+                startOffset = endOffset = endDuration = 0;
+            }
+
             videoLength = TimeSpan.FromSeconds((double)((endTime - endOffset) - (startTime + startOffset)));
 
             return new Range(startIndex, endIndex);

--- a/TwitchDownloaderWPF/App.config
+++ b/TwitchDownloaderWPF/App.config
@@ -232,6 +232,9 @@
             <setting name="AdjustUsernameVisibility" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="VodTrimMode" serializeAs="String">
+                <value>1</value>
+            </setting>
         </TwitchDownloaderWPF.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -68,7 +68,7 @@
             <StackPanel HorizontalAlignment="Left">
                 <TextBlock Text="{lex:Loc Length}" HorizontalAlignment="Right" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc Quality}" HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}" />
-                <TextBlock HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}"><Run Text="Trim Mode "/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video."/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                <TextBlock HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc VideoTrimMode}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc VideoTrimModeTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                 <TextBlock Text="{lex:Loc TrimVideo}" HorizontalAlignment="Right" Margin="0,11,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc VideoDownloadThreads}" HorizontalAlignment="Right" Margin="0,46,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock HorizontalAlignment="Right" Margin="0,21,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc Oauth}"/><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc OauthTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
@@ -78,8 +78,8 @@
                 <ComboBox x:Name="comboQuality" Margin="5,10,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 <StackPanel Margin="5,8,0,0">
                     <StackPanel Orientation="Horizontal">
-                        <RadioButton x:Name="RadioTrimSafe" Content="Safe" Margin="3,0,0,0" Checked="RadioTrimSafe_OnCheckedStateChanged" Unchecked="RadioTrimSafe_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
-                        <RadioButton x:Name="RadioTrimExact" Content="Exact" IsChecked="True" Margin="3,0,0,0" Checked="RadioTrimExact_OnCheckedStateChanged" Unchecked="RadioTrimExact_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                        <RadioButton x:Name="RadioTrimSafe" Content="{lex:Loc VideoTrimModeSafe}" Margin="3,0,0,0" Checked="RadioTrimSafe_OnCheckedStateChanged" Unchecked="RadioTrimSafe_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                        <RadioButton x:Name="RadioTrimExact" Content="{lex:Loc VideoTrimModeExact}" IsChecked="True" Margin="3,0,0,0" Checked="RadioTrimExact_OnCheckedStateChanged" Unchecked="RadioTrimExact_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                         <CheckBox x:Name="checkStart" VerticalAlignment="Center" HorizontalAlignment="Left" Checked="checkStart_OnCheckStateChanged" Unchecked="checkStart_OnCheckStateChanged" BorderBrush="{DynamicResource AppElementBorder}"/>

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -68,15 +68,20 @@
             <StackPanel HorizontalAlignment="Left">
                 <TextBlock Text="{lex:Loc Length}" HorizontalAlignment="Right" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc Quality}" HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}" />
-                <TextBlock Text="{lex:Loc TrimVideo}" HorizontalAlignment="Right" Margin="0,17,0,0" Foreground="{DynamicResource AppText}" />
+                <TextBlock HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}"><Run Text="Trim Mode "/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video."/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                <TextBlock Text="{lex:Loc TrimVideo}" HorizontalAlignment="Right" Margin="0,11,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc VideoDownloadThreads}" HorizontalAlignment="Right" Margin="0,46,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock HorizontalAlignment="Right" Margin="0,21,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc Oauth}"/><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc OauthTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
             </StackPanel>
             <StackPanel>
                 <TextBlock x:Name="labelLength" Text="0:0:0" Margin="5,0,0,0" Foreground="{DynamicResource AppText}" />
                 <ComboBox x:Name="comboQuality" Margin="5,10,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-                <StackPanel Margin="5,5,0,0">
+                <StackPanel Margin="5,8,0,0">
                     <StackPanel Orientation="Horizontal">
+                        <RadioButton x:Name="RadioTrimSafe" Content="Safe" Margin="3,0,0,0" Checked="RadioTrimSafe_OnCheckedStateChanged" Unchecked="RadioTrimSafe_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                        <RadioButton x:Name="RadioTrimExact" Content="Exact" IsChecked="True" Margin="3,0,0,0" Checked="RadioTrimExact_OnCheckedStateChanged" Unchecked="RadioTrimExact_OnCheckedStateChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                         <CheckBox x:Name="checkStart" VerticalAlignment="Center" HorizontalAlignment="Left" Checked="checkStart_OnCheckStateChanged" Unchecked="checkStart_OnCheckStateChanged" BorderBrush="{DynamicResource AppElementBorder}"/>
                         <TextBlock Margin="2,0,0,0" Text="{lex:Loc TrimStart}" VerticalAlignment="Center" Foreground="{DynamicResource AppText}" />
                         <hc:NumericUpDown Margin="3,-1,0,0" Minimum="0" Maximum="48" Value="0" x:Name="numStartHour" ValueChanged="numStartHour_ValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -215,6 +215,12 @@ namespace TwitchDownloaderWPF
                 FfmpegPath = "ffmpeg",
                 TempFolder = Settings.Default.TempPath
             };
+
+            if (RadioTrimSafe.IsChecked == true)
+                options.TrimMode = VideoTrimMode.Safe;
+            else if (RadioTrimExact.IsChecked == true)
+                options.TrimMode = VideoTrimMode.Exact;
+
             return options;
         }
 
@@ -338,6 +344,11 @@ namespace TwitchDownloaderWPF
             WebRequest.DefaultWebProxy = null;
             numDownloadThreads.Value = Settings.Default.VodDownloadThreads;
             TextOauth.Text = Settings.Default.OAuth;
+            _ = (VideoTrimMode)Settings.Default.VodTrimMode switch
+            {
+                VideoTrimMode.Exact => RadioTrimExact.IsChecked = true,
+                _ => RadioTrimSafe.IsChecked = true,
+            };
         }
 
         private void numDownloadThreads_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
@@ -545,6 +556,24 @@ namespace TwitchDownloaderWPF
             {
                 await GetVideoInfo();
                 e.Handled = true;
+            }
+        }
+
+        private void RadioTrimSafe_OnCheckedStateChanged(object sender, RoutedEventArgs e)
+        {
+            if (IsInitialized)
+            {
+                Settings.Default.VodTrimMode = (int)VideoTrimMode.Safe;
+                Settings.Default.Save();
+            }
+        }
+
+        private void RadioTrimExact_OnCheckedStateChanged(object sender, RoutedEventArgs e)
+        {
+            if (IsInitialized)
+            {
+                Settings.Default.VodTrimMode = (int)VideoTrimMode.Exact;
+                Settings.Default.Save();
             }
         }
     }

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -921,5 +921,17 @@ namespace TwitchDownloaderWPF.Properties {
                 this["AdjustUsernameVisibility"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int VodTrimMode {
+            get {
+                return ((int)(this["VodTrimMode"]));
+            }
+            set {
+                this["VodTrimMode"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -227,6 +227,9 @@
     <Setting Name="AdjustUsernameVisibility" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="VodTrimMode" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/README.md
+++ b/TwitchDownloaderWPF/README.md
@@ -45,6 +45,8 @@ To get started, input a valid link or ID to a VOD or highlight. If the VOD or hi
 
 **Quality**: Selects the quality of the download and provides an estimated file size. Occasionally Twitch calls the highest quality as 'Source' instead of the typical resolution formatting (1080p60 in the case of figure 1.1).
 
+**Trim Mode**: Sets the video trim handling. Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.
+
 **Trim**: Sets the start and end time to trim the video download in the format \[hours\] \[minutes\] \[seconds\]. Trimming the video will result in a smaller total download.
 
 **Download Threads**: The amount of parallel download threads to be dispatched.

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -2040,7 +2040,7 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select Render Rage (Seconds).
+        ///   Looks up a localized string similar to Select Render Range (Seconds).
         /// </summary>
         public static string TitleRenderRange {
             get {
@@ -2378,6 +2378,42 @@ namespace TwitchDownloaderWPF.Translations {
         public static string VideoTitle {
             get {
                 return ResourceManager.GetString("VideoTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trim Mode .
+        /// </summary>
+        public static string VideoTrimMode {
+            get {
+                return ResourceManager.GetString("VideoTrimMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exact.
+        /// </summary>
+        public static string VideoTrimModeExact {
+            get {
+                return ResourceManager.GetString("VideoTrimModeExact", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Safe.
+        /// </summary>
+        public static string VideoTrimModeSafe {
+            get {
+                return ResourceManager.GetString("VideoTrimModeSafe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video..
+        /// </summary>
+        public static string VideoTrimModeTooltip {
+            get {
+                return ResourceManager.GetString("VideoTrimModeTooltip", resourceCulture);
             }
         }
         

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -928,4 +928,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -927,4 +927,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -928,4 +928,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -926,4 +926,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -927,4 +927,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -926,4 +926,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -926,4 +926,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -927,4 +927,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -928,4 +928,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -927,4 +927,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>Remember my choice for this session</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -929,4 +929,16 @@
   <data name="FileAlreadyExistsRememberMyChoice" xml:space="preserve">
     <value>记住我的选择</value>
   </data>
+  <data name="VideoTrimMode" xml:space="preserve">
+    <value>Trim Mode </value><comment>Leave a trailing space</comment>
+  </data>
+  <data name="VideoTrimModeSafe" xml:space="preserve">
+    <value>Safe</value>
+  </data>
+  <data name="VideoTrimModeExact" xml:space="preserve">
+    <value>Exact</value>
+  </data>
+  <data name="VideoTrimModeTooltip" xml:space="preserve">
+    <value>Videos trimmed with exact trim may rarely experience video/audio stuttering within the first/last few seconds. Safe trimming is guaranteed to not stutter but may result in a slightly longer video.</value>
+  </data>
 </root>


### PR DESCRIPTION
I tried 3 different solutions to the problem but only this one provided good results and also didn't corrupt the rest of the video.

- Fixes #531 
- Fixes #863 
- Fixes #556