### PR TITLE
QOL Enhancement: Remember recent channels in mass downloader window

### DIFF
--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -993,5 +993,16 @@ namespace TwitchDownloaderWPF.Properties {
                 this["ReduceMotion"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection RecentChannels {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["RecentChannels"]));
+            }
+            set {
+                this["RecentChannels"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -245,6 +245,9 @@
     <Setting Name="ReduceMotion" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="RecentChannels" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -843,15 +843,6 @@ namespace TwitchDownloaderWPF.Translations {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Favorites.
-        /// </summary>
-        public static string Favorites {
-            get {
-                return ResourceManager.GetString("Favorites", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Input Arguments:.
         /// </summary>
         public static string FfmpegInputArguments {
@@ -1676,6 +1667,15 @@ namespace TwitchDownloaderWPF.Translations {
         public static string Quality {
             get {
                 return ResourceManager.GetString("Quality", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Recent Channels.
+        /// </summary>
+        public static string RecentChannels {
+            get {
+                return ResourceManager.GetString("RecentChannels", resourceCulture);
             }
         }
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -841,6 +841,15 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("FatalError", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Favorites.
+        /// </summary>
+        public static string Favorites {
+            get {
+                return ResourceManager.GetString("Favorites", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Input Arguments:.

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -492,6 +492,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear Recent Channels.
+        /// </summary>
+        public static string ClearRecentChannels {
+            get {
+                return ResourceManager.GetString("ClearRecentChannels", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Clip Download.
         /// </summary>
         public static string ClipDownload {
@@ -841,7 +850,7 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("FatalError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Input Arguments:.
         /// </summary>
@@ -1272,8 +1281,8 @@ namespace TwitchDownloaderWPF.Translations {
             get {
                 return ResourceManager.GetString("HideDonationButton", resourceCulture);
             }
-        }        
-       
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Highlight Indent Scale:.
         /// </summary>
@@ -1669,16 +1678,7 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("Quality", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Recent Channels.
-        /// </summary>
-        public static string RecentChannels {
-            get {
-                return ResourceManager.GetString("RecentChannels", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reduce Motion:.
         /// </summary>

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1042,4 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1041,4 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1042,4 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1040,4 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1041,4 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1040,4 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1040,7 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1040,4 +1040,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1041,4 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1042,4 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1042,7 +1042,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1041,4 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1041,7 +1041,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1043,4 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1043,7 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1043,7 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1043,4 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
+  <data name="Favorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1043,7 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+  <data name="RecentChannels" xml:space="preserve">
+    <value>Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1043,7 +1043,7 @@
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>
   </data>
-  <data name="RecentChannels" xml:space="preserve">
-    <value>Recent Channels</value>
+  <data name="ClearRecentChannels" xml:space="preserve">
+    <value>Clear Recent Channels</value>
   </data>
 </root>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -38,6 +38,9 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
             <Image x:Name="StatusImage" gif:ImageBehavior.AnimatedSource="Images/ppOverheat.gif" MaxWidth="50" Margin="0, 6, 6, 0" Visibility="Hidden" />
+            <ComboBox x:Name="ComboFavorites" SelectedIndex="0" Margin="5,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" SelectionChanged="ComboFavorites_SelectionChanged">
+                <ComboBoxItem Content="{lex:Loc Favorites}"/>
+            </ComboBox>
             <TextBox x:Name="textChannel" Height="23" Text="" MinWidth="194" MaxWidth="300" Margin="0,6,0,0" KeyDown="TextChannel_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" Margin="3,6,0,0" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -38,10 +38,7 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
             <Image x:Name="StatusImage" gif:ImageBehavior.AnimatedSource="Images/ppOverheat.gif" MaxWidth="50" Margin="0, 6, 6, 0" Visibility="Hidden" />
-            <ComboBox x:Name="ComboRecentChannels" SelectedIndex="0" Margin="5,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" SelectionChanged="ComboRecentChannels_SelectionChanged">
-                <ComboBoxItem Content="{lex:Loc RecentChannels}"/>
-            </ComboBox>
-            <TextBox x:Name="textChannel" Height="23" Text="" MinWidth="194" MaxWidth="300" Margin="0,6,0,0" KeyDown="TextChannel_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+            <ComboBox x:Name="ComboChannel" SelectedIndex="0" Margin="5,6,0,0" IsEditable="True" Height="23" MinWidth="194" MaxWidth="300" KeyDown="ComboChannel_OnKeyDown" DropDownClosed="ComboChannel_OnDropDownClosed" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" Margin="3,6,0,0" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -38,7 +38,7 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
             <Image x:Name="StatusImage" gif:ImageBehavior.AnimatedSource="Images/ppOverheat.gif" MaxWidth="50" Margin="0, 6, 6, 0" Visibility="Hidden" />
-            <ComboBox x:Name="ComboChannel" SelectedIndex="0" Margin="5,6,0,0" IsEditable="True" Height="23" MinWidth="194" MaxWidth="300" KeyDown="ComboChannel_OnKeyDown" DropDownClosed="ComboChannel_OnDropDownClosed" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+            <ComboBox x:Name="ComboChannel" IsEditable="True" Height="23" MinWidth="194" MaxWidth="300" Margin="0,6,0,0" KeyDown="ComboChannel_OnKeyDown" DropDownClosed="ComboChannel_OnDropDownClosed" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" Margin="3,6,0,0" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml
@@ -38,8 +38,8 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
             <Image x:Name="StatusImage" gif:ImageBehavior.AnimatedSource="Images/ppOverheat.gif" MaxWidth="50" Margin="0, 6, 6, 0" Visibility="Hidden" />
-            <ComboBox x:Name="ComboFavorites" SelectedIndex="0" Margin="5,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" SelectionChanged="ComboFavorites_SelectionChanged">
-                <ComboBoxItem Content="{lex:Loc Favorites}"/>
+            <ComboBox x:Name="ComboRecentChannels" SelectedIndex="0" Margin="5,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" SelectionChanged="ComboRecentChannels_SelectionChanged">
+                <ComboBoxItem Content="{lex:Loc RecentChannels}"/>
             </ComboBox>
             <TextBox x:Name="textChannel" Height="23" Text="" MinWidth="194" MaxWidth="300" Margin="0,6,0,0" KeyDown="TextChannel_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             <Button x:Name="btnChannel" Content="{lex:Loc SetChannel}" Margin="3,6,0,0" MinWidth="84" Height="30" Click="btnChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -74,6 +74,7 @@ namespace TwitchDownloaderWPF
                         var idRes = await TwitchHelper.GetUserIds(new[] { textTrimmed });
                         var infoRes = await TwitchHelper.GetUserInfo(idRes.data.users.Select(x => x.id));
                         currentChannel = infoRes.data.users[0];
+                        ComboFavorites.Items.Add(new ComboBoxItem() { Content = currentChannel.displayName });
                     }
                     catch (Exception ex)
                     {
@@ -417,6 +418,18 @@ namespace TwitchDownloaderWPF
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 
             e.Handled = true;
+        }
+
+        private void ComboFavorites_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if(!IsInitialized)
+                return;
+
+            if (ComboFavorites.SelectedIndex != 0)
+            {
+                textChannel.Text = (string)((ComboBoxItem)ComboFavorites.SelectedValue).Content;
+            }
+            ComboFavorites.SelectedIndex = 0;
         }
     }
 }

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -476,7 +476,7 @@ namespace TwitchDownloaderWPF
                 ComboChannel.SelectedIndex = 0;
             }
 
-            ComboChannel.Items.Add(new ComboBoxItem { Content = "Clear Recent Channels", Tag = _clearChannelsConstant });
+            ComboChannel.Items.Add(new ComboBoxItem { Content = Translations.Strings.ClearRecentChannels, Tag = _clearChannelsConstant });
 
             Settings.Default.RecentChannels = recentChannels;
             Settings.Default.Save();

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -457,11 +457,11 @@ namespace TwitchDownloaderWPF
                 // Move the most current channel to the top of the list
                 recentChannels.Remove(currentChannel.login);
                 recentChannels.Insert(0, currentChannel.login);
+            }
 
-                while (recentChannels.Count > 15)
-                {
-                    recentChannels.RemoveAt(recentChannels.Count - 1);
-                }
+            while (recentChannels.Count > 15)
+            {
+                recentChannels.RemoveAt(recentChannels.Count - 1);
             }
 
             ComboChannel.Items.Clear();

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -454,7 +454,7 @@ namespace TwitchDownloaderWPF
 
             if (!string.IsNullOrWhiteSpace(currentChannel?.login))
             {
-                // Move the most current channel to the top of the list
+                // Move the current channel to the top of the list
                 recentChannels.Remove(currentChannel.login);
                 recentChannels.Insert(0, currentChannel.login);
             }

--- a/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
+++ b/TwitchDownloaderWPF/WindowMassDownload.xaml.cs
@@ -83,7 +83,6 @@ namespace TwitchDownloaderWPF
                         var idRes = await TwitchHelper.GetUserIds(new[] { textTrimmed });
                         var infoRes = await TwitchHelper.GetUserInfo(idRes.data.users.Select(x => x.id));
                         currentChannel = infoRes.data.users[0];
-                        UpdateRecentChannels();
                     }
                     catch (Exception ex)
                     {
@@ -143,6 +142,7 @@ namespace TwitchDownloaderWPF
                     return;
                 }
 
+                UpdateRecentChannels();
                 videoList.Clear();
                 if (res.data.user != null)
                 {
@@ -208,6 +208,7 @@ namespace TwitchDownloaderWPF
                     return;
                 }
 
+                UpdateRecentChannels();
                 videoList.Clear();
                 if (res.data.user != null)
                 {


### PR DESCRIPTION
Fixes https://github.com/lay295/TwitchDownloader/issues/1361

Adds a "Recent Channels" combo box to the left of the channel text box in the mass downloader window:

![image](https://github.com/user-attachments/assets/ce4b59a4-42ba-4920-9b8d-47ef6d747a10)

This combo box will remember up to **ten** previous (valid) channel names that have been set in the window. On selecting a channel name in the box, that channel name will be mirrored in the adjacent channel text box to allow it to be set again easily.

Some important notes:
 - Channel names are only added to the combo box if they are not already in the list of items 
 - Entering an 11th channel name will cause the 1st channel name in the box to be replaced.

These recent channels are also saved in the program settings, which ensures that they will be remembered even if the program is closed and restarted.