### PR TITLE
Enhancement - Add Log Scroll Bars and "Clear Log" Buttons

### DIFF
--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -136,9 +136,9 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
+        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="1">
             <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}" />
-            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
@@ -146,6 +146,7 @@
                 </RichTextBox.Resources>
             </RichTextBox>
         </StackPanel>
+        <Button x:Name="BtnClearLog" Grid.Column="4" Grid.Row="3" MinWidth="50" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">
             <StatusBarItem Padding="10,5,0,5">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -280,6 +280,13 @@ namespace TwitchDownloaderWPF
             );
         }
 
+        private void BtnClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.Document.Blocks.Clear()
+            );
+        }
+
         public ChatDownloadOptions GetOptions(string filename)
         {
             ChatDownloadOptions options = new ChatDownloadOptions();

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -246,9 +246,9 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
+        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="1">
             <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}"/>
-            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
@@ -256,6 +256,7 @@
                 </RichTextBox.Resources>
             </RichTextBox>
         </StackPanel>
+        <Button x:Name="BtnClearLog" Grid.Column="4" Grid.Row="3" MinWidth="50" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">
             <StatusBarItem Padding="10,5,0,5">

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -425,6 +425,13 @@ namespace TwitchDownloaderWPF
             );
         }
 
+        private void BtnClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.Document.Blocks.Clear()
+            );
+        }
+
         public void SetImage(string imageUri, bool isGif)
         {
             var image = new BitmapImage();

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml
@@ -136,9 +136,9 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
+        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="1">
             <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}" />
-            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
@@ -146,6 +146,7 @@
                 </RichTextBox.Resources>
             </RichTextBox>
         </StackPanel>
+        <Button x:Name="BtnClearLog" Grid.Column="4" Grid.Row="3" MinWidth="50" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">
             <StatusBarItem Padding="10,5,0,5">

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -311,6 +311,13 @@ namespace TwitchDownloaderWPF
             );
         }
 
+        private void BtnClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.Document.Blocks.Clear()
+            );
+        }
+
         public ChatUpdateOptions GetOptions(string outputFile)
         {
             ChatUpdateOptions options = new ChatUpdateOptions()

--- a/TwitchDownloaderWPF/PageClipDownload.xaml
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml
@@ -91,9 +91,9 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
+        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="1">
             <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}" />
-            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" >
+            <RichTextBox Margin="0,5" IsReadOnly="True" Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" >
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
@@ -101,6 +101,7 @@
                 </RichTextBox.Resources>
             </RichTextBox>
         </StackPanel>
+        <Button x:Name="BtnClearLog" Grid.Column="4" Grid.Row="3" MinWidth="50" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">
             <StatusBarItem Padding="10,5,0,5">

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -145,6 +145,13 @@ namespace TwitchDownloaderWPF
             );
         }
 
+        private void BtnClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.Document.Blocks.Clear()
+            );
+        }
+
         private void Page_Initialized(object sender, EventArgs e)
         {
             SetEnabled(false);

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -117,9 +117,9 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
+        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="1">
             <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}" />
-            <RichTextBox Margin="0,5" IsReadOnly="True" x:Name="textLog" Height="230" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <RichTextBox Margin="0,5" IsReadOnly="True" x:Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
@@ -127,6 +127,7 @@
                 </RichTextBox.Resources>
             </RichTextBox>
         </StackPanel>
+        <Button x:Name="BtnClearLog" Grid.Column="4" Grid.Row="3" MinWidth="50" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">
             <StatusBarItem Padding="10,5,0,5">

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -337,6 +337,13 @@ namespace TwitchDownloaderWPF
             );
         }
 
+        private void BtnClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.Document.Blocks.Clear()
+            );
+        }
+
         private void Page_Initialized(object sender, EventArgs e)
         {
             SetEnabled(false);

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -492,6 +492,15 @@ namespace TwitchDownloaderWPF.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear Log.
+        /// </summary>
+        public static string ClearLog {
+            get {
+                return ResourceManager.GetString("ClearLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Clear Recent Channels.
         /// </summary>
         public static string ClearRecentChannels {

--- a/TwitchDownloaderWPF/Translations/Strings.es.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.es.resx
@@ -1045,4 +1045,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.fr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.fr.resx
@@ -1044,4 +1044,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.it.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.it.resx
@@ -1045,4 +1045,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ja.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ja.resx
@@ -1043,4 +1043,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pl.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pl.resx
@@ -1044,4 +1044,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.pt-br.resx
@@ -1043,4 +1043,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Limpar Canais Recentes</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -1043,4 +1043,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.ru.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.ru.resx
@@ -1044,4 +1044,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.tr.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.tr.resx
@@ -1045,4 +1045,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.uk.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.uk.resx
@@ -1044,4 +1044,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>Clear Recent Channels</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-cn.resx
@@ -1046,4 +1046,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>清除最近的频道</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>

--- a/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.zh-tw.resx
@@ -1046,4 +1046,7 @@
   <data name="ClearRecentChannels" xml:space="preserve">
     <value>清除最近的頻道</value>
   </data>
+  <data name="ClearLog" xml:space="preserve">
+    <value>Clear Log</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/lay295/TwitchDownloader/issues/1437

- Adds a vertical scroll bar to the log text box in the VOD Download, Clip Download, Chat Download, Chat Updater, and Chat Render windows that only appears when the text box fills with logs
- Adds a "Clear Log" button to the VOD Download, Clip Download, Chat Download, Chat Updater, and Chat Render windows that clears the log text box when clicked

![image](https://github.com/user-attachments/assets/7eb9e84a-9b43-4560-9de8-d254ced09480)