### PR TITLE
Add auto-update functionality to CLI

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/UpdateArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/UpdateArgs.cs
@@ -6,8 +6,8 @@ namespace TwitchDownloaderCLI.Modes.Arguments
     [Verb("update", HelpText = "Manages updating the CLI")]
     internal sealed class UpdateArgs : ITwitchDownloaderArgs
     {
-        [Option('c', "check", Default = true, Required = false, HelpText = "Checks whether a new version of the CLI is available")]
-        public bool CheckForUpdate { get; set; }
+        [Option('f', "force", Default = false, Required = false, HelpText = "Skips the yes/no prompt for updating")]
+        public bool ForceUpdate { get; set; }
 
         // Interface args
         public bool? ShowBanner { get; set; }

--- a/TwitchDownloaderCLI/Modes/Arguments/UpdateArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/UpdateArgs.cs
@@ -1,0 +1,16 @@
+﻿using CommandLine;
+using TwitchDownloaderCLI.Models;
+
+namespace TwitchDownloaderCLI.Modes.Arguments
+{
+    [Verb("update", HelpText = "Manages updating the CLI")]
+    internal sealed class UpdateArgs : ITwitchDownloaderArgs
+    {
+        [Option('c', "check", Default = true, Required = false, HelpText = "Checks whether a new version of the CLI is available")]
+        public bool CheckForUpdate { get; set; }
+
+        // Interface args
+        public bool? ShowBanner { get; set; }
+        public LogLevel LogLevel { get; set; }
+    }
+}

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -57,14 +57,14 @@ namespace TwitchDownloaderCLI.Modes
 
             Console.WriteLine($"A new version of TwitchDownloader CLI is available ({newVersionString})!");
 
-            string origUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url").InnerText;
+            string origUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url-cli").InnerText;
             string urlBase = new Regex(@"(.*)\/").Match(origUrl).Groups[1].Value;
 
             string origPackageName = origUrl.Split("/").Last();
-            string packageNameBase = new Regex(@"(.*)-(?:.*)-(?:.*)").Match(origPackageName).Groups[1].Value;
+            string packageNameBase = new Regex(@"(.*)-\{0\}").Match(origPackageName).Groups[1].Value;
 
             // Construct the appropriate package name
-            string packageName = ConstructPackageName(Regex.Replace(packageNameBase, "GUI", "CLI"));
+            string packageName = ConstructPackageName(packageNameBase);
 
             if (packageName == string.Empty)
             {

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -17,15 +17,12 @@ namespace TwitchDownloaderCLI.Modes
 
         public static void ParseArgs(UpdateArgs args)
         {
-            if (args.CheckForUpdate)
-            {
 #if !DEBUG
-                CheckForUpdate().GetAwaiter().GetResult();
+            CheckForUpdate(args.ForceUpdate).GetAwaiter().GetResult();
 #endif
-            }
         }
 
-        private static async Task CheckForUpdate()
+        private static async Task CheckForUpdate(bool forceUpdate)
         {
             // Get the old version
             string headerString = HeadingInfo.Default.ToString();
@@ -61,16 +58,24 @@ namespace TwitchDownloaderCLI.Modes
             if (newVersion.CompareTo(oldVersion) > 0)
             {
                 Console.WriteLine($"A new version of TwitchDownloader CLI is available ({newVersionString})!");
-                Console.WriteLine("Would you like to auto-update? (y/n):");
-                var input = Console.ReadLine();
 
-                if (input == "y")
+                // We want the download for the CLI version, not the GUI version
+                string oldUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url").InnerText;
+                string newUrl = Regex.Replace(oldUrl, "GUI", "CLI");
+
+                if (forceUpdate)
                 {
-                    // We want the download for the CLI version, not the GUI version
-                    string oldUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url").InnerText;
-                    string newUrl = Regex.Replace(oldUrl, "GUI", "CLI");
-                    
                     await AutoUpdate(newUrl);
+                }
+                else
+                {
+                    Console.WriteLine("Would you like to auto-update? (y/n):");
+                    var input = Console.ReadLine();
+
+                    if (input == "y")
+                    {
+                        await AutoUpdate(newUrl);
+                    }
                 }
             }
             else if (newVersion.CompareTo(oldVersion) == 0)

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -60,11 +60,8 @@ namespace TwitchDownloaderCLI.Modes
             string origUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url-cli").InnerText;
             string urlBase = new Regex(@"(.*)\/").Match(origUrl).Groups[1].Value;
 
-            string origPackageName = origUrl.Split("/").Last();
-            string packageNameBase = new Regex(@"(.*)-\{0\}").Match(origPackageName).Groups[1].Value;
-
             // Construct the appropriate package name
-            string packageName = ConstructPackageName(packageNameBase);
+            string packageName = ConstructPackageName(origUrl.Split("/").Last());
 
             if (packageName == string.Empty)
             {
@@ -98,20 +95,21 @@ namespace TwitchDownloaderCLI.Modes
             }
         }
 
-        private static string ConstructPackageName(string packageNameBase)
+        private static string ConstructPackageName(string origPackageName)
         {
             var arch = RuntimeInformation.OSArchitecture;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return packageNameBase + "-Windows-x64.zip";
+                return string.Format(origPackageName, "Windows-x64");
+                
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return arch switch
                 {
-                    Architecture.X64 => packageNameBase + "-MacOS-x64.zip",
-                    Architecture.Arm64 => packageNameBase + "-MacOSArm64.zip",
+                    Architecture.X64 => string.Format(origPackageName, "MacOS-x64"),
+                    Architecture.Arm64 => string.Format(origPackageName, "MacOSArm64"),
                     _ => string.Empty
                 };
             }
@@ -120,15 +118,15 @@ namespace TwitchDownloaderCLI.Modes
                 // TODO: Change to 'linux-musl-x64' when .NET 8+
                 if (RuntimeInformation.RuntimeIdentifier.Contains("musl"))
                 {
-                    return packageNameBase + "-LinuxAlpine-x64.zip";
+                    return string.Format(origPackageName, "LinuxAlpine-x64");
                 } 
                 else
                 {
                     return arch switch
                     {
-                        Architecture.X64 => packageNameBase + "-Linux-x64.zip",
-                        Architecture.Arm => packageNameBase + "-LinuxArm.zip",
-                        Architecture.Arm64 => packageNameBase + "-LinuxArm64.zip",
+                        Architecture.X64 => string.Format(origPackageName, "Linux-x64"),
+                        Architecture.Arm => string.Format(origPackageName, "LinuxArm"),
+                        Architecture.Arm64 => string.Format(origPackageName, "LinuxArm64"),
                         _ => string.Empty
                     };
                 }    

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -119,8 +119,7 @@ namespace TwitchDownloaderCLI.Modes
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // TODO: Change to 'linux-musl-x64' when .NET 8+
-                if (RuntimeInformation.RuntimeIdentifier == "linux.kernel.version-musl-x64" ||
-                    RuntimeInformation.RuntimeIdentifier == "linux-musl.kernel.version-x64")
+                if (RuntimeInformation.RuntimeIdentifier.Contains("musl"))
                 {
                     return packageNameBase + "-LinuxAlpine-x64.zip";
                 } 

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -24,10 +24,10 @@ namespace TwitchDownloaderCLI.Modes
 
         public static void ParseArgs(UpdateArgs args)
         {
-#if DEBUG
-            Console.WriteLine("Auto-update is not supported for debug builds");
-#else
             var progress = new CliTaskProgress(args.LogLevel);
+#if DEBUG
+            progress.LogInfo("Auto-update is not supported for debug builds");
+#else
             CheckForUpdate(args.ForceUpdate, progress).GetAwaiter().GetResult();
 #endif
         }
@@ -43,7 +43,7 @@ namespace TwitchDownloaderCLI.Modes
 
             if (string.IsNullOrEmpty(xmlString))
             {
-                progress.LogError("Internal error: could not parse remote update info XML!");
+                progress.LogError("Could not parse remote update info XML!");
             }
 
             XmlDocument xmlDoc = new XmlDocument();
@@ -55,11 +55,11 @@ namespace TwitchDownloaderCLI.Modes
 
             if (newVersion <= oldVersion)
             {
-                Console.WriteLine("You have the latest version of TwitchDownloader CLI!");
+                progress.LogInfo("You have the latest version of TwitchDownloader CLI!");
                 return;
             }
 
-            Console.WriteLine($"A new version of TwitchDownloader CLI is available ({newVersionString})!");
+            progress.LogInfo($"A new version of TwitchDownloader CLI is available ({newVersionString})!");
 
             string origUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url-cli").InnerText;
             string urlBase = new Regex(@"(.*)\/").Match(origUrl).Groups[1].Value;
@@ -148,15 +148,15 @@ namespace TwitchDownloaderCLI.Modes
 
             if (string.IsNullOrEmpty(currentExePath))
             {
-                progress.LogError("Internal error: Current executable path is null or empty!");
+                progress.LogError("Current executable path is null or empty!");
             }
 
             if (string.IsNullOrEmpty(updateDir))
             {
-                progress.LogError("Internal error: Update directory is null or empty!");
+                progress.LogError("Update directory is null or empty!");
             }
 
-            Console.WriteLine("Downloading update archive...");
+            progress.LogInfo("Downloading update archive...");
 
             using var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
@@ -188,7 +188,7 @@ namespace TwitchDownloaderCLI.Modes
                 }
             }
 
