### PR TITLE
Render continuing anonymous gift subs correctly

### DIFF
--- a/TwitchDownloaderCore.Tests/ToolTests/HighlightIconsTests.cs
+++ b/TwitchDownloaderCore.Tests/ToolTests/HighlightIconsTests.cs
@@ -98,8 +98,12 @@ namespace TwitchDownloaderCore.Tests.ToolTests
         // Special case, in separate method.
         // ContinuingGift
         [InlineData(
-            "{\"body\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"}],\"user_color\":\"#8A2BE2\",\"emoticons\":[]}",
+            "{\"body\":\"viewer8 is continuing the Gift Sub they got from viewer9! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is continuing the Gift Sub they got from viewer9! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"}],\"user_color\":\"#8A2BE2\",\"emoticons\":[]}",
             HighlightType.ContinuingGift)]
+        // ContinuingGift
+        [InlineData(
+            "{\"body\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"}],\"user_color\":\"#8A2BE2\",\"emoticons\":[]}",
+            HighlightType.ContinuingAnonymousGift)]
         // PayingForward
         [InlineData(
             "{\"body\":\"viewer8 is paying forward the Gift they got from an anonymous gifter to the community! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is paying forward the Gift they got from an anonymous gifter to the community! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"},{\"_id\":\"bits\",\"version\":\"100\"}],\"user_color\":null,\"emoticons\":[]}",

--- a/TwitchDownloaderCore.Tests/ToolTests/HighlightIconsTests.cs
+++ b/TwitchDownloaderCore.Tests/ToolTests/HighlightIconsTests.cs
@@ -100,7 +100,7 @@ namespace TwitchDownloaderCore.Tests.ToolTests
         [InlineData(
             "{\"body\":\"viewer8 is continuing the Gift Sub they got from viewer9! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is continuing the Gift Sub they got from viewer9! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"}],\"user_color\":\"#8A2BE2\",\"emoticons\":[]}",
             HighlightType.ContinuingGift)]
-        // ContinuingGift
+        // ContinuingAnonymousGift
         [InlineData(
             "{\"body\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"bits_spent\":0,\"fragments\":[{\"text\":\"viewer8 is continuing the Gift Sub they got from an anonymous user! \",\"emoticon\":null}],\"user_badges\":[{\"_id\":\"subscriber\",\"version\":\"0\"}],\"user_color\":\"#8A2BE2\",\"emoticons\":[]}",
             HighlightType.ContinuingAnonymousGift)]

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -709,6 +709,7 @@ namespace TwitchDownloaderCore
                 case HighlightType.GiftedMany:
                 case HighlightType.GiftedSingle:
                 case HighlightType.GiftedAnonymous:
+                case HighlightType.ContinuingAnonymousGift:
                     DrawGiftMessage(comment, sectionImages, emotePositionList, ref drawPos, defaultPos, highlightIcon, iconPoint);
                     break;
                 case HighlightType.ChannelPointHighlight:

--- a/TwitchDownloaderCore/Tools/HighlightIcons.cs
+++ b/TwitchDownloaderCore/Tools/HighlightIcons.cs
@@ -17,6 +17,7 @@ namespace TwitchDownloaderCore.Tools
         GiftedMany,
         GiftedSingle,
         ContinuingGift,
+        ContinuingAnonymousGift,
         GiftedAnonymous,
         PayingForward,
         ChannelPointHighlight,
@@ -104,8 +105,13 @@ namespace TwitchDownloaderCore.Tools
                 if (bodyWithoutName.StartsWith(" gifted a Tier"))
                     return HighlightType.GiftedSingle;
 
-                if (bodyWithoutName.StartsWith(" is continuing the Gift Sub"))
+                if (bodyWithoutName.StartsWith(" is continuing the Gift Sub they got from"))
+                {
+                    if (bodyWithoutName.EndsWith("from an anonymous user! "))
+                        return HighlightType.ContinuingAnonymousGift;
+
                     return HighlightType.ContinuingGift;
+                }
 
                 if (bodyWithoutName.StartsWith(" is paying forward the Gift they got from"))
                     return HighlightType.PayingForward;
@@ -162,7 +168,7 @@ namespace TwitchDownloaderCore.Tools
                 HighlightType.SubscribedPrime => _subscribedPrimeIcon ??= GenerateSvgIcon(SUBSCRIBED_PRIME_ICON_SVG, _purple),
                 HighlightType.GiftedSingle => _giftSingleIcon ??= GenerateSvgIcon(GIFTED_SINGLE_ICON_SVG, textColor),
                 HighlightType.GiftedMany => _giftManyIcon ??= GenerateGiftedManyIcon(),
-                HighlightType.GiftedAnonymous => _giftAnonymousIcon ??= GenerateSvgIcon(GIFTED_ANONYMOUS_ICON_SVG, textColor),
+                HighlightType.GiftedAnonymous or HighlightType.ContinuingAnonymousGift => _giftAnonymousIcon ??= GenerateSvgIcon(GIFTED_ANONYMOUS_ICON_SVG, textColor),
                 HighlightType.BitBadgeTierNotification => _bitBadgeTierNotificationIcon ??= GenerateSvgIcon(BIT_BADGE_TIER_NOTIFICATION_ICON_SVG, textColor),
                 HighlightType.WatchStreak => _watchStreakIcon ??= GenerateSvgIcon(WATCH_STREAK_ICON_SVG, textColor),
                 HighlightType.CharityDonation => _charityDonationIcon ??= GenerateSvgIcon(CHARITY_DONATION_ICON_SVG, textColor),


### PR DESCRIPTION
Used to render like bottom, now renders as top (parity with Twitch chat).
![image](https://github.com/user-attachments/assets/e6464114-99a8-404e-bbf0-ba0a5a88b58f)
