### PR TITLE
Correctly use ref parameter when flashing taskbar icon

### DIFF
--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -153,7 +153,7 @@ namespace TwitchDownloaderWPF
                 FlashCount = uint.MaxValue,
                 Timeout = 0
             };
-            _ = NativeFunctions.FlashWindowEx(flashWInfo);
+            _ = NativeFunctions.FlashWindowEx(ref flashWInfo);
 
             await Task.Delay(flashDuration);
 
@@ -165,7 +165,7 @@ namespace TwitchDownloaderWPF
                 FlashCount = 0,
                 Timeout = 0
             };
-            _ = NativeFunctions.FlashWindowEx(stopFlashWInfo);
+            _ = NativeFunctions.FlashWindowEx(ref stopFlashWInfo);
         }
 
         private class FfmpegDownloadProgress : IProgress<ProgressInfo>

--- a/TwitchDownloaderWPF/Services/NativeFunctions.cs
+++ b/TwitchDownloaderWPF/Services/NativeFunctions.cs
@@ -15,7 +15,7 @@ namespace TwitchDownloaderWPF.Services
 
         [DllImport("user32.dll", EntryPoint = "FlashWindowEx", PreserveSig = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool FlashWindowEx(FlashWInfo info);
+        public static extern bool FlashWindowEx([In] ref FlashWInfo info);
 
         // https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-flashwinfo
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
I'm surprised this worked previously when not passing as a pointer