-            Console.WriteLine("TwitchDownloader CLI has been updated!");
+            progress.LogInfo("TwitchDownloader CLI has been updated!");
 
             void DownloadProgressHandler(StreamCopyProgress streamProgress)
             {

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -109,29 +109,31 @@ namespace TwitchDownloaderCLI.Modes
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                switch(arch)
+                return arch switch
                 {
-                    case Architecture.X64:
-                        return packageNameBase + "-MacOS-x64.zip";
-                    case Architecture.Arm64:
-                        return packageNameBase + "-MacOSArm64.zip";
-                    default:
-                        return string.Empty;
-                }
+                    Architecture.X64 => packageNameBase + "-MacOS-x64.zip",
+                    Architecture.Arm64 => packageNameBase + "-MacOSArm64.zip",
+                    _ => string.Empty
+                };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                switch(arch)
+                // TODO: Change to 'linux-musl-x64' when .NET 8+
+                if (RuntimeInformation.RuntimeIdentifier == "linux.kernel.version-musl-x64" ||
+                    RuntimeInformation.RuntimeIdentifier == "linux-musl.kernel.version-x64")
                 {
-                    case Architecture.X64:
-                        return packageNameBase + "-Linux-x64.zip";
-                    case Architecture.Arm:
-                        return packageNameBase + "-LinuxArm.zip";
-                    case Architecture.Arm64:
-                        return packageNameBase + "-LinuxArm64.zip";
-                    default:
-                        return string.Empty;
-                }
+                    return packageNameBase + "-LinuxAlpine-x64.zip";
+                } 
+                else
+                {
+                    return arch switch
+                    {
+                        Architecture.X64 => packageNameBase + "-Linux-x64.zip",
+                        Architecture.Arm => packageNameBase + "-LinuxArm.zip",
+                        Architecture.Arm64 => packageNameBase + "-LinuxArm64.zip",
+                        _ => string.Empty
+                    };
+                }    
             }
 
             return string.Empty;

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -1,0 +1,126 @@
+﻿using CommandLine.Text;
+using System;
+using System.Net.Http;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Linq;
+using System.IO.Compression;
+using TwitchDownloaderCLI.Modes.Arguments;
+
+namespace TwitchDownloaderCLI.Modes
+{
+    internal static class UpdateHandler
+    {
+        private static HttpClient _client = new();
+
+        public static void ParseArgs(UpdateArgs args)
+        {
+            if (args.CheckForUpdate)
+            {
+#if !DEBUG
+                CheckForUpdate().GetAwaiter().GetResult();
+#endif
+            }
+        }
+
+        private static async Task CheckForUpdate()
+        {
+            // Get the old version
+            string headerString = HeadingInfo.Default.ToString();
+            Regex versionPattern = new Regex(@"([0-9]+\.[0-9]+\.[0-9]+)");
+            Match m = versionPattern.Match(headerString);
+            string oldVersionString = m.Success ? m.Groups[1].Value : string.Empty;
+
+            if (oldVersionString == string.Empty)
+            {
+                Console.Error.WriteLine("Internal error: could not parse old version string!");
+                return;
+            }
+
+            Version oldVersion = new Version(oldVersionString);
+
+            // Get the new version
+            var updateInfoUrl = @"https://downloader-update.twitcharchives.workers.dev/";
+            using HttpResponseMessage response = await _client.GetAsync(updateInfoUrl);
+            string xmlString = await response.Content.ReadAsStringAsync();
+
+            if (string.IsNullOrEmpty(xmlString))
+            {
+                Console.Error.WriteLine("Internal error: could not parse remote update info XML!");
+            }
+
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xmlString);
+
+            string newVersionString = xmlDoc.DocumentElement.SelectSingleNode("/item/version").InnerText;
+
+            Version newVersion = new Version(newVersionString);
+
+            if (newVersion.CompareTo(oldVersion) > 0)
+            {
+                Console.WriteLine($"A new version of TwitchDownloader CLI is available ({newVersionString})!");
+                Console.WriteLine("Would you like to auto-update? (y/n):");
+                var input = Console.ReadLine();
+
+                if (input == "y")
+                {
+                    // We want the download for the CLI version, not the GUI version
+                    string oldUrl = xmlDoc.DocumentElement.SelectSingleNode("/item/url").InnerText;
+                    string newUrl = Regex.Replace(oldUrl, "GUI", "CLI");
+                    
+                    await AutoUpdate(newUrl);
+                }
+            }
+            else if (newVersion.CompareTo(oldVersion) == 0)
+            {
+                Console.WriteLine("You have the latest version of TwitchDownloader CLI!");
+            }
+        }
+
+        private static async Task AutoUpdate(string url)
+        {
+            Console.WriteLine("Downloading update archive...");
+            Stream s = await _client.GetStreamAsync(url);
+            var archiveName = url.Split("/").Last();
+
+            // Create downloaded archive file from stream data
+            using (var fs = new FileStream(archiveName, FileMode.OpenOrCreate))
+            {
+                s.CopyTo(fs);
+            }
+
+            var exeName = Path.GetFileName(Environment.ProcessPath);
+            var oldExe = exeName + ".bak";
+
+            if (string.IsNullOrEmpty(exeName))
+            {
+                Console.Error.WriteLine("Internal error: Executable name is null!");
+            }
+
+            // Check for a previous update
+            if (File.Exists(oldExe))
+            {
+                File.Delete(oldExe);
+            }
+
+            // Rename current exe
+            File.Move(exeName, oldExe);
+
+            if (File.Exists("COPYRIGHT.txt"))
+            {
+                File.Delete("COPYRIGHT.txt");
+            }
+
+            if (File.Exists("THIRD-PARTY-LICENSES.txt"))
+            {
+                File.Delete("THIRD-PARTY-LICENSES.txt");
+            }
+
+            ZipFile.ExtractToDirectory(archiveName, ".");
+
+            Console.WriteLine("TwitchDownloader CLI has been updated!");
+        }
+    }
+}

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -68,8 +68,7 @@ namespace TwitchDownloaderCLI.Modes
 
             if (packageName == string.Empty)
             {
-                Console.Error.WriteLine("Error: Current OS and architecture not supported for auto-update");
-                return;
+                throw new PlatformNotSupportedException("Current OS and architecture not supported for auto-update");
             }
 
             string newUrl = urlBase + "/" + packageName;

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -120,6 +120,9 @@ namespace TwitchDownloaderCLI.Modes
 
             ZipFile.ExtractToDirectory(archiveName, ".");
 
