### PR TITLE
Fix FFmpeg downloaders fetching >4 year old FFmpeg builds on Windows

### DIFF
--- a/TwitchDownloaderCLI/Modes/FfmpegHandler.cs
+++ b/TwitchDownloaderCLI/Modes/FfmpegHandler.cs
@@ -37,15 +37,14 @@ namespace TwitchDownloaderCLI.Modes
 
             using var progressHandler = new XabeProgressHandler(progress);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                FFmpegDownloader.GetLatestVersion(FFmpegVersion.Full, progressHandler).GetAwaiter().GetResult();
-                return;
-            }
-
             FFmpegDownloader.GetLatestVersion(FFmpegVersion.Official, progressHandler).GetAwaiter().GetResult();
 
             Console.WriteLine();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
 
             try
             {

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -104,7 +104,7 @@ namespace TwitchDownloaderWPF
                 var oldTitle = Title;
                 try
                 {
-                    await FFmpegDownloader.GetLatestVersion(FFmpegVersion.Full, new FfmpegDownloadProgress());
+                    await FFmpegDownloader.GetLatestVersion(FFmpegVersion.Official, new FfmpegDownloadProgress());
 
                     // Flash the window to signify that FFmpeg has been downloaded
                     FlashTaskbarIconIfNotForeground(TimeSpan.FromSeconds(3));

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -99,7 +99,7 @@ namespace TwitchDownloaderWPF
 #endif
 
             // TODO: extract FFmpeg handling to a dedicated service
-            if (!File.Exists("ffmpeg.exe"))
+            if (!File.Exists("ffmpeg.exe") || File.GetLastWriteTime("ffmpeg.exe") < DateTime.Now - TimeSpan.FromDays(365))
             {
                 var oldTitle = Title;
                 try


### PR DESCRIPTION
The library literally does nothing but provide FFmpeg builds, how is it so hard to maintain that builds are over 4 years out of date??