### PR TITLE
Embed more metadata in videos and clips

### DIFF
--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -224,8 +224,7 @@ namespace TwitchDownloaderCore
             Process process = null;
             try
             {
-                await FfmpegMetadata.SerializeAsync(metadataFile, clipMetadata.broadcaster?.displayName, downloadOptions.Id, clipMetadata.title, clipMetadata.createdAt, clipMetadata.viewCount,
-                    videoMomentEdges: new[] { clipChapter }, cancellationToken: cancellationToken);
+                await FfmpegMetadata.SerializeAsync(metadataFile, downloadOptions.Id, clipMetadata, new[] { clipChapter }, cancellationToken);
 
                 process = new Process
                 {

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -224,7 +224,7 @@ namespace TwitchDownloaderCore
             Process process = null;
             try
             {
-                await FfmpegMetadata.SerializeAsync(metadataFile, downloadOptions.Id, clipMetadata, new[] { clipChapter }, cancellationToken);
+                await FfmpegMetadata.SerializeAsync(metadataFile, downloadOptions.Id, clipMetadata, new[] { clipChapter });
 
                 process = new Process
                 {

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -43,9 +43,9 @@ namespace TwitchDownloaderCore.Tools
         {
             // ReSharper disable once StringLiteralTypo
             await sw.WriteLineAsync(";FFMETADATA1");
-            await sw.WriteLineAsync($"title={SanitizeKeyValue(title)} ({SanitizeKeyValue(id)})");
+            await sw.WriteLineAsync($"title={EscapeMetadataValue(title)} ({EscapeMetadataValue(id)})");
             if (!string.IsNullOrWhiteSpace(streamer))
-                await sw.WriteLineAsync($"artist={SanitizeKeyValue(streamer)}");
+                await sw.WriteLineAsync($"artist={EscapeMetadataValue(streamer)}");
             await sw.WriteLineAsync($"date={createdAt:yyyy}"); // The 'date' key becomes 'year' in most formats
             if (!string.IsNullOrWhiteSpace(game))
                 await sw.WriteLineAsync($"genre={game}");
@@ -53,13 +53,13 @@ namespace TwitchDownloaderCore.Tools
             if (!string.IsNullOrWhiteSpace(description))
             {
                 // We could use the 'description' key, but so few media players support mp4 descriptions that users would probably think it was missing
-                await sw.WriteLineAsync(@$"{SanitizeKeyValue(description.TrimEnd())}\");
+                await sw.WriteLineAsync(@$"{EscapeMetadataValue(description.TrimEnd())}\");
                 await sw.WriteLineAsync(@"------------------------\");
             }
             if (!string.IsNullOrWhiteSpace(clipper))
-                await sw.WriteLineAsync($@"Clipped by: {SanitizeKeyValue(clipper)}\");
-            await sw.WriteLineAsync(@$"Created at: {SanitizeKeyValue(createdAt.ToString("u"))}\");
-            await sw.WriteLineAsync(@$"Video id: {SanitizeKeyValue(id)}\");
+                await sw.WriteLineAsync($@"Clipped by: {EscapeMetadataValue(clipper)}\");
+            await sw.WriteLineAsync(@$"Created at: {EscapeMetadataValue(createdAt.ToString("u"))}\");
+            await sw.WriteLineAsync(@$"Video id: {EscapeMetadataValue(id)}\");
             await sw.WriteLineAsync(@$"Views: {viewCount}");
         }
 
@@ -102,7 +102,7 @@ namespace TwitchDownloaderCore.Tools
                 await sw.WriteLineAsync("TIMEBASE=1/1000");
                 await sw.WriteLineAsync($"START={startMillis}");
                 await sw.WriteLineAsync($"END={startMillis + lengthMillis}");
-                await sw.WriteLineAsync($"title={SanitizeKeyValue(gameName)}");
+                await sw.WriteLineAsync($"title={EscapeMetadataValue(gameName)}");
             }
         }
 
@@ -128,7 +128,9 @@ namespace TwitchDownloaderCore.Tools
         }
 
         // https://trac.ffmpeg.org/ticket/11096 The Ffmpeg documentation is outdated and =;# do not need to be escaped.
-        private static string SanitizeKeyValue(string str)
+        // TODO: Use nameof(filename) when C# 11+
+        [return: NotNullIfNotNull("str")]
+        private static string EscapeMetadataValue([AllowNull] string str)
         {
             if (string.IsNullOrWhiteSpace(str))
             {

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 
@@ -15,7 +14,7 @@ namespace TwitchDownloaderCore.Tools
     {
         private const string LINE_FEED = "\u000A";
 
-        public static async Task SerializeAsync(string filePath, string videoId, VideoInfo videoInfo, TimeSpan startOffset, TimeSpan videoLength, IEnumerable<VideoMomentEdge> videoMomentEdges, CancellationToken cancellationToken = default)
+        public static async Task SerializeAsync(string filePath, string videoId, VideoInfo videoInfo, TimeSpan startOffset, TimeSpan videoLength, IEnumerable<VideoMomentEdge> videoMomentEdges)
         {
             await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
             await using var sw = new StreamWriter(fs) { NewLine = LINE_FEED };
@@ -23,13 +22,11 @@ namespace TwitchDownloaderCore.Tools
             var streamer = GetUserName(videoInfo.owner.displayName, videoInfo.owner.login);
             var description = videoInfo.description?.Replace("  \n", "\n").Replace("\n\n", "\n").TrimEnd();
             await SerializeGlobalMetadata(sw, streamer, videoId, videoInfo.title, videoInfo.createdAt, videoInfo.viewCount, description, videoInfo.game?.displayName);
-            await fs.FlushAsync(cancellationToken);
 
             await SerializeChapters(sw, videoMomentEdges, startOffset, videoLength);
-            await fs.FlushAsync(cancellationToken);
         }
 
-        public static async Task SerializeAsync(string filePath, string videoId, Clip clip, IEnumerable<VideoMomentEdge> videoMomentEdges, CancellationToken cancellationToken = default)
+        public static async Task SerializeAsync(string filePath, string videoId, Clip clip, IEnumerable<VideoMomentEdge> videoMomentEdges)
         {
             await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
             await using var sw = new StreamWriter(fs) { NewLine = LINE_FEED };
@@ -37,10 +34,8 @@ namespace TwitchDownloaderCore.Tools
             var streamer = GetUserName(clip.broadcaster.displayName, clip.broadcaster.login);
             var clipper = GetUserName(clip.curator.displayName, clip.curator.login);
             await SerializeGlobalMetadata(sw, streamer, videoId, clip.title, clip.createdAt, clip.viewCount, game: clip.game?.displayName, clipper: clipper);
-            await fs.FlushAsync(cancellationToken);
 
             await SerializeChapters(sw, videoMomentEdges);
-            await fs.FlushAsync(cancellationToken);
         }
 
         private static async Task SerializeGlobalMetadata(StreamWriter sw, [AllowNull] string streamer, string id, string title, DateTime createdAt, int viewCount, [AllowNull] string description = null, [AllowNull] string game = null,

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -105,8 +105,8 @@ namespace TwitchDownloaderCore
                 _progress.SetTemplateStatus("Finalizing Video {0}% [4/4]", 0);
 
                 string metadataPath = Path.Combine(downloadFolder, "metadata.txt");
-                await FfmpegMetadata.SerializeAsync(metadataPath, downloadOptions.Id.ToString(), videoInfo, downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero,
-                    videoLength, videoChapterResponse.data.video.moments.edges, cancellationToken);
+                await FfmpegMetadata.SerializeAsync(metadataPath, downloadOptions.Id.ToString(), videoInfo, downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero, videoLength,
+                    videoChapterResponse.data.video.moments.edges);
 
                 var concatListPath = Path.Combine(downloadFolder, "concat.txt");
                 await FfmpegConcatList.SerializeAsync(concatListPath, playlist, videoListCrop, cancellationToken);

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -105,8 +105,7 @@ namespace TwitchDownloaderCore
                 _progress.SetTemplateStatus("Finalizing Video {0}% [4/4]", 0);
 
                 string metadataPath = Path.Combine(downloadFolder, "metadata.txt");
-                await FfmpegMetadata.SerializeAsync(metadataPath, videoInfo.owner.displayName, downloadOptions.Id.ToString(), videoInfo.title, videoInfo.createdAt, videoInfo.viewCount,
-                    videoInfo.description?.Replace("  \n", "\n").Replace("\n\n", "\n").TrimEnd(), downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero,
+                await FfmpegMetadata.SerializeAsync(metadataPath, downloadOptions.Id.ToString(), videoInfo, downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero,
                     videoLength, videoChapterResponse.data.video.moments.edges, cancellationToken);
 
                 var concatListPath = Path.Combine(downloadFolder, "concat.txt");


### PR DESCRIPTION
Adds game to `genre` field and `Clipped by: <name>` to clip descriptions. Ascii usernames are also now included in fields containing user names if the display name is non-ascii.