+            // Clean up downloaded archive
+            File.Delete(archiveName);
+
             Console.WriteLine("TwitchDownloader CLI has been updated!");
         }
     }

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -182,12 +182,22 @@ namespace TwitchDownloaderCLI.Modes
             // Rename current exe
             File.Move(currentExePath!, oldExePath);
 
+            progress.SetTemplateStatus("Extracting Files {0}%", 0);
+
             await using (var archiveFs = File.Open(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 using var archive = new ZipArchive(archiveFs, ZipArchiveMode.Read);
+
+                var entryCount = archive.Entries.Count;
+                var extracted = 0;
+
                 foreach (var entry in archive.Entries)
                 {
                     entry.ExtractToFile(Path.Combine(updateDir, entry.FullName), true);
+                    extracted++;
+
+                    var percent = (int)(extracted / (double)entryCount * 100);
+                    progress.ReportProgress(percent);
                 }
             }
 

--- a/TwitchDownloaderCLI/Modes/UpdateHandler.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateHandler.cs
@@ -44,6 +44,7 @@ namespace TwitchDownloaderCLI.Modes
             if (string.IsNullOrEmpty(xmlString))
             {
                 progress.LogError("Could not parse remote update info XML!");
+                return;
             }
 
             XmlDocument xmlDoc = new XmlDocument();
@@ -149,14 +150,16 @@ namespace TwitchDownloaderCLI.Modes
             if (string.IsNullOrEmpty(currentExePath))
             {
                 progress.LogError("Current executable path is null or empty!");
+                return;
             }
 
             if (string.IsNullOrEmpty(updateDir))
             {
                 progress.LogError("Update directory is null or empty!");
+                return;
             }
 
-            progress.LogInfo("Downloading update archive...");
+            progress.SetTemplateStatus("Downloading Update {0}%", 0);
 
             using var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
@@ -187,6 +190,9 @@ namespace TwitchDownloaderCLI.Modes
                     entry.ExtractToFile(Path.Combine(updateDir, entry.FullName), true);
                 }
             }
