### PR TITLE
Accessibility enhancement: Add setting to hide pp/peepo status animations

### DIFF
--- a/TwitchDownloaderWPF/App.config
+++ b/TwitchDownloaderWPF/App.config
@@ -247,7 +247,7 @@
             <setting name="FileCollisionBehavior" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="HideStatusAnimations" serializeAs="String">
+            <setting name="ReduceMotion" serializeAs="String">
                 <value>False</value>
             </setting>
         </TwitchDownloaderWPF.Properties.Settings>

--- a/TwitchDownloaderWPF/App.config
+++ b/TwitchDownloaderWPF/App.config
@@ -247,6 +247,9 @@
             <setting name="FileCollisionBehavior" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="HideStatusAnimations" serializeAs="String">
+                <value>False</value>
+            </setting>
         </TwitchDownloaderWPF.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -351,11 +351,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void NumChatDownloadThreads_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -351,13 +351,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void NumChatDownloadThreads_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -510,11 +510,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void btnResetFfmpeg_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -510,13 +510,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void btnResetFfmpeg_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -384,11 +384,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void checkEmbedMissing_Checked(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -384,13 +384,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void checkEmbedMissing_Checked(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -191,13 +191,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private async void SplitBtnDownload_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -191,11 +191,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private async void SplitBtnDownload_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -388,13 +388,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
-            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void checkStart_OnCheckStateChanged(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -388,11 +388,13 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+            statusImage.Visibility = Settings.Default.HideStatusAnimations ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void checkStart_OnCheckStateChanged(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -981,5 +981,17 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FileCollisionBehavior"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideStatusAnimations {
+            get {
+                return ((bool)(this["HideStatusAnimations"]));
+            }
+            set {
+                this["HideStatusAnimations"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -985,12 +985,12 @@ namespace TwitchDownloaderWPF.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool HideStatusAnimations {
+        public bool ReduceMotion {
             get {
-                return ((bool)(this["HideStatusAnimations"]));
+                return ((bool)(this["ReduceMotion"]));
             }
             set {
-                this["HideStatusAnimations"] = value;
+                this["ReduceMotion"] = value;
             }
         }
     }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -242,6 +242,9 @@
     <Setting Name="FileCollisionBehavior" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="HideStatusAnimations" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -242,7 +242,7 @@
     <Setting Name="FileCollisionBehavior" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="HideStatusAnimations" Type="System.Boolean" Scope="User">
+    <Setting Name="ReduceMotion" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -1275,6 +1275,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide Status Animations:.
+        /// </summary>
+        public static string HideStatusAnimations {
+            get {
+                return ResourceManager.GetString("HideStatusAnimations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Highlight Indent Scale:.
         /// </summary>
         public static string HighlightIndentScale {

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -1272,17 +1272,8 @@ namespace TwitchDownloaderWPF.Translations {
             get {
                 return ResourceManager.GetString("HideDonationButton", resourceCulture);
             }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hide Status Animations:.
-        /// </summary>
-        public static string HideStatusAnimations {
-            get {
-                return ResourceManager.GetString("HideStatusAnimations", resourceCulture);
-            }
-        }
-        
+        }        
+       
         /// <summary>
         ///   Looks up a localized string similar to Highlight Indent Scale:.
         /// </summary>
@@ -1676,6 +1667,15 @@ namespace TwitchDownloaderWPF.Translations {
         public static string Quality {
             get {
                 return ResourceManager.GetString("Quality", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Reduce Motion:.
+        /// </summary>
+        public static string ReduceMotion {
+            get {
+                return ResourceManager.GetString("ReduceMotion", resourceCulture);
             }
         }
         

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1039,7 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1039,4 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1038,7 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1038,4 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1039,7 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1039,4 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1037,7 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1037,4 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1038,7 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1038,4 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1037,7 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1037,4 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1037,7 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1037,4 +1037,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1038,7 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1038,4 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1039,7 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1039,4 +1039,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1038,7 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1038,4 +1038,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1040,7 +1040,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1040,4 +1040,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1040,7 +1040,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
-  <data name="HideStatusAnimations" xml:space="preserve">
-    <value>Hide Status Animations:</value>
+  <data name="ReduceMotion" xml:space="preserve">
+    <value>Reduce Motion:</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1040,4 +1040,7 @@
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
   </data>
+  <data name="HideStatusAnimations" xml:space="preserve">
+    <value>Hide Status Animations:</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
@@ -91,7 +91,7 @@ namespace TwitchDownloaderWPF.TwitchTasks
 
             CanCancel = newStatus is not TwitchTaskStatus.Canceled and not TwitchTaskStatus.Failed and not TwitchTaskStatus.Finished and not TwitchTaskStatus.Stopping;
 
-            if (Settings.Default.HideStatusAnimations)
+            if (Settings.Default.ReduceMotion)
             {
                 StatusImage = null;
             }

--- a/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using TwitchDownloaderWPF.Properties;
 
 namespace TwitchDownloaderWPF.TwitchTasks
 {
@@ -90,13 +91,20 @@ namespace TwitchDownloaderWPF.TwitchTasks
 
             CanCancel = newStatus is not TwitchTaskStatus.Canceled and not TwitchTaskStatus.Failed and not TwitchTaskStatus.Finished and not TwitchTaskStatus.Stopping;
 
-            StatusImage = newStatus switch
+            if (Settings.Default.HideStatusAnimations)
             {
-                TwitchTaskStatus.Running => "Images/ppOverheat.gif",
-                TwitchTaskStatus.Ready or TwitchTaskStatus.Waiting => "Images/ppHop.gif",
-                TwitchTaskStatus.Stopping => "Images/ppStretch.gif",
-                _ => null
-            };
+                StatusImage = null;
+            }
+            else
+            {
+                StatusImage = newStatus switch
+                {
+                    TwitchTaskStatus.Running => "Images/ppOverheat.gif",
+                    TwitchTaskStatus.Ready or TwitchTaskStatus.Waiting => "Images/ppHop.gif",
+                    TwitchTaskStatus.Stopping => "Images/ppStretch.gif",
+                    _ => null
+                };
+            }
         }
 
         private void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -94,7 +94,10 @@ namespace TwitchDownloaderWPF
             if (!IsInitialized)
                 return;
 
-            StatusImage.Visibility = Visibility.Visible;
+            if (!Settings.Default.HideStatusAnimations)
+            {
+                StatusImage.Visibility = Visibility.Visible;
+            }
 
             if (string.IsNullOrWhiteSpace(currentChannel?.login))
             {

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -94,7 +94,7 @@ namespace TwitchDownloaderWPF
             if (!IsInitialized)
                 return;
 
-            if (!Settings.Default.HideStatusAnimations)
+            if (!Settings.Default.ReduceMotion)
             {
                 StatusImage.Visibility = Visibility.Visible;
             }

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -13,7 +13,7 @@
         xmlns:hc="https://handyorg.github.io/handycontrol"
         xmlns:fa="http://schemas.fontawesome.com/icons/"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleGlobalSettings}" MinWidth="450" MinHeight="600" Width="500" Height="600" SizeToContent="Height" Initialized="Window_Initialized" Closing="Window_Closing" SourceInitialized="Window_OnSourceInitialized" Background="{DynamicResource AppBackground}">
+        Title="{lex:Loc TitleGlobalSettings}" MinWidth="450" MinHeight="675" Width="500" Height="675" SizeToContent="Height" Initialized="Window_Initialized" Closing="Window_Closing" SourceInitialized="Window_OnSourceInitialized" Background="{DynamicResource AppBackground}">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />
@@ -42,6 +42,10 @@
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,4,3,3" Text="{lex:Loc HideDonationButton}" Foreground="{DynamicResource AppText}" />
                 <CheckBox x:Name="CheckDonation" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckDonation_OnCheckedChanged" Unchecked="CheckDonation_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
+                <TextBlock Margin="3,4,3,3" Text="{lex:Loc HideStatusAnimations}" Foreground="{DynamicResource AppText}" />
+                <CheckBox x:Name="CheckStatus" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckStatus_OnCheckedChanged" Unchecked="CheckStatus_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,3,3,4" Text="{lex:Loc SettingsTimeFormat}" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -44,8 +44,8 @@
                 <CheckBox x:Name="CheckDonation" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckDonation_OnCheckedChanged" Unchecked="CheckDonation_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
-                <TextBlock Margin="3,4,3,3" Text="{lex:Loc HideStatusAnimations}" Foreground="{DynamicResource AppText}" />
-                <CheckBox x:Name="CheckStatus" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckStatus_OnCheckedChanged" Unchecked="CheckStatus_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
+                <TextBlock Margin="3,4,3,3" Text="{lex:Loc ReduceMotion}" Foreground="{DynamicResource AppText}" />
+                <CheckBox x:Name="CheckReduceMotion" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckReduceMotion_OnCheckedChanged" Unchecked="CheckReduceMotion_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,3,3,4" Text="{lex:Loc SettingsTimeFormat}" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -60,6 +60,7 @@ namespace TwitchDownloaderWPF
             NumMaximumBandwidth.IsEnabled = Settings.Default.DownloadThrottleEnabled;
             CheckThrottleEnabled.IsChecked = Settings.Default.DownloadThrottleEnabled;
             RadioTimeFormatUtc.IsChecked = Settings.Default.UTCVideoTime;
+            CheckStatus.IsChecked = Settings.Default.HideStatusAnimations;
 
             if (Directory.Exists("Themes"))
             {
@@ -376,6 +377,14 @@ namespace TwitchDownloaderWPF
                 return TextChatTemplate;
 
             return null;
+        }
+
+        private void CheckStatus_OnCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized)
+                return;
+
+            Settings.Default.HideStatusAnimations = CheckStatus.IsChecked.GetValueOrDefault();
         }
     }
 }

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -60,7 +60,7 @@ namespace TwitchDownloaderWPF
             NumMaximumBandwidth.IsEnabled = Settings.Default.DownloadThrottleEnabled;
             CheckThrottleEnabled.IsChecked = Settings.Default.DownloadThrottleEnabled;
             RadioTimeFormatUtc.IsChecked = Settings.Default.UTCVideoTime;
-            CheckStatus.IsChecked = Settings.Default.HideStatusAnimations;
+            CheckReduceMotion.IsChecked = Settings.Default.ReduceMotion;
 
             if (Directory.Exists("Themes"))
             {
@@ -379,12 +379,12 @@ namespace TwitchDownloaderWPF
             return null;
         }
 
-        private void CheckStatus_OnCheckedChanged(object sender, RoutedEventArgs e)
+        private void CheckReduceMotion_OnCheckedChanged(object sender, RoutedEventArgs e)
         {
             if (!IsInitialized)
                 return;
 
-            Settings.Default.HideStatusAnimations = CheckStatus.IsChecked.GetValueOrDefault();
+            Settings.Default.ReduceMotion = CheckReduceMotion.IsChecked.GetValueOrDefault();
         }
     }
 }


### PR DESCRIPTION
Implements the enhancement described in issue https://github.com/lay295/TwitchDownloader/issues/1346

Adds a checkbox in the settings window that hides pp/peepo status animations in the following places:

- VOD Download page
- Clip Download page
- Chat Download page
- Chat Updater page
- Chat Render page
- Task queue page (for each individual task in the queue)
- Search VODs mass downloader window (when a channel's VODs are loading)
- Search Clips mass downloader window (when a channel's clips are loading)
