### PR TITLE
Add null check for emoticon id in TwitchHelper.GetEmotes() (#1254)

### DIFF
--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -539,7 +539,7 @@ namespace TwitchDownloaderCore
 
                 foreach (var id in comment.message.fragments
                              .Select(f => f.emoticon?.emoticon_id)
-                             .Where(id => !alreadyAdded.Contains(id) && !failedEmotes.Contains(id)))
+                             .Where(id => id != null && !alreadyAdded.Contains(id) && !failedEmotes.Contains(id)))
                 {
                     try
                     {


### PR DESCRIPTION
See #1254 for details. I'm not sure whether this is the proper solution, but in case it is here's a PR for it.