### PR TITLE
Fix incorrect character encoding for HTML chat download on Brave browser

### DIFF
--- a/TwitchDownloaderCore/Resources/chat-template.html
+++ b/TwitchDownloaderCore/Resources/chat-template.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="UTF-8">
 <base target="_blank">
 <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'>
 <title>


### PR DESCRIPTION
Fixes https://github.com/lay295/TwitchDownloader/issues/1397

Sets the character encoding for the template file used for HTML chat downloads to UTF-8. Without setting this in the template file certain characters were appearing incorrectly in the latest Brave browser.