### PR TITLE
Allow integer scaling small emotes

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1762,12 +1762,13 @@ namespace TwitchDownloaderCore
             var emoteTask = await TwitchHelper.GetEmotes(chatRoot.comments, _cacheDir, _progress, chatRoot.embeddedData, renderOptions.Offline, cancellationToken);
 
             var newHeight = (int)Math.Round(60 * renderOptions.ReferenceScale * renderOptions.EmoteScale);
-            var snapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var upSnapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var downSnapThreshold = (int)Math.Round(24 * renderOptions.ReferenceScale);
             foreach (var emote in emoteTask)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                emote.SnapResize(newHeight, snapThreshold);
+                emote.SnapResize(newHeight, upSnapThreshold, downSnapThreshold);
             }
 
             return emoteTask;
@@ -1779,12 +1780,13 @@ namespace TwitchDownloaderCore
                 renderOptions.StvEmotes, renderOptions.AllowUnlistedEmotes, renderOptions.Offline, cancellationToken);
 
             var newHeight = (int)Math.Round(60 * renderOptions.ReferenceScale * renderOptions.EmoteScale);
-            var snapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var upSnapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var downSnapThreshold = (int)Math.Round(24 * renderOptions.ReferenceScale);
             foreach (var emote in emoteThirdTask)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                emote.SnapResize(newHeight, snapThreshold);
+                emote.SnapResize(newHeight, upSnapThreshold, downSnapThreshold);
             }
 
             return emoteThirdTask;
@@ -1795,12 +1797,13 @@ namespace TwitchDownloaderCore
             var cheerTask = await TwitchHelper.GetBits(chatRoot.comments, _cacheDir, chatRoot.streamer.id.ToString(), _progress, chatRoot.embeddedData, renderOptions.Offline, cancellationToken);
 
             var newHeight = (int)Math.Round(60 * renderOptions.ReferenceScale * renderOptions.EmoteScale);
-            var snapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var upSnapThreshold = (int)Math.Round(4 * renderOptions.ReferenceScale);
+            var downSnapThreshold = (int)Math.Round(24 * renderOptions.ReferenceScale);
             foreach (var cheer in cheerTask)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                cheer.SnapResize(newHeight, snapThreshold);
+                cheer.SnapResize(newHeight, upSnapThreshold, downSnapThreshold);
             }
 
             return cheerTask;

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -1371,5 +1371,39 @@ namespace TwitchDownloaderCore
                 }
             };
         }
+
+        public static int SnapResizeHeight(int desiredHeight, int upSnapThreshold, int downSnapThreshold, int imageHeight)
+        {
+            if (upSnapThreshold == downSnapThreshold && upSnapThreshold != 0)
+            {
+                var o = (desiredHeight + upSnapThreshold) % imageHeight;
+                if (o <= upSnapThreshold * 2)
+                {
+                    desiredHeight += upSnapThreshold - o;
+                }
+            }
+            else
+            {
+                if (downSnapThreshold != 0)
+                {
+                    var o = desiredHeight % imageHeight;
+                    if (o <= downSnapThreshold)
+                    {
+                        desiredHeight -= o;
+                    }
+                }
+
+                if (upSnapThreshold != 0)
+                {
+                    var o = imageHeight - (desiredHeight % imageHeight);
+                    if (o <= upSnapThreshold)
+                    {
+                        desiredHeight += o;
+                    }
+                }
+            }
+
+            return desiredHeight;
+        }
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/ChatBadge.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatBadge.cs
@@ -82,23 +82,18 @@ namespace TwitchDownloaderCore.TwitchObjects
             };
         }
 
-        /// <inheritdoc cref="TwitchEmote.SnapResize"/>
-        public void SnapResize(int height, int snapThreshold)
+        /// <inheritdoc cref="TwitchEmote.SnapResize(int,int)"/>
+        public void SnapResize(int height, int snapThreshold) => SnapResize(height, snapThreshold, snapThreshold);
+
+        public void SnapResize(int height, int upSnapThreshold, int downSnapThreshold)
         {
             foreach (var (versionName, bitmap) in Versions)
             {
                 var bitmapInfo = bitmap.Info;
 
-                if (snapThreshold != 0)
-                {
-                    var o = (height + snapThreshold) % bitmapInfo.Height;
-                    if (o <= snapThreshold * 2)
-                    {
-                        height += snapThreshold - o;
-                    }
-                }
+                var badgeHeight = TwitchHelper.SnapResizeHeight(height, upSnapThreshold, downSnapThreshold, bitmapInfo.Height);
 
-                var imageInfo = new SKImageInfo((int)(height / (double)bitmap.Height * bitmap.Width), height);
+                var imageInfo = new SKImageInfo((int)(badgeHeight / (double)bitmap.Height * bitmap.Width), badgeHeight);
                 var newBitmap = new SKBitmap(imageInfo);
                 bitmap.ScalePixels(newBitmap, SKFilterQuality.High);
                 bitmap.Dispose();

--- a/TwitchDownloaderCore/TwitchObjects/CheerEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/CheerEmote.cs
@@ -25,12 +25,14 @@ namespace TwitchDownloaderCore.TwitchObjects
             return returnPair;
         }
 
-        /// <inheritdoc cref="TwitchEmote.SnapResize"/>
-        public void SnapResize(int newScale, int snapThreshold)
+        /// <inheritdoc cref="TwitchEmote.SnapResize(int,int)"/>
+        public void SnapResize(int newScale, int snapThreshold) => SnapResize(newScale, snapThreshold, snapThreshold);
+
+        public void SnapResize(int newScale, int upSnapThreshold, int downSnapThreshold)
         {
             for (var i = 0; i < tierList.Count; i++)
             {
-                tierList[i].Value.SnapResize(newScale, snapThreshold);
+                tierList[i].Value.SnapResize(newScale, upSnapThreshold, downSnapThreshold);
             }
         }
 

--- a/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
@@ -114,18 +114,13 @@ namespace TwitchDownloaderCore.TwitchObjects
         /// Resizes the emote to have a <see cref="Height"/> of <paramref name="height"/>.
         /// If the nearest integer scale is within <paramref name="snapThreshold"/> of <paramref name="height"/>, it will be integer scaled instead.
         /// </summary>
-        public void SnapResize(int height, int snapThreshold)
+        public void SnapResize(int height, int snapThreshold) => SnapResize(height, snapThreshold, snapThreshold);
+
+        public void SnapResize(int height, int upSnapThreshold, int downSnapThreshold)
         {
             var codecInfo = Codec.Info;
 
-            if (snapThreshold != 0)
-            {
-                var o = (height + snapThreshold) % codecInfo.Height;
-                if (o <= snapThreshold * 2)
-                {
-                    height += snapThreshold - o;
-                }
-            }
+            height = TwitchHelper.SnapResizeHeight(height, upSnapThreshold, downSnapThreshold, codecInfo.Height);
 
             var imageInfo = new SKImageInfo((int)(height / (double)codecInfo.Height * codecInfo.Width), height);
             for (var i = 0; i < FrameCount; i++)


### PR DESCRIPTION
This allows emotes that don't conform to 56x56-64x64 @ 24pt font to still be integer scaled
![image](https://github.com/user-attachments/assets/17d68b72-7323-4b93-8392-1c77b66c7d7b)
Fixes #1472 