+
+            // Clean up downloaded archive
+            File.Delete(archivePath);
 
             progress.LogInfo("TwitchDownloader CLI has been updated!");
 

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -25,7 +25,7 @@ namespace TwitchDownloaderCLI
                 config.HelpWriter = null; // Use null instead of TextWriter.Null due to how CommandLine works internally
             });
 
-            var parserResult = parser.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, InfoArgs, FfmpegArgs, CacheArgs, TsMergeArgs>(preParsedArgs);
+            var parserResult = parser.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, InfoArgs, FfmpegArgs, CacheArgs, TsMergeArgs, UpdateArgs>(preParsedArgs);
             parserResult.WithNotParsed(errors => WriteHelpText(errors, parserResult, parser.Settings));
 
             CoreLicensor.EnsureFilesExist(AppContext.BaseDirectory);
@@ -40,7 +40,8 @@ namespace TwitchDownloaderCLI
                 .WithParsed<InfoArgs>(InfoHandler.PrintInfo)
                 .WithParsed<FfmpegArgs>(FfmpegHandler.ParseArgs)
                 .WithParsed<CacheArgs>(CacheHandler.ParseArgs)
-                .WithParsed<TsMergeArgs>(MergeTs.Merge);
+                .WithParsed<TsMergeArgs>(MergeTs.Merge)
+                .WithParsed<UpdateArgs>(UpdateHandler.ParseArgs);
         }
 
         private static void WriteHelpText(IEnumerable<Error> errors, ParserResult<object> parserResult, ParserSettings parserSettings)

