### PR TITLE
Only escape backslashes, single quotes, and newlines when writing ffmetadata

### DIFF
--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -94,17 +94,14 @@ namespace TwitchDownloaderCore.Tools
                 return str;
             }
 
-            if (str.AsSpan().IndexOfAny(@$"=;#\{LINE_FEED}") == -1)
+            if (str.AsSpan().IndexOfAny(@$"\'") == -1)
             {
                 return str;
             }
 
             return new StringBuilder(str)
-                .Replace("=", @"\=")
-                .Replace(";", @"\;")
-                .Replace("#", @"\#")
                 .Replace(@"\", @"\\")
-                .Replace(LINE_FEED, $@"\{LINE_FEED}")
+                .Replace("'", @"\'")
                 .ToString();
         }
     }

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -87,6 +87,7 @@ namespace TwitchDownloaderCore.Tools
             }
         }
 
+        // https://trac.ffmpeg.org/ticket/11096 The Ffmpeg documentation is outdated and =;# do not need to be escaped.
         private static string SanitizeKeyValue(string str)
         {
             if (string.IsNullOrWhiteSpace(str))

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -94,7 +94,7 @@ namespace TwitchDownloaderCore.Tools
                 return str;
             }
 
-            if (str.AsSpan().IndexOfAny(@$"\'") == -1)
+            if (str.AsSpan().IndexOfAny(@$"\'{LINE_FEED}") == -1)
             {
                 return str;
             }
@@ -102,6 +102,7 @@ namespace TwitchDownloaderCore.Tools
             return new StringBuilder(str)
                 .Replace(@"\", @"\\")
                 .Replace("'", @"\'")
+                .Replace(LINE_FEED, $@"\{LINE_FEED}")
                 .ToString();
         }
     }


### PR DESCRIPTION
this documentation is correct:
https://ffmpeg.org/ffmpeg-utils.html#Quoting-and-escaping

this is outdated:
https://ffmpeg.org/ffmpeg-formats.html#metadata

Escaping only backslash `\\` is enough but single quotes can be escaped no problem.