### PR TITLE
Add test runner job to build-pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
-      - run: dotnet test TwitchDownloaderCLI.Tests
-      - run: dotnet test TwitchDownloaderCore.Tests
+      - name: Run TwitchDownloaderCLI Tests
+        run: dotnet test TwitchDownloaderCLI.Tests
+      - name: Run TwitchDownloaderCore Tests
+        run: dotnet test TwitchDownloaderCore.Tests
 
   build-gui:
     runs-on: windows-latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,7 +10,12 @@ jobs:
   run-tests:
     runs-on: ubuntu-20.04
     steps:
-      - run: dotnet test
+      - uses: actions/checkout@v4.1.7
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+      - run: dotnet test TwitchDownloaderWPF.sln
         continue-on-error: true
 
   build-gui:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,9 +7,15 @@ on:
     types: [ opened, reopened ]
 
 jobs:
-  
+  run-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: dotnet test
+        continue-on-error: true
+
   build-gui:
     runs-on: windows-latest
+    needs: [run-tests]
     env:
      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
  

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,11 +15,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
-      - run: dotnet test TwitchDownloaderWPF.sln
+      - run: dotnet test TwitchDownloaderCLI.Tests
+      - run: dotnet test TwitchDownloaderCore.Tests
 
   build-gui:
     runs-on: windows-latest
-    needs: [run-tests]
     env:
      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
  

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Setup .NET

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - run: dotnet test TwitchDownloaderWPF.sln
-        continue-on-error: true
 
   build-gui:
     runs-on: windows-latest

--- a/TwitchDownloaderCore.Tests/ToolTests/FilenameServiceTests.cs
+++ b/TwitchDownloaderCore.Tests/ToolTests/FilenameServiceTests.cs
@@ -23,6 +23,7 @@ namespace TwitchDownloaderCore.Tests.ToolTests
         [InlineData("{length_custom=\"hh\\-mm\\-ss\"}", "04-04-04")]
         public void CorrectlyGeneratesIndividualTemplates(string template, string expected)
         {
+            Assert.Fail();
             var (title, id, date, channel, trimStart, trimEnd, viewCount, game) = GetExampleInfo();
 
             var result = FilenameService.GetFilename(template, title, id, date, channel, trimStart, trimEnd, viewCount, game);

--- a/TwitchDownloaderCore.Tests/ToolTests/FilenameServiceTests.cs
+++ b/TwitchDownloaderCore.Tests/ToolTests/FilenameServiceTests.cs
@@ -23,7 +23,6 @@ namespace TwitchDownloaderCore.Tests.ToolTests
         [InlineData("{length_custom=\"hh\\-mm\\-ss\"}", "04-04-04")]
         public void CorrectlyGeneratesIndividualTemplates(string template, string expected)
         {
-            Assert.Fail();
             var (title, id, date, channel, trimStart, trimEnd, viewCount, game) = GetExampleInfo();
 
             var result = FilenameService.GetFilename(template, title, id, date, channel, trimStart, trimEnd, viewCount, game);


### PR DESCRIPTION
Tests are not mandatory for the build steps to run, its just nice to know when tests are failing if you forget to run them locally.