--- a/TwitchDownloaderCore/Extensions/VersionExtensions.cs
+++ b/TwitchDownloaderCore/Extensions/VersionExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace TwitchDownloaderWPF.Extensions
+namespace TwitchDownloaderCore.Extensions
 {
     public static class VersionExtensions
     {

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
-using TwitchDownloaderWPF.Extensions;
+using TwitchDownloaderCore.Extensions;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
 using Xabe.FFmpeg;


### PR DESCRIPTION
Implements the enhancement described in this issue: #1288 

Creates facilities to enable the auto-update of the CLI without having to manually download the package release every time. 

When a user wants to update the CLI, they can simply run either:

- `TwitchDownloaderCLI.exe update` - First checks if a new version is available, and if it is, prompts whether it should be installed. If the user selects yes, an update archive is downloaded and extracted and the old executable is renamed to "TwitchDownloaderCLI.exe.bak"
- `TwitchDownloaderCLI.exe update -f` or `TwitchDownloaderCLI.exe update --force` - Same as above but bypasses the prompt asking whether to proceed with the update or not

Like the GUI auto-update, this code relies on the following URL to get information about a new version: https://downloader-update.twitcharchives.workers.dev.

The code makes the following assumptions when accessing the URL:
- GUI and CLI versioning will remain consistent (i.e. they will not diverge from each other)
- GUI and CLI package releases and naming will also remain consistent (if a TwitchDownloaderGUI archive exists in a release, a corresponding TwitchDownloaderCLI archive will also exist with similar naming)