### PR TITLE
Add render preview, presets, highlight users, live stream queuing, and VOD chapter splitting

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -88,6 +88,7 @@ namespace TwitchDownloaderCore
         private SKPaint nameFont;
         private SKPaint outlinePaint;
         private readonly HighlightIcons highlightIcons;
+        private int _usernameCenteredY;
 
         public ChatRenderer(ChatRenderOptions chatRenderOptions, ITaskProgress progress)
         {
@@ -157,6 +158,11 @@ namespace TwitchDownloaderCore
                 (int)messageFont.MeasureText("0:00:00"),
                 (int)messageFont.MeasureText("00:00:00")
             };
+
+            // Cache username vertical centering offset (constant for the whole render)
+            SKRect nameBounds = new SKRect();
+            nameFont.MeasureText("ABC123", ref nameBounds);
+            _usernameCenteredY = (int)(((renderOptions.SectionHeight - nameBounds.Height) / 2.0) + nameBounds.Height);
 
             // Rough estimation of the width of a single block art character
             renderOptions.BlockArtCharWidth = GetFallbackFont('█').MeasureText("█");
@@ -1512,21 +1518,14 @@ namespace TwitchDownloaderCore
                 : nameFont.Clone();
 
             userPaint.Color = userColor;
-            userPaint.TextSize = (float)renderOptions.EffectiveUsernameFontSize;
             var userName = appendColon
                 ? comment.commenter.display_name + ":"
                 : comment.commenter.display_name;
 
-            // Center the username text using its own font metrics so it scales from the middle,
-            // matching badge centering behavior (badgeY = (sectionHeight - badgeHeight) / 2).
-            // The global sectionDefaultYPos is computed for messageFont, not the username font.
-            SKRect userNameBounds = new SKRect();
-            userPaint.MeasureText("ABC123", ref userNameBounds);
-            int userCenteredY = (int)(((renderOptions.SectionHeight - userNameBounds.Height) / 2.0) + userNameBounds.Height);
             int savedY = drawPos.Y;
-            drawPos.Y = userCenteredY;
+            drawPos.Y = _usernameCenteredY;
             DrawText(userName, userPaint, true, sectionImages, ref drawPos, defaultPos, false);
-            drawPos.Y = savedY; // restore for subsequent message text
+            drawPos.Y = savedY;
         }
 
         private SKColor AdjustUsernameVisibility(SKColor userColor, SKColor backgroundColor)

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -2,7 +2,6 @@
 using SkiaSharp;
 using SkiaSharp.HarfBuzz;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -59,7 +58,7 @@ namespace TwitchDownloaderCore
         [GeneratedRegex(@"(?:[#*0-9]\uFE0F?\u20E3|©\uFE0F?|[®\u203C\u2049\u2122\u2139\u2194-\u2199\u21A9\u21AA\u231A\u231B\u2328\u23CF\u23ED-\u23EF\u23F1\u23F2\u23F8-\u23FA\u24C2\u25AA\u25AB\u25B6\u25C0\u25FB\u25FC\u25FE\u2600-\u2604\u260E\u2611\u2614\u2615\u2618\u2620\u2622\u2623\u2626\u262A\u262E\u262F\u2638-\u263A\u2640\u2642\u2648-\u2653\u265F\u2660\u2663\u2665\u2666\u2668\u267B\u267E\u267F\u2692\u2694-\u2697\u2699\u269B\u269C\u26A0\u26A7\u26AA\u26B0\u26B1\u26BD\u26BE\u26C4\u26C8\u26CF\u26D1\u26D3\u26E9\u26F0-\u26F5\u26F7\u26F8\u26FA\u2702\u2708\u2709\u270F\u2712\u2714\u2716\u271D\u2721\u2733\u2734\u2744\u2747\u2757\u2763\u27A1\u2934\u2935\u2B05-\u2B07\u2B1B\u2B1C\u2B55\u3030\u303D\u3297\u3299]\uFE0F?|[\u261D\u270C\u270D](?:\uFE0F|\uD83C[\uDFFB-\uDFFF])?|[\u270A\u270B](?:\uD83C[\uDFFB-\uDFFF])?|[\u23E9-\u23EC\u23F0\u23F3\u25FD\u2693\u26A1\u26AB\u26C5\u26CE\u26D4\u26EA\u26FD\u2705\u2728\u274C\u274E\u2753-\u2755\u2795-\u2797\u27B0\u27BF\u2B50]|\u26F9(?:\uFE0F|\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|\u2764\uFE0F?(?:\u200D(?:\uD83D\uDD25|\uD83E\uDE79))?|\uD83C(?:[\uDC04\uDD70\uDD71\uDD7E\uDD7F\uDE02\uDE37\uDF21\uDF24-\uDF2C\uDF36\uDF7D\uDF96\uDF97\uDF99-\uDF9B\uDF9E\uDF9F\uDFCD\uDFCE\uDFD4-\uDFDF\uDFF5\uDFF7]\uFE0F?|[\uDF85\uDFC2\uDFC7](?:\uD83C[\uDFFB-\uDFFF])?|[\uDFC3\uDFC4\uDFCA](?:\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|[\uDFCB\uDFCC](?:\uFE0F|\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|[\uDCCF\uDD8E\uDD91-\uDD9A\uDE01\uDE1A\uDE2F\uDE32-\uDE36\uDE38-\uDE3A\uDE50\uDE51\uDF00-\uDF20\uDF2D-\uDF35\uDF37-\uDF7C\uDF7E-\uDF84\uDF86-\uDF93\uDFA0-\uDFC1\uDFC5\uDFC6\uDFC8\uDFC9\uDFCF-\uDFD3\uDFE0-\uDFF0\uDFF8-\uDFFF]|\uDDE6\uD83C[\uDDE8-\uDDEC\uDDEE\uDDF1\uDDF2\uDDF4\uDDF6-\uDDFA\uDDFC\uDDFD\uDDFF]|\uDDE7\uD83C[\uDDE6\uDDE7\uDDE9-\uDDEF\uDDF1-\uDDF4\uDDF6-\uDDF9\uDDFB\uDDFC\uDDFE\uDDFF]|\uDDE8\uD83C[\uDDE6\uDDE8\uDDE9\uDDEB-\uDDEE\uDDF0-\uDDF5\uDDF7\uDDFA-\uDDFF]|\uDDE9\uD83C[\uDDEA\uDDEC\uDDEF\uDDF0\uDDF2\uDDF4\uDDFF]|\uDDEA\uD83C[\uDDE6\uDDE8\uDDEA\uDDEC\uDDED\uDDF7-\uDDFA]|\uDDEB\uD83C[\uDDEE-\uDDF0\uDDF2\uDDF4\uDDF7]|\uDDEC\uD83C[\uDDE6\uDDE7\uDDE9-\uDDEE\uDDF1-\uDDF3\uDDF5-\uDDFA\uDDFC\uDDFE]|\uDDED\uD83C[\uDDF0\uDDF2\uDDF3\uDDF7\uDDF9\uDDFA]|\uDDEE\uD83C[\uDDE8-\uDDEA\uDDF1-\uDDF4\uDDF6-\uDDF9]|\uDDEF\uD83C[\uDDEA\uDDF2\uDDF4\uDDF5]|\uDDF0\uD83C[\uDDEA\uDDEC-\uDDEE\uDDF2\uDDF3\uDDF5\uDDF7\uDDFC\uDDFE\uDDFF]|\uDDF1\uD83C[\uDDE6-\uDDE8\uDDEE\uDDF0\uDDF7-\uDDFB\uDDFE]|\uDDF2\uD83C[\uDDE6\uDDE8-\uDDED\uDDF0-\uDDFF]|\uDDF3\uD83C[\uDDE6\uDDE8\uDDEA-\uDDEC\uDDEE\uDDF1\uDDF4\uDDF5\uDDF7\uDDFA\uDDFF]|\uDDF4\uD83C\uDDF2|\uDDF5\uD83C[\uDDE6\uDDEA-\uDDED\uDDF0-\uDDF3\uDDF7-\uDDF9\uDDFC\uDDFE]|\uDDF6\uD83C\uDDE6|\uDDF7\uD83C[\uDDEA\uDDF4\uDDF8\uDDFA\uDDFC]|\uDDF8\uD83C[\uDDE6-\uDDEA\uDDEC-\uDDF4\uDDF7-\uDDF9\uDDFB\uDDFD-\uDDFF]|\uDDF9\uD83C[\uDDE6\uDDE8\uDDE9\uDDEB-\uDDED\uDDEF-\uDDF4\uDDF7\uDDF9\uDDFB\uDDFC\uDDFF]|\uDDFA\uD83C[\uDDE6\uDDEC\uDDF2\uDDF3\uDDF8\uDDFE\uDDFF]|\uDDFB\uD83C[\uDDE6\uDDE8\uDDEA\uDDEC\uDDEE\uDDF3\uDDFA]|\uDDFC\uD83C[\uDDEB\uDDF8]|\uDDFD\uD83C\uDDF0|\uDDFE\uD83C[\uDDEA\uDDF9]|\uDDFF\uD83C[\uDDE6\uDDF2\uDDFC]|\uDFF3\uFE0F?(?:\u200D(?:\u26A7\uFE0F?|\uD83C\uDF08))?|\uDFF4(?:\u200D\u2620\uFE0F?|\uDB40\uDC67\uDB40\uDC62\uDB40(?:\uDC65\uDB40\uDC6E\uDB40\uDC67|\uDC73\uDB40\uDC63\uDB40\uDC74|\uDC77\uDB40\uDC6C\uDB40\uDC73)\uDB40\uDC7F)?)|\uD83D(?:[\uDC3F\uDCFD\uDD49\uDD4A\uDD6F\uDD70\uDD73\uDD76-\uDD79\uDD87\uDD8A-\uDD8D\uDDA5\uDDA8\uDDB1\uDDB2\uDDBC\uDDC2-\uDDC4\uDDD1-\uDDD3\uDDDC-\uDDDE\uDDE1\uDDE3\uDDE8\uDDEF\uDDF3\uDDFA\uDECB\uDECD-\uDECF\uDEE0-\uDEE5\uDEE9\uDEF0\uDEF3]\uFE0F?|[\uDC42\uDC43\uDC46-\uDC50\uDC66\uDC67\uDC6B-\uDC6D\uDC72\uDC74-\uDC76\uDC78\uDC7C\uDC83\uDC85\uDC8F\uDC91\uDCAA\uDD7A\uDD95\uDD96\uDE4C\uDE4F\uDEC0\uDECC](?:\uD83C[\uDFFB-\uDFFF])?|[\uDC6E\uDC70\uDC71\uDC73\uDC77\uDC81\uDC82\uDC86\uDC87\uDE45-\uDE47\uDE4B\uDE4D\uDE4E\uDEA3\uDEB4-\uDEB6](?:\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|[\uDD74\uDD90](?:\uFE0F|\uD83C[\uDFFB-\uDFFF])?|[\uDC00-\uDC07\uDC09-\uDC14\uDC16-\uDC3A\uDC3C-\uDC3E\uDC40\uDC44\uDC45\uDC51-\uDC65\uDC6A\uDC79-\uDC7B\uDC7D-\uDC80\uDC84\uDC88-\uDC8E\uDC90\uDC92-\uDCA9\uDCAB-\uDCFC\uDCFF-\uDD3D\uDD4B-\uDD4E\uDD50-\uDD67\uDDA4\uDDFB-\uDE2D\uDE2F-\uDE34\uDE37-\uDE44\uDE48-\uDE4A\uDE80-\uDEA2\uDEA4-\uDEB3\uDEB7-\uDEBF\uDEC1-\uDEC5\uDED0-\uDED2\uDED5-\uDED7\uDEDD-\uDEDF\uDEEB\uDEEC\uDEF4-\uDEFC\uDFE0-\uDFEB\uDFF0]|\uDC08(?:\u200D\u2B1B)?|\uDC15(?:\u200D\uD83E\uDDBA)?|\uDC3B(?:\u200D\u2744\uFE0F?)?|\uDC41\uFE0F?(?:\u200D\uD83D\uDDE8\uFE0F?)?|\uDC68(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D(?:[\uDC68\uDC69]\u200D\uD83D(?:\uDC66(?:\u200D\uD83D\uDC66)?|\uDC67(?:\u200D\uD83D[\uDC66\uDC67])?)|[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uDC66(?:\u200D\uD83D\uDC66)?|\uDC67(?:\u200D\uD83D[\uDC66\uDC67])?)|\uD83E[\uDDAF-\uDDB3\uDDBC\uDDBD])|\uD83C(?:\uDFFB(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D\uDC68\uD83C[\uDFFC-\uDFFF])))?|\uDFFC(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D\uDC68\uD83C[\uDFFB\uDFFD-\uDFFF])))?|\uDFFD(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D\uDC68\uD83C[\uDFFB\uDFFC\uDFFE\uDFFF])))?|\uDFFE(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D\uDC68\uD83C[\uDFFB-\uDFFD\uDFFF])))?|\uDFFF(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?\uDC68\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D\uDC68\uD83C[\uDFFB-\uDFFE])))?))?|\uDC69(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:\uDC8B\u200D\uD83D)?[\uDC68\uDC69]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D(?:[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uDC66(?:\u200D\uD83D\uDC66)?|\uDC67(?:\u200D\uD83D[\uDC66\uDC67])?|\uDC69\u200D\uD83D(?:\uDC66(?:\u200D\uD83D\uDC66)?|\uDC67(?:\u200D\uD83D[\uDC66\uDC67])?))|\uD83E[\uDDAF-\uDDB3\uDDBC\uDDBD])|\uD83C(?:\uDFFB(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:[\uDC68\uDC69]|\uDC8B\u200D\uD83D[\uDC68\uDC69])\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D[\uDC68\uDC69]\uD83C[\uDFFC-\uDFFF])))?|\uDFFC(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:[\uDC68\uDC69]|\uDC8B\u200D\uD83D[\uDC68\uDC69])\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D[\uDC68\uDC69]\uD83C[\uDFFB\uDFFD-\uDFFF])))?|\uDFFD(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:[\uDC68\uDC69]|\uDC8B\u200D\uD83D[\uDC68\uDC69])\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D[\uDC68\uDC69]\uD83C[\uDFFB\uDFFC\uDFFE\uDFFF])))?|\uDFFE(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:[\uDC68\uDC69]|\uDC8B\u200D\uD83D[\uDC68\uDC69])\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D[\uDC68\uDC69]\uD83C[\uDFFB-\uDFFD\uDFFF])))?|\uDFFF(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D\uD83D(?:[\uDC68\uDC69]|\uDC8B\u200D\uD83D[\uDC68\uDC69])\uD83C[\uDFFB-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83D[\uDC68\uDC69]\uD83C[\uDFFB-\uDFFE])))?))?|\uDC6F(?:\u200D[\u2640\u2642]\uFE0F?)?|\uDD75(?:\uFE0F|\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|\uDE2E(?:\u200D\uD83D\uDCA8)?|\uDE35(?:\u200D\uD83D\uDCAB)?|\uDE36(?:\u200D\uD83C\uDF2B\uFE0F?)?)|\uD83E(?:[\uDD0C\uDD0F\uDD18-\uDD1F\uDD30-\uDD34\uDD36\uDD77\uDDB5\uDDB6\uDDBB\uDDD2\uDDD3\uDDD5\uDEC3-\uDEC5\uDEF0\uDEF2-\uDEF6](?:\uD83C[\uDFFB-\uDFFF])?|[\uDD26\uDD35\uDD37-\uDD39\uDD3D\uDD3E\uDDB8\uDDB9\uDDCD-\uDDCF\uDDD4\uDDD6-\uDDDD](?:\uD83C[\uDFFB-\uDFFF])?(?:\u200D[\u2640\u2642]\uFE0F?)?|[\uDDDE\uDDDF](?:\u200D[\u2640\u2642]\uFE0F?)?|[\uDD0D\uDD0E\uDD10-\uDD17\uDD20-\uDD25\uDD27-\uDD2F\uDD3A\uDD3F-\uDD45\uDD47-\uDD76\uDD78-\uDDB4\uDDB7\uDDBA\uDDBC-\uDDCC\uDDD0\uDDE0-\uDDFF\uDE70-\uDE74\uDE78-\uDE7C\uDE80-\uDE86\uDE90-\uDEAC\uDEB0-\uDEBA\uDEC0-\uDEC2\uDED0-\uDED9\uDEE0-\uDEE7]|\uDD3C(?:\u200D[\u2640\u2642]\uFE0F?|\uD83C[\uDFFB-\uDFFF])?|\uDDD1(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1))|\uD83C(?:\uDFFB(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D(?:\uD83D\uDC8B\u200D)?\uD83E\uDDD1\uD83C[\uDFFC-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1\uD83C[\uDFFB-\uDFFF])))?|\uDFFC(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D(?:\uD83D\uDC8B\u200D)?\uD83E\uDDD1\uD83C[\uDFFB\uDFFD-\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1\uD83C[\uDFFB-\uDFFF])))?|\uDFFD(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D(?:\uD83D\uDC8B\u200D)?\uD83E\uDDD1\uD83C[\uDFFB\uDFFC\uDFFE\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1\uD83C[\uDFFB-\uDFFF])))?|\uDFFE(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D(?:\uD83D\uDC8B\u200D)?\uD83E\uDDD1\uD83C[\uDFFB-\uDFFD\uDFFF]|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1\uD83C[\uDFFB-\uDFFF])))?|\uDFFF(?:\u200D(?:[\u2695\u2696\u2708]\uFE0F?|\u2764\uFE0F?\u200D(?:\uD83D\uDC8B\u200D)?\uD83E\uDDD1\uD83C[\uDFFB-\uDFFE]|\uD83C[\uDF3E\uDF73\uDF7C\uDF84\uDF93\uDFA4\uDFA8\uDFEB\uDFED]|\uD83D[\uDCBB\uDCBC\uDD27\uDD2C\uDE80\uDE92]|\uD83E(?:[\uDDAF-\uDDB3\uDDBC\uDDBD]|\uDD1D\u200D\uD83E\uDDD1\uD83C[\uDFFB-\uDFFF])))?))?|\uDEF1(?:\uD83C(?:\uDFFB(?:\u200D\uD83E\uDEF2\uD83C[\uDFFC-\uDFFF])?|\uDFFC(?:\u200D\uD83E\uDEF2\uD83C[\uDFFB\uDFFD-\uDFFF])?|\uDFFD(?:\u200D\uD83E\uDEF2\uD83C[\uDFFB\uDFFC\uDFFE\uDFFF])?|\uDFFE(?:\u200D\uD83E\uDEF2\uD83C[\uDFFB-\uDFFD\uDFFF])?|\uDFFF(?:\u200D\uD83E\uDEF2\uD83C[\uDFFB-\uDFFE])?))?))")]
         private static partial Regex EmojiRegex { get; }
 
-        private static readonly IReadOnlyDictionary<int, string> AllEmojiSequences = Emoji.All.ToFrozenDictionary(e => e.SortOrder, e => e.Sequence.AsString);
+        private static readonly IReadOnlyDictionary<int, string> AllEmojiSequences = Emoji.All.ToFrozenDictionary(e => e.SortOrder, e => e.Sequence.AsString.Replace("️", ""));
 
         private readonly ITaskProgress _progress;
         private readonly ChatRenderOptions renderOptions;
@@ -86,7 +85,7 @@ namespace TwitchDownloaderCore
             renderOptions.BlockArtPreWrap = renderOptions.ChatWidth > renderOptions.BlockArtPreWrapWidth;
             _progress = progress;
             outlinePaint = new SKPaint { Style = SKPaintStyle.Stroke, StrokeWidth = (float)(renderOptions.OutlineSize * renderOptions.ReferenceScale), StrokeJoin = SKStrokeJoin.Round, Color = SKColors.Black, IsAntialias = true, IsAutohinted = true, LcdRenderText = true, SubpixelText = true, HintingLevel = SKPaintHinting.Full, FilterQuality = SKFilterQuality.High };
-            nameFont = new SKPaint { LcdRenderText = true, SubpixelText = true, TextSize = (float)renderOptions.FontSize, IsAntialias = true, IsAutohinted = true, HintingLevel = SKPaintHinting.Full, FilterQuality = SKFilterQuality.High };
+            nameFont = new SKPaint { LcdRenderText = true, SubpixelText = true, TextSize = (float)renderOptions.EffectiveUsernameFontSize, IsAntialias = true, IsAutohinted = true, HintingLevel = SKPaintHinting.Full, FilterQuality = SKFilterQuality.High };
             messageFont = new SKPaint { LcdRenderText = true, SubpixelText = true, TextSize = (float)renderOptions.FontSize, IsAntialias = true, IsAutohinted = true, HintingLevel = SKPaintHinting.Full, FilterQuality = SKFilterQuality.High, Color = renderOptions.MessageColor };
             highlightIcons = new HighlightIcons(renderOptions, _cacheDir, Purple, outlinePaint);
         }
@@ -335,7 +334,9 @@ namespace TwitchDownloaderCore
                     var elapsed = stopwatch.Elapsed;
                     var elapsedSeconds = elapsed.TotalSeconds;
 
-                    var secondsLeft = unchecked((int)(100 / percent * elapsedSeconds - elapsedSeconds));
+                    var secondsLeft = percent > 0
+                        ? (int)(100 / percent * elapsedSeconds - elapsedSeconds)
+                        : 0;
                     _progress.ReportProgress((int)Math.Round(percent), elapsed, TimeSpan.FromSeconds(secondsLeft));
                 }
             }
@@ -355,23 +356,14 @@ namespace TwitchDownloaderCore
 
         private static void SetFrameMask(SKBitmap frame)
         {
-            IntPtr pixelsAddr = frame.GetPixels();
-            SKImageInfo frameInfo = frame.Info;
-            int height = frameInfo.Height;
-            int width = frameInfo.Width;
+            // Copy alpha channel into RGB, set alpha to 0xFF to produce a luma-matte image
             unsafe
             {
-                byte* ptr = (byte*)pixelsAddr.ToPointer();
-                for (int row = 0; row < height; row++)
+                var pixels = new Span<uint>((void*)frame.GetPixels(), frame.Width * frame.Height);
+                for (int i = 0; i < pixels.Length; i++)
                 {
-                    for (int col = 0; col < width; col++)
-                    {
-                        byte alpha = *(ptr + 3); // alpha of the unmasked pixel
-                        *ptr++ = alpha;
-                        *ptr++ = alpha;
-                        *ptr++ = alpha;
-                        *ptr++ = 0xFF;
-                    }
+                    uint alpha = pixels[i] >> 24;
+                    pixels[i] = alpha | (alpha << 8) | (alpha << 16) | 0xFF000000u;
                 }
             }
         }
@@ -1018,37 +1010,35 @@ namespace TwitchDownloaderCore
             StringBuilder nonEmojiBuffer = new();
             while (enumerator.MoveNext())
             {
-                if (enumerator.GetTextElement().Length == 1 && char.IsAscii(enumerator.GetTextElement()[0]))
+                var textElement = enumerator.GetTextElement();
+                // Strip variation selector-16 (U+FE0F) so sequences without it still match
+                var normalizedElement = textElement.Replace("️", "");
+
+                // Skip standalone variation selectors
+                if (normalizedElement.Length == 0)
+                    continue;
+
+                if (normalizedElement.Length == 1 && char.IsAscii(normalizedElement[0]))
                 {
-                    nonEmojiBuffer.Append(enumerator.GetTextElement());
+                    nonEmojiBuffer.Append(textElement);
                     continue;
                 }
 
-                var emojiBag = new ConcurrentBag<SingleEmoji>();
-                Emoji.All.AsParallel()
-                    .Where(emoji => enumerator.GetTextElement().StartsWith(AllEmojiSequences[emoji.SortOrder]))
-                    .ForAll(emoji =>
-                    {
-                        if (emoji.Group != "Flags")
-                        {
-                            emojiBag.Add(emoji);
-                            return;
-                        }
-
-                        if (enumerator.GetTextElement().StartsWith(AllEmojiSequences[emoji.SortOrder], StringComparison.Ordinal))
-                        {
-                            emojiBag.Add(emoji);
-                        }
-                    });
-
-                if (emojiBag.IsEmpty)
+                var emojiBag = new List<SingleEmoji>();
+                foreach (var emoji in Emoji.All)
                 {
-                    nonEmojiBuffer.Append(enumerator.GetTextElement());
+                    if (normalizedElement.StartsWith(AllEmojiSequences[emoji.SortOrder], StringComparison.Ordinal))
+                        emojiBag.Add(emoji);
+                }
+
+                if (emojiBag.Count == 0)
+                {
+                    nonEmojiBuffer.Append(textElement);
                     continue;
                 }
 
                 // Make sure the found emojis actually exist in our cache
-                var emojiMatches = emojiBag.ToList();
+                var emojiMatches = emojiBag;
                 int emojiMatchesCount = emojiMatches.Count;
                 for (int j = 0; j < emojiMatchesCount; j++)
                 {
@@ -1062,7 +1052,7 @@ namespace TwitchDownloaderCore
 
                 if (emojiMatchesCount == 0)
                 {
-                    nonEmojiBuffer.Append(enumerator.GetTextElement());
+                    nonEmojiBuffer.Append(textElement);
                     continue;
                 }
 
@@ -1122,12 +1112,17 @@ namespace TwitchDownloaderCore
             }
 
             // We cannot draw nonFont chars individually or Arabic script looks improper https://github.com/lay295/TwitchDownloader/issues/484
-            // The fragment has either surrogate pairs or characters not in the messageFont
+            // Iterate by grapheme clusters so combining characters stay attached to their base character
             var inFontBuffer = new StringBuilder();
             var nonFontBuffer = new StringBuilder();
-            for (int j = 0; j < fragmentSpan.Length; j++)
+
+            var elementEnumerator = StringInfo.GetTextElementEnumerator(fragmentSpan.ToString());
+            while (elementEnumerator.MoveNext())
             {
-                if (char.IsHighSurrogate(fragmentSpan[j]) && j + 1 < fragmentSpan.Length && char.IsLowSurrogate(fragmentSpan[j + 1]))
+                var element = elementEnumerator.GetTextElement();
+
+                // Supplementary-plane characters: select fallback font by their full codepoint
+                if (element.Length == 2 && char.IsHighSurrogate(element[0]) && char.IsLowSurrogate(element[1]))
                 {
                     if (inFontBuffer.Length > 0)
                     {
@@ -1136,57 +1131,66 @@ namespace TwitchDownloaderCore
                     }
                     if (nonFontBuffer.Length > 0)
                     {
-                        using SKPaint nonFontFallbackFont = GetFallbackFont(nonFontBuffer[0]).Clone();
+                        using SKPaint nonFontFallbackFont = GetFallbackFont(GetFirstCodePoint(nonFontBuffer)).Clone();
                         nonFontFallbackFont.Color = renderOptions.MessageColor;
                         DrawText(nonFontBuffer.ToString(), nonFontFallbackFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
                         nonFontBuffer.Clear();
                     }
-                    int utf32Char = char.ConvertToUtf32(fragmentSpan[j], fragmentSpan[j + 1]);
-                    //Don't attempt to draw U+E0000
+                    int utf32Char = char.ConvertToUtf32(element[0], element[1]);
+                    // Don't attempt to draw U+E0000
                     if (utf32Char != 0xE0000)
                     {
                         using SKPaint highSurrogateFallbackFont = GetFallbackFont(utf32Char).Clone();
                         highSurrogateFallbackFont.Color = renderOptions.MessageColor;
-                        DrawText(fragmentSpan.Slice(j, 2).ToString(), highSurrogateFallbackFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
+                        DrawText(element, highSurrogateFallbackFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
                     }
-                    j++;
+                    continue;
                 }
-                else if (!messageFont.ContainsGlyphs(fragmentSpan.Slice(j, 1)) || new StringInfo(fragmentSpan[j].ToString()).LengthInTextElements == 0)
+
+                // Treat remaining grapheme clusters as a unit (keeps combining marks attached to their base)
+                bool elementInFont = messageFont.ContainsGlyphs(element)
+                    && (element.Length != 1 || new StringInfo(element).LengthInTextElements > 0);
+
+                if (elementInFont)
+                {
+                    if (nonFontBuffer.Length > 0)
+                    {
+                        using SKPaint fallbackFont = GetFallbackFont(GetFirstCodePoint(nonFontBuffer)).Clone();
+                        fallbackFont.Color = renderOptions.MessageColor;
+                        DrawText(nonFontBuffer.ToString(), fallbackFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
+                        nonFontBuffer.Clear();
+                    }
+                    inFontBuffer.Append(element);
+                }
+                else
                 {
                     if (inFontBuffer.Length > 0)
                     {
                         DrawText(inFontBuffer.ToString(), messageFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
                         inFontBuffer.Clear();
                     }
-
-                    nonFontBuffer.Append(fragmentSpan[j]);
-                }
-                else
-                {
-                    if (nonFontBuffer.Length > 0)
-                    {
-                        using SKPaint fallbackFont = GetFallbackFont(nonFontBuffer[0]).Clone();
-                        fallbackFont.Color = renderOptions.MessageColor;
-                        DrawText(nonFontBuffer.ToString(), fallbackFont, false, sectionImages, ref drawPos, defaultPos, highlightWords);
-                        nonFontBuffer.Clear();
-                    }
-
-                    inFontBuffer.Append(fragmentSpan[j]);
+                    nonFontBuffer.Append(element);
                 }
             }
+
             // Only one or the other should occur
             if (nonFontBuffer.Length > 0)
             {
-                using SKPaint fallbackFont = GetFallbackFont(nonFontBuffer[0]).Clone();
+                using SKPaint fallbackFont = GetFallbackFont(GetFirstCodePoint(nonFontBuffer)).Clone();
                 fallbackFont.Color = renderOptions.MessageColor;
                 DrawText(nonFontBuffer.ToString(), fallbackFont, true, sectionImages, ref drawPos, defaultPos, highlightWords);
-                nonFontBuffer.Clear();
             }
             if (inFontBuffer.Length > 0)
             {
                 DrawText(inFontBuffer.ToString(), messageFont, true, sectionImages, ref drawPos, defaultPos, highlightWords);
-                inFontBuffer.Clear();
             }
+        }
+
+        private static int GetFirstCodePoint(StringBuilder sb)
+        {
+            if (sb.Length >= 2 && char.IsHighSurrogate(sb[0]) && char.IsLowSurrogate(sb[1]))
+                return char.ConvertToUtf32(sb[0], sb[1]);
+            return sb[0];
         }
 
         private void DrawRegularMessage(List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, List<(Point, TwitchEmote)> emotePositionList, ref Point drawPos, Point defaultPos, int bitsCount, string fragmentString, bool highlightWords)
@@ -1405,7 +1409,7 @@ namespace TwitchDownloaderCore
             do
             {
                 length++;
-            } while (MeasureText(text[..length], textFont, isRtl, shaper) < maxWidth);
+            } while (length < text.Length && MeasureText(text[..length], textFont, isRtl, shaper) < maxWidth);
             text = text[..(length - 1)];
 
             // Cut at the last delimiter character if applicable
@@ -1462,11 +1466,17 @@ namespace TwitchDownloaderCore
 
         private void DrawUsername(Comment comment, List<(SKImageInfo info, SKBitmap bitmap)> sectionImages, ref Point drawPos, Point defaultPos, bool appendColon = true, SKColor? colorOverride = null, int commentIndex = 0)
         {
-            var userColor = colorOverride ?? (comment.message.user_color is not null
-                ? SKColor.Parse(comment.message.user_color)
-                : DefaultUsernameColors[Math.Abs(comment.commenter.display_name.GetHashCode()) % DefaultUsernameColors.Length]);
+            var isHighlighted = renderOptions.HighlightUsersArray.Length > 0
+                                && (renderOptions.HighlightUsersArray.Contains(comment.commenter.name, StringComparer.OrdinalIgnoreCase)
+                                    || renderOptions.HighlightUsersArray.Contains(comment.commenter.display_name, StringComparer.OrdinalIgnoreCase));
 
-            if (colorOverride is null && renderOptions.AdjustUsernameVisibility)
+            var userColor = isHighlighted
+                ? renderOptions.HighlightUsersColor
+                : colorOverride ?? (comment.message.user_color is not null
+                    ? SKColor.Parse(comment.message.user_color)
+                    : DefaultUsernameColors[Math.Abs(comment.commenter.display_name.GetHashCode()) % DefaultUsernameColors.Length]);
+
+            if (!isHighlighted && colorOverride is null && renderOptions.AdjustUsernameVisibility)
             {
                 var useAlternateBackground = renderOptions.AlternateMessageBackgrounds && commentIndex % 2 == 1;
                 var backgroundColor = useAlternateBackground ? renderOptions.AlternateBackgroundColor : renderOptions.BackgroundColor;
@@ -1478,11 +1488,21 @@ namespace TwitchDownloaderCore
                 : nameFont.Clone();
 
             userPaint.Color = userColor;
+            userPaint.TextSize = (float)renderOptions.EffectiveUsernameFontSize;
             var userName = appendColon
                 ? comment.commenter.display_name + ":"
                 : comment.commenter.display_name;
 
+            // Center the username text using its own font metrics so it scales from the middle,
+            // matching badge centering behavior (badgeY = (sectionHeight - badgeHeight) / 2).
+            // The global sectionDefaultYPos is computed for messageFont, not the username font.
+            SKRect userNameBounds = new SKRect();
+            userPaint.MeasureText("ABC123", ref userNameBounds);
+            int userCenteredY = (int)(((renderOptions.SectionHeight - userNameBounds.Height) / 2.0) + userNameBounds.Height);
+            int savedY = drawPos.Y;
+            drawPos.Y = userCenteredY;
             DrawText(userName, userPaint, true, sectionImages, ref drawPos, defaultPos, false);
+            drawPos.Y = savedY; // restore for subsequent message text
         }
 
         private SKColor AdjustUsernameVisibility(SKColor userColor, SKColor backgroundColor)

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -60,6 +60,18 @@ namespace TwitchDownloaderCore
 
         private static readonly IReadOnlyDictionary<int, string> AllEmojiSequences = Emoji.All.ToFrozenDictionary(e => e.SortOrder, e => e.Sequence.AsString.Replace("️", ""));
 
+        // Index emojis by the first Unicode code point of their normalized sequence for fast prefix lookup
+        private static readonly FrozenDictionary<string, SingleEmoji[]> EmojiByLeadCodePoint =
+            Emoji.All
+                .GroupBy(static e =>
+                {
+                    var seq = AllEmojiSequences[e.SortOrder];
+                    if (seq.Length == 0) return null;
+                    return char.IsHighSurrogate(seq[0]) && seq.Length > 1 ? seq[..2] : seq[..1];
+                })
+                .Where(static g => g.Key is not null)
+                .ToFrozenDictionary(g => g.Key, g => g.ToArray());
+
         private readonly ITaskProgress _progress;
         private readonly ChatRenderOptions renderOptions;
         private readonly string _cacheDir;
@@ -1008,6 +1020,7 @@ namespace TwitchDownloaderCore
 
             var enumerator = StringInfo.GetTextElementEnumerator(fragmentString);
             StringBuilder nonEmojiBuffer = new();
+            var emojiBag = new List<SingleEmoji>();
             while (enumerator.MoveNext())
             {
                 var textElement = enumerator.GetTextElement();
@@ -1024,8 +1037,19 @@ namespace TwitchDownloaderCore
                     continue;
                 }
 
-                var emojiBag = new List<SingleEmoji>();
-                foreach (var emoji in Emoji.All)
+                // Narrow candidates to emojis sharing the same leading code point
+                var leadKey = char.IsHighSurrogate(normalizedElement[0]) && normalizedElement.Length > 1
+                    ? normalizedElement[..2]
+                    : normalizedElement[..1];
+
+                if (!EmojiByLeadCodePoint.TryGetValue(leadKey, out var candidates))
+                {
+                    nonEmojiBuffer.Append(textElement);
+                    continue;
+                }
+
+                emojiBag.Clear();
+                foreach (var emoji in candidates)
                 {
                     if (normalizedElement.StartsWith(AllEmojiSequences[emoji.SortOrder], StringComparison.Ordinal))
                         emojiBag.Add(emoji);

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -112,7 +112,7 @@ namespace TwitchDownloaderCore
 
         private async Task<(GqlShareClipRenderStatusResponse clipInfo, string downloadUrl)> GetClipInfo()
         {
-            var clipRenderStatus = await TwitchHelper.GetShareClipRenderStatus(downloadOptions.Id);
+            var clipRenderStatus = await TwitchHelper.GetShareClipRenderStatus(downloadOptions.Id, downloadOptions.Oauth);
             var clip = clipRenderStatus.data.clip;
 
             if (clip.playbackAccessToken is null)
@@ -200,6 +200,7 @@ namespace TwitchDownloaderCore
                     await Task.Delay(100, cancellationToken);
                 }
 
+                process?.Dispose();
                 File.Delete(metadataFile);
             }
         }

--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -55,6 +55,17 @@ namespace TwitchDownloaderCore
 
             var (outputFile, extension) = ResolveOutputPath();
 
+            // Clean up any leftover part files from a previous interrupted session
+            // (e.g. the app was closed mid-recording and restarted while the stream is still live).
+            var stalePartA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
+            var stalePartB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
+            if (File.Exists(stalePartA) || File.Exists(stalePartB))
+            {
+                _progress.LogInfo("Removing leftover part files from a previous interrupted session.");
+                TryDelete(stalePartA);
+                TryDelete(stalePartB);
+            }
+
             // If the broadcast already ended, the in-progress VOD is just a normal finished
             // VOD - one multi-threaded download, no split, no stitch.
             if (!isLive)

--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -122,6 +122,7 @@ namespace TwitchDownloaderCore
 
             int splitSegmentIndex;
             TimeSpan splitTime;
+            TimeSpan lastSegmentDuration;
             try
             {
                 var mediaString = await HttpClient.GetStringAsync(mediaUrl, cancellationToken);
@@ -129,20 +130,35 @@ namespace TwitchDownloaderCore
                 var segments = media.Streams ?? Array.Empty<M3U8.Stream>();
                 splitSegmentIndex = segments.Length;
                 splitTime = TimeSpan.FromSeconds((double)segments.Sum(s => s.PartInfo?.Duration ?? 0m));
+                lastSegmentDuration = segments.Length > 0
+                    ? TimeSpan.FromSeconds((double)(segments[^1].PartInfo?.Duration ?? 10m))
+                    : TimeSpan.Zero;
             }
             catch (Exception ex)
             {
                 throw new Exception($"Could not read the live media playlist to find the split point: {ex.Message}", ex);
             }
 
-            if (splitSegmentIndex <= 0 || splitTime <= TimeSpan.FromSeconds(1))
+            // Need at least 2 segments so that partA gets at least one and partB gets the last.
+            if (splitSegmentIndex <= 1 || splitTime <= TimeSpan.FromSeconds(1))
             {
-                // Nothing meaningful aired yet - just record everything live with ffmpeg.
+                // Nothing (or almost nothing) meaningful aired yet - just record everything live with ffmpeg.
                 _progress.LogInfo("Nothing has aired yet; recording the whole broadcast live.");
                 await RecordLiveTail(mediaUrl, 0, outputFile, extension, channel, cancellationToken);
                 _progress.ReportProgress(100);
                 return;
             }
+
+            // Split strategy: give the LAST already-aired segment exclusively to the live tail (partB).
+            // partA gets everything up to (but not including) that segment.
+            // partB starts from that last segment via -live_start_index.
+            //
+            // Why: some ffmpeg versions clamp -live_start_index to last_seq_no when the requested
+            // index equals the current playlist length. Using N-1 (a definitely-present segment)
+            // avoids this, and keeping it exclusively in partB prevents a ~10 s repeated block at
+            // the join point.
+            var partATrimEnd = splitTime - lastSegmentDuration - TimeSpan.FromMilliseconds(100);
+            var ffmpegStartIndex = splitSegmentIndex - 1;
 
             var partA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
             var partB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
@@ -160,12 +176,12 @@ namespace TwitchDownloaderCore
 
                 var backCatalogTask = new VideoDownloader(BuildOptions(partA,
                     _options.TrimBeginning ? _options.TrimBeginningTime : (TimeSpan?)null,
-                    splitTime), _progress)
+                    partATrimEnd), _progress)
                     .DownloadAsync(backCatalogCts.Token);
 
                 // Live tail listens to the user's cancellation token — pressing Cancel
                 // gracefully stops the ffmpeg recording and lets us stitch what we have.
-                var liveTailTask = RecordLiveTail(mediaUrl, splitSegmentIndex, partB, extension, channel, cancellationToken);
+                var liveTailTask = RecordLiveTail(mediaUrl, ffmpegStartIndex, partB, extension, channel, cancellationToken);
 
                 bool stoppedEarly = false;
                 try

--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -60,7 +60,9 @@ namespace TwitchDownloaderCore
             if (!isLive)
             {
                 _progress.LogWarning($"'{channel}' is not live (status: {video.status ?? "unknown"}). Downloading the complete VOD instead.");
-                await new VideoDownloader(BuildOptions(outputFile, null, null), _progress).DownloadAsync(cancellationToken);
+                await new VideoDownloader(BuildOptions(outputFile,
+                    _options.TrimBeginning ? _options.TrimBeginningTime : (TimeSpan?)null,
+                    _options.TrimEnding ? _options.TrimEndingTime : (TimeSpan?)null), _progress).DownloadAsync(cancellationToken);
                 _progress.ReportProgress(100);
                 return;
             }
@@ -121,7 +123,9 @@ namespace TwitchDownloaderCore
                 // almost always be done before the user ever stops the recording.
                 using var backCatalogCts = new CancellationTokenSource();
 
-                var backCatalogTask = new VideoDownloader(BuildOptions(partA, null, splitTime), _progress)
+                var backCatalogTask = new VideoDownloader(BuildOptions(partA,
+                    _options.TrimBeginning ? _options.TrimBeginningTime : (TimeSpan?)null,
+                    splitTime), _progress)
                     .DownloadAsync(backCatalogCts.Token);
 
                 // Live tail listens to the user's cancellation token — pressing Cancel

--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -32,6 +32,26 @@ namespace TwitchDownloaderCore
     {
         private static readonly HttpClient HttpClient = new();
 
+        // Tracks every ffmpeg process currently recording a live tail so they can be
+        // killed if the host application exits without going through normal cancellation.
+        private static readonly HashSet<Process> _activeFfmpegProcesses = new();
+        private static readonly object _activeFfmpegLock = new();
+
+        static LiveStreamDownloader()
+        {
+            AppDomain.CurrentDomain.ProcessExit += static (_, _) =>
+            {
+                lock (_activeFfmpegLock)
+                {
+                    foreach (var p in _activeFfmpegProcesses)
+                    {
+                        try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                    }
+                    _activeFfmpegProcesses.Clear();
+                }
+            };
+        }
+
         private readonly LiveStreamDownloadOptions _options;
         private readonly ITaskProgress _progress;
 
@@ -57,13 +77,17 @@ namespace TwitchDownloaderCore
 
             // Clean up any leftover part files from a previous interrupted session
             // (e.g. the app was closed mid-recording and restarted while the stream is still live).
+            // The ProcessExit handler kills any surviving ffmpeg before we reach this point,
+            // so the files should be unlocked. If somehow a file is still locked, log and continue.
             var stalePartA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
             var stalePartB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
             if (File.Exists(stalePartA) || File.Exists(stalePartB))
             {
                 _progress.LogInfo("Removing leftover part files from a previous interrupted session.");
-                TryDelete(stalePartA);
-                TryDelete(stalePartB);
+                if (!TryDelete(stalePartA))
+                    _progress.LogWarning($"Could not delete stale part file (still locked?): {stalePartA}");
+                if (!TryDelete(stalePartB))
+                    _progress.LogWarning($"Could not delete stale part file (still locked?): {stalePartB}");
             }
 
             // If the broadcast already ended, the in-progress VOD is just a normal finished
@@ -303,6 +327,7 @@ namespace TwitchDownloaderCore
             };
 
             process.Start();
+            lock (_activeFfmpegLock) { _activeFfmpegProcesses.Add(process); }
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
@@ -325,6 +350,10 @@ namespace TwitchDownloaderCore
                     try { if (!process.HasExited) process.Kill(true); } catch { /* ignored */ }
                 }
                 throw;
+            }
+            finally
+            {
+                lock (_activeFfmpegLock) { _activeFfmpegProcesses.Remove(process); }
             }
 
             if (process.ExitCode != 0)
@@ -412,14 +441,15 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private static void TryDelete(string path)
+        private static bool TryDelete(string path)
         {
             try
             {
                 if (!string.IsNullOrEmpty(path) && File.Exists(path))
                     File.Delete(path);
+                return true;
             }
-            catch { /* best effort */ }
+            catch { return false; }
         }
     }
 }

--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TwitchDownloaderCore.Extensions;
+using TwitchDownloaderCore.Interfaces;
+using TwitchDownloaderCore.Models;
+using TwitchDownloaderCore.Options;
+
+namespace TwitchDownloaderCore
+{
+    /// <summary>
+    /// "Live download": captures a currently-airing broadcast in full.
+    /// <list type="number">
+    /// <item><b>Back-catalog</b> <c>[start -&gt; split]</c>: the hours already aired are
+    /// downloaded immediately with the multi-threaded <see cref="VideoDownloader"/>. This
+    /// range is static, so it is fast and finalizes reliably.</item>
+    /// <item><b>Live tail</b> <c>[split -&gt; end]</c>: recorded concurrently in real time by
+    /// ffmpeg streaming the in-progress VOD from segment index <c>split</c>. ffmpeg only has
+    /// to keep up with real time (the backlog is the back-catalog's job), and it finalizes
+    /// once cleanly when the broadcast ends.</item>
+    /// <item><b>Stitch</b>: the two halves are concatenated with <c>-c copy</c>. The split is
+    /// an exact HLS segment boundary (same source segments, "Safe" trim), so the join is
+    /// bit-exact - no re-encode, no overlap, no gap, no frame matching.</item>
+    /// </list>
+    /// </summary>
+    public sealed class LiveStreamDownloader
+    {
+        private static readonly HttpClient HttpClient = new();
+
+        private readonly LiveStreamDownloadOptions _options;
+        private readonly ITaskProgress _progress;
+
+        public LiveStreamDownloader(LiveStreamDownloadOptions options, ITaskProgress progress)
+        {
+            _options = options;
+            _progress = progress;
+        }
+
+        public async Task DownloadAsync(CancellationToken cancellationToken)
+        {
+            _progress.SetStatus("Starting live download...");
+
+            var info = await TwitchHelper.GetVideoInfo(_options.Id);
+            var video = info?.data?.video;
+            if (video is null)
+                throw new Exception($"Could not get video info for {_options.Id}. A live download requires the in-progress VOD (the channel must have VODs/archive enabled).");
+
+            var channel = video.owner?.login ?? video.owner?.displayName ?? _options.Channel ?? _options.Id.ToString();
+            var isLive = string.Equals(video.status, "RECORDING", StringComparison.OrdinalIgnoreCase);
+
+            var (outputFile, extension) = ResolveOutputPath();
+
+            // If the broadcast already ended, the in-progress VOD is just a normal finished
+            // VOD - one multi-threaded download, no split, no stitch.
+            if (!isLive)
+            {
+                _progress.LogWarning($"'{channel}' is not live (status: {video.status ?? "unknown"}). Downloading the complete VOD instead.");
+                await new VideoDownloader(BuildOptions(outputFile, null, null), _progress).DownloadAsync(cancellationToken);
+                _progress.ReportProgress(100);
+                return;
+            }
+
+            // Resolve the media playlist for the chosen quality and measure where the live
+            // edge currently is (segment count + total duration so far).
+            var tokenResponse = await TwitchHelper.GetVideoToken(_options.Id, _options.Oauth);
+            var vodToken = tokenResponse?.data?.videoPlaybackAccessToken;
+            if (vodToken is null || string.IsNullOrEmpty(vodToken.value))
+                throw new Exception($"Could not retrieve a playback token for video {_options.Id}.");
+
+            var masterString = await TwitchHelper.GetVideoPlaylist(_options.Id, vodToken.value, vodToken.signature);
+            if (masterString.Contains("vod_manifest_restricted") || masterString.Contains("unauthorized_entitlements"))
+                throw new Exception("This VOD requires authorization (sub-only / restricted). Provide a valid OAuth token in Settings.");
+
+            var master = M3U8.Parse(masterString);
+            master.SortStreamsByQuality();
+            var quality = VideoQualities.FromM3U8(master).GetQuality(_options.Quality);
+            var mediaUrl = quality?.Item?.Path;
+            if (string.IsNullOrWhiteSpace(mediaUrl))
+                throw new Exception("Could not find a playable quality for this stream.");
+
+            int splitSegmentIndex;
+            TimeSpan splitTime;
+            try
+            {
+                var mediaString = await HttpClient.GetStringAsync(mediaUrl, cancellationToken);
+                var media = M3U8.Parse(mediaString);
+                var segments = media.Streams ?? Array.Empty<M3U8.Stream>();
+                splitSegmentIndex = segments.Length;
+                splitTime = TimeSpan.FromSeconds((double)segments.Sum(s => s.PartInfo?.Duration ?? 0m));
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Could not read the live media playlist to find the split point: {ex.Message}", ex);
+            }
+
+            if (splitSegmentIndex <= 0 || splitTime <= TimeSpan.FromSeconds(1))
+            {
+                // Nothing meaningful aired yet - just record everything live with ffmpeg.
+                _progress.LogInfo("Nothing has aired yet; recording the whole broadcast live.");
+                await RecordLiveTail(mediaUrl, 0, outputFile, extension, channel, cancellationToken);
+                _progress.ReportProgress(100);
+                return;
+            }
+
+            var partA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
+            var partB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
+
+            try
+            {
+                _progress.LogInfo($"Live download for '{channel}': {splitTime:hh\\:mm\\:ss} already aired ({splitSegmentIndex} segments). "
+                                  + "Downloading the back-catalog multi-threaded while recording the live tail with ffmpeg in parallel.");
+
+                // Back-catalog uses its own CancellationTokenSource so it can run to
+                // completion even when the user requests an early stop.  The back-catalog
+                // is static content and downloads much faster than real time, so it will
+                // almost always be done before the user ever stops the recording.
+                using var backCatalogCts = new CancellationTokenSource();
+
+                var backCatalogTask = new VideoDownloader(BuildOptions(partA, null, splitTime), _progress)
+                    .DownloadAsync(backCatalogCts.Token);
+
+                // Live tail listens to the user's cancellation token — pressing Cancel
+                // gracefully stops the ffmpeg recording and lets us stitch what we have.
+                var liveTailTask = RecordLiveTail(mediaUrl, splitSegmentIndex, partB, extension, channel, cancellationToken);
+
+                bool stoppedEarly = false;
+                try
+                {
+                    await Task.WhenAll(backCatalogTask, liveTailTask);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    stoppedEarly = true;
+                    _progress.SetStatus("Recording stopped — waiting for back-catalog to finalize...");
+
+                    // Give the back-catalog up to 60 s to finish cleanly (it is static
+                    // content and almost certainly already done).  If it misses the
+                    // deadline, cancel it and stitch whatever partial output we have.
+                    using var backCatalogTimeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+                    try
+                    {
+                        await backCatalogTask.WaitAsync(backCatalogTimeoutCts.Token);
+                    }
+                    catch
+                    {
+                        backCatalogCts.Cancel();
+                        try { await backCatalogTask; } catch { /* ignored */ }
+                    }
+                }
+
+                _progress.SetStatus(stoppedEarly ? "Saving captured footage..." : "Stitching the two halves (lossless)...");
+                try
+                {
+                    await ConcatLossless(partA, partB, outputFile, CancellationToken.None);
+                }
+                catch (Exception ex) when (stoppedEarly)
+                {
+                    _progress.LogWarning($"Could not save partial recording: {ex.Message}");
+                }
+
+                if (stoppedEarly)
+                {
+                    _progress.SetStatus("Recording stopped and saved.");
+                    throw new OperationCanceledException("Recording stopped by user.", cancellationToken);
+                }
+
+                _progress.SetStatus("Live download complete.");
+                _progress.ReportProgress(100);
+            }
+            finally
+            {
+                TryDelete(partA);
+                TryDelete(partB);
+            }
+        }
+
+        private (string outputFile, string extension) ResolveOutputPath()
+        {
+            var outputFile = _options.Filename;
+            var extension = (Path.GetExtension(outputFile) ?? "").ToLowerInvariant();
+            if (string.IsNullOrEmpty(extension))
+            {
+                extension = ".mp4";
+                outputFile += extension;
+            }
+
+            var directory = Path.GetDirectoryName(outputFile);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+
+                if (outputFile.Length > 250)
+                {
+                    var name = Path.GetFileNameWithoutExtension(outputFile);
+                    var available = 250 - directory.Length - 1 - extension.Length - 6;
+                    if (available > 16)
+                    {
+                        name = name.Substring(0, Math.Min(name.Length, available));
+                        outputFile = Path.Combine(directory, name + extension);
+                        _progress.LogWarning($"Output path was too long; truncated to {outputFile}");
+                    }
+                }
+            }
+
+            return (outputFile, extension);
+        }
+
+        private VideoDownloadOptions BuildOptions(string filename, TimeSpan? trimStart, TimeSpan? trimEnd)
+        {
+            return new VideoDownloadOptions
+            {
+                Id = _options.Id,
+                Quality = _options.Quality,
+                Filename = filename,
+                Oauth = _options.Oauth,
+                FfmpegPath = _options.FfmpegPath,
+                DownloadThreads = _options.DownloadThreads,
+                ThrottleKib = _options.ThrottleKib,
+                TempFolder = _options.TempFolder,
+                TrimMode = VideoTrimMode.Safe,
+                TrimBeginning = trimStart.HasValue,
+                TrimBeginningTime = trimStart ?? TimeSpan.Zero,
+                TrimEnding = trimEnd.HasValue,
+                TrimEndingTime = trimEnd ?? TimeSpan.Zero,
+            };
+        }
+
+        private async Task RecordLiveTail(string mediaUrl, int startSegmentIndex, string outFile, string extension, string channel, CancellationToken cancellationToken)
+        {
+            var format = extension switch
+            {
+                ".mp4" => "mp4",
+                ".mov" => "mov",
+                ".mkv" => "matroska",
+                ".ts" => "mpegts",
+                ".webm" => "webm",
+                ".m4a" => "mp4",
+                _ => "mp4"
+            };
+            var audioBsf = extension is ".mp4" or ".mov" or ".m4a" ? " -bsf:a aac_adtstoasc" : "";
+
+            var arguments =
+                "-hide_banner -loglevel warning "
+                + "-user_agent \"Mozilla/5.0\" "
+                + "-protocol_whitelist file,crypto,data,http,https,tcp,tls "
+                + "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 "
+                + $"-live_start_index {startSegmentIndex} "
+                + $"-i \"{mediaUrl}\" -c copy{audioBsf} -f {format} -progress pipe:1 -y "
+                + $"\"{outFile}\"";
+
+            _progress.LogVerbose($"ffmpeg {arguments}");
+
+            var errorTail = new Queue<string>();
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = _options.FfmpegPath,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is null || !e.Data.StartsWith("out_time=", StringComparison.Ordinal)) return;
+                var value = e.Data.Substring("out_time=".Length).Trim();
+                if (TimeSpan.TryParse(value, out var captured))
+                    _progress.SetStatus($"● LIVE recording '{channel}'  -  {captured:hh\\:mm\\:ss} captured");
+            };
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is null) return;
+                _progress.LogFfmpeg(e.Data);
+                lock (errorTail)
+                {
+                    errorTail.Enqueue(e.Data);
+                    while (errorTail.Count > 20) errorTail.Dequeue();
+                }
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _progress.SetStatus("Stopping live recording...");
+                try { if (!process.HasExited) await process.StandardInput.WriteLineAsync("q"); }
+                catch { /* ignored */ }
+                try
+                {
+                    using var graceCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                    await process.WaitForExitAsync(graceCts.Token);
+                }
+                catch
+                {
+                    try { if (!process.HasExited) process.Kill(true); } catch { /* ignored */ }
+                }
+                throw;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                string tail;
+                lock (errorTail) tail = string.Join(Environment.NewLine, errorTail);
+                throw new Exception($"Live tail recording failed (ffmpeg code {process.ExitCode})."
+                                    + (string.IsNullOrWhiteSpace(tail) ? "" : Environment.NewLine + tail));
+            }
+        }
+
+        private async Task ConcatLossless(string partA, string partB, string outputFile, CancellationToken cancellationToken)
+        {
+            bool aExists = File.Exists(partA);
+            bool bExists = File.Exists(partB);
+
+            if (!aExists && !bExists)
+                throw new Exception("Neither recording portion was produced; no output to save.");
+
+            if (!aExists)
+            {
+                // Back-catalog did not complete in time — save the live tail only.
+                _progress.LogWarning("Back-catalog did not complete; output contains the live-recorded portion only.");
+                File.Copy(partB, outputFile, true);
+                return;
+            }
+
+            if (!bExists)
+            {
+                File.Copy(partA, outputFile, true);
+                return;
+            }
+
+            var listFile = Path.Combine(Path.GetTempPath(), $"tdw_concat_{_options.Id}_{Guid.NewGuid():N}.txt");
+            await File.WriteAllTextAsync(listFile,
+                $"file '{partA.Replace("'", "'\\''")}'\nfile '{partB.Replace("'", "'\\''")}'\n",
+                cancellationToken);
+
+            try
+            {
+                var args = "-hide_banner -loglevel warning -y -f concat -safe 0 "
+                           + $"-i \"{listFile}\" -c copy -fflags +genpts \"{outputFile}\"";
+
+                var errorTail = new Queue<string>();
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = _options.FfmpegPath,
+                        Arguments = args,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                    }
+                };
+                process.ErrorDataReceived += (_, e) =>
+                {
+                    if (e.Data is null) return;
+                    _progress.LogFfmpeg(e.Data);
+                    lock (errorTail)
+                    {
+                        errorTail.Enqueue(e.Data);
+                        while (errorTail.Count > 20) errorTail.Dequeue();
+                    }
+                };
+                process.OutputDataReceived += (_, e) => { if (e.Data != null) _progress.LogFfmpeg(e.Data); };
+
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+                await process.WaitForExitAsync(cancellationToken);
+
+                if (process.ExitCode != 0)
+                {
+                    string tail;
+                    lock (errorTail) tail = string.Join(Environment.NewLine, errorTail);
+                    throw new Exception($"Lossless stitch failed (ffmpeg code {process.ExitCode})."
+                                        + (string.IsNullOrWhiteSpace(tail) ? "" : Environment.NewLine + tail));
+                }
+            }
+            finally
+            {
+                TryDelete(listFile);
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    File.Delete(path);
+            }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/TwitchDownloaderCore/Options/ChatRenderOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatRenderOptions.cs
@@ -24,6 +24,11 @@ namespace TwitchDownloaderCore.Options
         public double OutlineSize { get; set; }
         public string Font { get; set; }
         public double FontSize { get; set; } = 24.0;
+        /// <summary>
+        /// Multiplier applied to <see cref="FontSize"/> to determine the username font size. 1.0 = same as message text.
+        /// </summary>
+        public double UsernameFontScale { get; set; } = 1.0;
+        public double EffectiveUsernameFontSize => FontSize * (UsernameFontScale > 0 ? UsernameFontScale : 1.0);
         public SKFontStyle MessageFontStyle { get; set; }
         public SKFontStyle UsernameFontStyle { get; set; }
         public double ReferenceScale => FontSize / 24;
@@ -51,6 +56,11 @@ namespace TwitchDownloaderCore.Options
         public string TempFolder { get; set; }
         public bool SubMessages { get; set; }
         public bool ChatBadges { get; set; }
+        /// <summary>
+        /// Usernames (login or display name, case-insensitive) whose names should be drawn with <see cref="HighlightUsersColor"/>.
+        /// </summary>
+        public string[] HighlightUsersArray { get; set; } = Array.Empty<string>();
+        public SKColor HighlightUsersColor { get; set; }
         public string[] IgnoreUsersArray { get; set; } = Array.Empty<string>();
         public string[] BannedWordsArray { get; set; } = Array.Empty<string>();
         public double EmoteScale { get; set; } = 1.0;

--- a/TwitchDownloaderCore/Options/ClipDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ClipDownloadOptions.cs
@@ -6,6 +6,7 @@ namespace TwitchDownloaderCore.Options
     public class ClipDownloadOptions
     {
         public string Id { get; set; }
+        public string Oauth { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
         public int ThrottleKib { get; set; }

--- a/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
@@ -1,0 +1,24 @@
+namespace TwitchDownloaderCore.Options
+{
+    public class LiveStreamDownloadOptions
+    {
+        /// <summary>
+        /// The id of the in-progress VOD. Used to resolve the channel login (and is shown in the queue).
+        /// Ignored if <see cref="Channel"/> is set.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// The channel login to record. If empty, it is resolved from <see cref="Id"/>.
+        /// </summary>
+        public string Channel { get; set; }
+
+        public string Quality { get; set; }
+        public string Filename { get; set; }
+        public string Oauth { get; set; }
+        public string FfmpegPath { get; set; }
+        public int DownloadThreads { get; set; } = 4;
+        public int ThrottleKib { get; set; } = -1;
+        public string TempFolder { get; set; }
+    }
+}

--- a/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TwitchDownloaderCore.Options
 {
     public class LiveStreamDownloadOptions
@@ -20,5 +22,10 @@ namespace TwitchDownloaderCore.Options
         public int DownloadThreads { get; set; } = 4;
         public int ThrottleKib { get; set; } = -1;
         public string TempFolder { get; set; }
+
+        public bool TrimBeginning { get; set; }
+        public TimeSpan TrimBeginningTime { get; set; }
+        public bool TrimEnding { get; set; }
+        public TimeSpan TrimEndingTime { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Services/FilenameService.cs
+++ b/TwitchDownloaderCore/Services/FilenameService.cs
@@ -146,7 +146,6 @@ namespace TwitchDownloaderCore.Services
             return newName.ReplaceAny(FilenameInvalidChars, '_');
         }
 
-        [return: MaybeNull]
         public static string GuessVodFileExtension([AllowNull] string qualityString)
         {
             if (string.IsNullOrWhiteSpace(qualityString))
@@ -159,14 +158,7 @@ namespace TwitchDownloaderCore.Services
                 return ".m4a";
             }
 
-            if (char.IsDigit(qualityString[0])
-                || qualityString.Contains("source", StringComparison.OrdinalIgnoreCase)
-                || qualityString.Contains("chunked", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".mp4";
-            }
-
-            return null;
+            return ".mp4";
         }
 
         public static FileInfo GetNonCollidingName(FileInfo fileInfo)

--- a/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
@@ -24,7 +24,7 @@ namespace TwitchDownloaderCore.Tools
                 cancellationToken.ThrowIfCancellationRequested();
 
                 await sw.WriteAsync("file '");
-                await sw.WriteAsync(DownloadTools.RemoveQueryString(stream.Path));
+                await sw.WriteAsync(DownloadTools.RemoveQueryString(stream.Path).Replace("#", @"\#"));
                 await sw.WriteLineAsync('\'');
 
                 foreach (var id in streamIds.Ids)

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -64,6 +64,34 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlVideoTokenResponse>();
         }
 
+        public static async Task<GqlVideoTokenResponse> GetLiveStreamToken(string channelLogin, string authToken)
+        {
+            var request = new HttpRequestMessage()
+            {
+                RequestUri = new Uri("https://gql.twitch.tv/gql"),
+                Method = HttpMethod.Post,
+                Content = new StringContent("{\"operationName\":\"PlaybackAccessToken_Template\",\"query\":\"query PlaybackAccessToken_Template($login: String!, $isLive: Boolean!, $vodID: ID!, $isVod: Boolean!, $playerType: String!) {  streamPlaybackAccessToken(channelName: $login, params: {platform: \\\"web\\\", playerBackend: \\\"mediaplayer\\\", playerType: $playerType}) @include(if: $isLive) {    value    signature    __typename  }  videoPlaybackAccessToken(id: $vodID, params: {platform: \\\"web\\\", playerBackend: \\\"mediaplayer\\\", playerType: $playerType}) @include(if: $isVod) {    value    signature    __typename  }}\",\"variables\":{\"isLive\":true,\"login\":\"" + channelLogin + "\",\"isVod\":false,\"vodID\":\"\",\"playerType\":\"site\"}}", Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            if (!string.IsNullOrWhiteSpace(authToken))
+                request.Headers.Add("Authorization", $"OAuth {authToken}");
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<GqlVideoTokenResponse>();
+        }
+
+        public static async Task<string> GetLiveStreamPlaylist(string channelLogin, string token, string sig)
+        {
+            var request = new HttpRequestMessage()
+            {
+                RequestUri = new Uri($"https://usher.ttvnw.net/api/channel/hls/{channelLogin}.m3u8?sig={sig}&token={Uri.EscapeDataString(token)}&allow_source=true&allow_audio_only=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264&fast_bread=true"),
+                Method = HttpMethod.Get
+            };
+            using var response = await httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public static async Task<string> GetVideoPlaylist(long videoId, string token, string sig)
         {
             HttpRequestMessage request;
@@ -124,7 +152,7 @@ namespace TwitchDownloaderCore
             return false;
         }
 
-        public static async Task<GqlClipResponse> GetClipInfo(object clipId)
+        public static async Task<GqlClipResponse> GetClipInfo(object clipId, string oauth = null)
         {
             var request = new HttpRequestMessage()
             {
@@ -133,12 +161,14 @@ namespace TwitchDownloaderCore
                 Content = new StringContent("{\"query\":\"query{clip(slug:\\\"" + clipId + "\\\"){title,thumbnailURL,createdAt,curator{id,displayName,login},durationSeconds,broadcaster{id,displayName,login},videoOffsetSeconds,video{id},viewCount,game{id,displayName,boxArtURL}}}\",\"variables\":{}}", Encoding.UTF8, "application/json")
             };
             request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            if (!string.IsNullOrWhiteSpace(oauth))
+                request.Headers.Add("Authorization", $"OAuth {oauth}");
             using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<GqlClipResponse>();
         }
 
-        public static async Task<GqlClipTokenResponse> GetClipLinks(string clipId)
+        public static async Task<GqlClipTokenResponse> GetClipLinks(string clipId, string oauth = null)
         {
             var request = new HttpRequestMessage()
             {
@@ -147,6 +177,8 @@ namespace TwitchDownloaderCore
                 Content = new StringContent("{\"operationName\":\"VideoAccessToken_Clip\",\"variables\":{\"slug\":\"" + clipId + "\"},\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11\"}}}", Encoding.UTF8, "application/json")
             };
             request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            if (!string.IsNullOrWhiteSpace(oauth))
+                request.Headers.Add("Authorization", $"OAuth {oauth}");
             using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
 
@@ -159,7 +191,7 @@ namespace TwitchDownloaderCore
             return gqlClipTokenResponses;
         }
 
-        public static async Task<GqlShareClipRenderStatusResponse> GetShareClipRenderStatus(string clipId)
+        public static async Task<GqlShareClipRenderStatusResponse> GetShareClipRenderStatus(string clipId, string oauth = null)
         {
             var request = new HttpRequestMessage()
             {
@@ -168,6 +200,8 @@ namespace TwitchDownloaderCore
                 Content = new StringContent("{\"operationName\":\"ShareClipRenderStatus\",\"variables\":{\"slug\":\"" + clipId + "\"},\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"761bc03a4b100ec4f73fa78a5011847bb8ad7693d223d055fd013f79390acd41\"}}}", Encoding.UTF8, "application/json")
             };
             request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            if (!string.IsNullOrWhiteSpace(oauth))
+                request.Headers.Add("Authorization", $"OAuth {oauth}");
             using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
 

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoTokenResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoTokenResponse.cs
@@ -3,6 +3,7 @@
     public class GqlVideoData
     {
         public VideoPlaybackAccessToken videoPlaybackAccessToken { get; set; }
+        public VideoPlaybackAccessToken streamPlaybackAccessToken { get; set; }
     }
 
     public class GqlVideoTokenResponse

--- a/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
@@ -79,8 +79,7 @@ namespace TwitchDownloaderCore.TwitchObjects
             {
                 for (int i = 0; i < EmoteFrameDurations.Count; i++)
                 {
-                    EmoteFrameDurations.RemoveAt(i);
-                    EmoteFrameDurations.Insert(i, 10);
+                    EmoteFrameDurations[i] = 10;
                 }
                 TotalDuration = EmoteFrameDurations.Count * 10;
             }
@@ -98,15 +97,52 @@ namespace TwitchDownloaderCore.TwitchObjects
         private void ExtractFrames()
         {
             var codecInfo = Codec.Info;
-            for (int i = 0; i < FrameCount; i++)
+            var imageInfo = new SKImageInfo(codecInfo.Width, codecInfo.Height);
+
+            if (FrameCount == 1)
             {
-                SKImageInfo imageInfo = new SKImageInfo(codecInfo.Width, codecInfo.Height);
-                SKBitmap newBitmap = new SKBitmap(imageInfo);
-                IntPtr pointer = newBitmap.GetPixels();
-                SKCodecOptions codecOptions = new SKCodecOptions(i);
-                Codec.GetPixels(imageInfo, pointer, codecOptions);
-                newBitmap.SetImmutable();
-                EmoteFrames.Add(newBitmap);
+                var singleBitmap = new SKBitmap(imageInfo);
+                Codec.GetPixels(imageInfo, singleBitmap.GetPixels(), new SKCodecOptions(0));
+                singleBitmap.SetImmutable();
+                EmoteFrames.Add(singleBitmap);
+                return;
+            }
+
+            // For animated images, frames may be encoded as deltas on top of a prior frame.
+            // We must pre-fill each work bitmap with its required prior frame before decoding.
+            var frameInfos = Codec.FrameInfo;
+            var priorFrames = new SKBitmap[FrameCount];
+            try
+            {
+                for (int i = 0; i < FrameCount; i++)
+                {
+                    var workBitmap = new SKBitmap(imageInfo);
+
+                    int requiredFrame = i < frameInfos.Length ? frameInfos[i].RequiredFrame : -1;
+
+                    if (requiredFrame >= 0 && priorFrames[requiredFrame] != null)
+                    {
+                        // Pre-fill the destination with the prior frame's composited pixels
+                        priorFrames[requiredFrame].CopyTo(workBitmap);
+                    }
+
+                    Codec.GetPixels(imageInfo, workBitmap.GetPixels(), new SKCodecOptions(i, requiredFrame));
+
+                    // Keep a mutable copy so subsequent frames can use it as their prior frame
+                    var priorCopy = new SKBitmap(imageInfo);
+                    workBitmap.CopyTo(priorCopy);
+                    priorFrames[i] = priorCopy;
+
+                    workBitmap.SetImmutable();
+                    EmoteFrames.Add(workBitmap);
+                }
+            }
+            finally
+            {
+                foreach (var frame in priorFrames)
+                {
+                    frame?.Dispose();
+                }
             }
         }
 

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -569,11 +569,12 @@ namespace TwitchDownloaderCore
                 return;
 
             // TimeSpan.Parse insists that hours cannot be greater than 24, thus we must use the TimeSpan ctor.
+            // ffmpeg reports time as HH:MM:SS.CC where CC is centiseconds (hundredths), not milliseconds.
             if (!int.TryParse(encodingTimeMatch.Groups[1].ValueSpan, out var hours)) return;
             if (!int.TryParse(encodingTimeMatch.Groups[2].ValueSpan, out var minutes)) return;
             if (!int.TryParse(encodingTimeMatch.Groups[3].ValueSpan, out var seconds)) return;
-            if (!int.TryParse(encodingTimeMatch.Groups[4].ValueSpan, out var milliseconds)) return;
-            var encodingTime = new TimeSpan(0, hours, minutes, seconds, milliseconds);
+            if (!int.TryParse(encodingTimeMatch.Groups[4].ValueSpan, out var centiseconds)) return;
+            var encodingTime = new TimeSpan(0, hours, minutes, seconds, centiseconds * 10);
 
             var percent = (int)Math.Round(encodingTime / videoLength * 100);
 

--- a/TwitchDownloaderWPF/App.xaml.cs
+++ b/TwitchDownloaderWPF/App.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Threading;
 using TwitchDownloaderWPF.Properties;
@@ -33,6 +36,8 @@ namespace TwitchDownloaderWPF
             var windowsThemeService = new WindowsThemeService();
             ThemeServiceSingleton = new ThemeService(this, windowsThemeService);
 
+            PromptImportSettingsIfNeeded();
+
             MainWindow = new MainWindow
             {
                 WindowStartupLocation = WindowStartupLocation.CenterScreen
@@ -48,6 +53,105 @@ namespace TwitchDownloaderWPF
                 Settings.Default.UpgradeRequired = false;
                 Settings.Default.Save();
             }
+        }
+
+        private static void MarkSettingsImported()
+        {
+            Settings.Default.SettingsImported = true;
+            Settings.Default.UpgradeRequired = false;
+            Settings.Default.Save();
+        }
+
+        private static void PromptImportSettingsIfNeeded()
+        {
+            if (Settings.Default.SettingsImported)
+                return;
+
+            string currentConfigPath;
+            try
+            {
+                var cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+                currentConfigPath = cfg.FilePath;
+            }
+            catch
+            {
+                MarkSettingsImported();
+                return;
+            }
+
+            try
+            {
+                // ...\<company>\<identity TwitchDownloaderWPF_xxx>\<version>\user.config
+                var currentIdentityDir = Path.GetDirectoryName(Path.GetDirectoryName(currentConfigPath));
+                var companyDir = Path.GetDirectoryName(currentIdentityDir);
+                if (string.IsNullOrEmpty(companyDir) || !Directory.Exists(companyDir))
+                {
+                    MarkSettingsImported();
+                    return;
+                }
+
+                var candidates = new List<SettingsImportCandidate>();
+                foreach (var dir in Directory.GetDirectories(companyDir, "TwitchDownloaderWPF*"))
+                {
+                    if (string.Equals(dir, currentIdentityDir, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    FileInfo newest = null;
+                    try
+                    {
+                        foreach (var file in Directory.EnumerateFiles(dir, "user.config", SearchOption.AllDirectories))
+                        {
+                            var fi = new FileInfo(file);
+                            if (newest is null || fi.LastWriteTime > newest.LastWriteTime)
+                                newest = fi;
+                        }
+                    }
+                    catch { /* unreadable identity dir, skip */ }
+
+                    if (newest is null)
+                        continue;
+
+                    var versionFolder = Path.GetFileName(Path.GetDirectoryName(newest.FullName));
+                    var idFolder = Path.GetFileName(dir);
+                    candidates.Add(new SettingsImportCandidate
+                    {
+                        ConfigPath = newest.FullName,
+                        LastModified = newest.LastWriteTime,
+                        DisplayName = $"{idFolder}  -  v{versionFolder}  -  modified {newest.LastWriteTime:g}"
+                    });
+                }
+
+                if (candidates.Count == 0)
+                {
+                    MarkSettingsImported();
+                    return;
+                }
+
+                candidates = candidates.OrderByDescending(c => c.LastModified).ToList();
+
+                var dialog = new WindowSettingsImport(candidates);
+                dialog.ShowDialog();
+
+                if (!string.IsNullOrEmpty(dialog.SelectedConfigPath))
+                {
+                    try
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(currentConfigPath)!);
+                        File.Copy(dialog.SelectedConfigPath, currentConfigPath, true);
+                        Settings.Default.Reload();
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show("Failed to import settings: " + ex.Message, "Import Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    }
+                }
+            }
+            catch
+            {
+                /* never block startup on import failure */
+            }
+
+            MarkSettingsImported();
         }
 
         private static void Current_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/TwitchDownloaderWPF/MainWindow.xaml
+++ b/TwitchDownloaderWPF/MainWindow.xaml
@@ -9,7 +9,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="Twitch Downloader" MinHeight="440" Height="500" MinWidth="700" Width="850" Loaded="Window_Loaded" SourceInitialized="Window_OnSourceInitialized">
+        Title="Twitch Downloader" MinHeight="440" Height="500" MinWidth="700" Width="850" Loaded="Window_Loaded" SourceInitialized="Window_OnSourceInitialized" Closing="Window_Closing">
     <Grid Background="{DynamicResource AppBackground}">
         <Grid.RowDefinitions>
             <RowDefinition Height="2" />
@@ -18,6 +18,7 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
@@ -41,9 +42,12 @@
         <Button x:Name="btnChatRender" Margin="4" Grid.Row="1" Grid.Column="5" MinWidth="122" Height="52" Click="btnChatRender_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
             <TextBlock Text="{lex:Loc ChatRender}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="{Binding ActualWidth, ElementName=btnChatRender, Mode=OneWay}" Padding="3,0,3,0" />
         </Button>
-        <Button x:Name="btnQueue" Margin="4" Grid.Row="1" Grid.Column="6" MinWidth="122" Height="52" Click="btnQueue_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
+        <Button x:Name="btnLiveMonitor" Margin="4" Grid.Row="1" Grid.Column="6" MinWidth="122" Height="52" Click="btnLiveMonitor_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
+            <TextBlock Text="{lex:Loc LiveMonitor}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="{Binding ActualWidth, ElementName=btnLiveMonitor, Mode=OneWay}" Padding="3,0,3,0" />
+        </Button>
+        <Button x:Name="btnQueue" Margin="4" Grid.Row="1" Grid.Column="7" MinWidth="122" Height="52" Click="btnQueue_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
             <TextBlock Text="{lex:Loc TaskQueue}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="{Binding ActualWidth, ElementName=btnQueue, Mode=OneWay}" Padding="3,0,3,0" />
         </Button>
-        <Frame Focusable="False" x:Name="Main" Grid.Column="0" Grid.ColumnSpan="8" Grid.Row="2" NavigationUIVisibility="Hidden" Navigated="Main_OnNavigated" Background="{DynamicResource AppBackground}" BorderBrush="{DynamicResource AppBackground}"/>
+        <Frame Focusable="False" x:Name="Main" Grid.Column="0" Grid.ColumnSpan="9" Grid.Row="2" NavigationUIVisibility="Hidden" Navigated="Main_OnNavigated" Background="{DynamicResource AppBackground}" BorderBrush="{DynamicResource AppBackground}"/>
     </Grid>
 </Window>

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -11,8 +11,10 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Navigation;
+using System.Linq;
 using TwitchDownloaderCore.Extensions;
 using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.TwitchTasks;
 using TwitchDownloaderWPF.Services;
 using Xabe.FFmpeg;
 using Xabe.FFmpeg.Downloader;
@@ -29,6 +31,7 @@ namespace TwitchDownloaderWPF
         public static PageChatDownload pageChatDownload = new PageChatDownload();
         public static PageChatUpdate pageChatUpdate = new PageChatUpdate();
         public static PageChatRender pageChatRender = new PageChatRender();
+        public static PageLiveMonitor pageLiveMonitor = new PageLiveMonitor();
         public static PageQueue pageQueue = new PageQueue();
 
         public MainWindow()
@@ -59,6 +62,11 @@ namespace TwitchDownloaderWPF
         private void btnChatRender_Click(object sender, RoutedEventArgs e)
         {
             Main.Content = pageChatRender;
+        }
+
+        private void btnLiveMonitor_Click(object sender, RoutedEventArgs e)
+        {
+            Main.Content = pageLiveMonitor;
         }
 
         private void btnQueue_Click(object sender, RoutedEventArgs e)
@@ -190,6 +198,40 @@ namespace TwitchDownloaderWPF
             }
         }
 
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (!IsAnyOperationRunning())
+                return;
+
+            var result = MessageBox.Show(this,
+                Translations.Strings.ExitWhileRunningMessage.Replace(@"\n", Environment.NewLine),
+                Translations.Strings.ExitWhileRunningTitle,
+                MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+            if (result != MessageBoxResult.Yes)
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private static bool IsAnyOperationRunning()
+        {
+            lock (PageQueue.taskLock)
+            {
+                if (PageQueue.taskList.Any(task => task.Status is TwitchTaskStatus.Running or TwitchTaskStatus.Stopping))
+                {
+                    return true;
+                }
+            }
+
+            return pageVodDownload.IsActionInProgress
+                   || pageClipDownload.IsActionInProgress
+                   || pageChatDownload.IsActionInProgress
+                   || pageChatUpdate.IsActionInProgress
+                   || pageChatRender.IsActionInProgress
+                   || pageLiveMonitor.IsMonitoring;
+        }
+
         private void Main_OnNavigated(object sender, NavigationEventArgs e)
         {
             UpdateSelectedBigButton();
@@ -202,6 +244,7 @@ namespace TwitchDownloaderWPF
             ((TextBlock)btnChatDownload.Content).TextDecorations = null;
             ((TextBlock)btnChatUpdate.Content).TextDecorations = null;
             ((TextBlock)btnChatRender.Content).TextDecorations = null;
+            ((TextBlock)btnLiveMonitor.Content).TextDecorations = null;
             ((TextBlock)btnQueue.Content).TextDecorations = null;
 
             var newPage = Main.Content;
@@ -224,6 +267,10 @@ namespace TwitchDownloaderWPF
             else if (ReferenceEquals(newPage, pageChatRender))
             {
                 ((TextBlock)btnChatRender.Content).TextDecorations = TextDecorations.Underline;
+            }
+            else if (ReferenceEquals(newPage, pageLiveMonitor))
+            {
+                ((TextBlock)btnLiveMonitor.Content).TextDecorations = TextDecorations.Underline;
             }
             else if (ReferenceEquals(newPage, pageQueue))
             {

--- a/TwitchDownloaderWPF/Models/ChatRenderPreset.cs
+++ b/TwitchDownloaderWPF/Models/ChatRenderPreset.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace TwitchDownloaderWPF.Models
+{
+    public class ChatRenderPreset
+    {
+        public string Name { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public string Font { get; set; }
+        public double FontSize { get; set; }
+        public int BackgroundColorA { get; set; }
+        public int BackgroundColorR { get; set; }
+        public int BackgroundColorG { get; set; }
+        public int BackgroundColorB { get; set; }
+        public int AltBackgroundColorA { get; set; }
+        public int AltBackgroundColorR { get; set; }
+        public int AltBackgroundColorG { get; set; }
+        public int AltBackgroundColorB { get; set; }
+        public int MessageColorR { get; set; }
+        public int MessageColorG { get; set; }
+        public int MessageColorB { get; set; }
+        public int HighlightUsersColorR { get; set; }
+        public int HighlightUsersColorG { get; set; }
+        public int HighlightUsersColorB { get; set; }
+        public bool Outline { get; set; }
+        public bool Timestamp { get; set; }
+        public bool Bttv { get; set; } = true;
+        public bool Ffz { get; set; } = true;
+        public bool Stv { get; set; } = true;
+        public bool SubMessages { get; set; }
+        public bool Badges { get; set; }
+        public bool RenderAvatars { get; set; }
+        public bool Offline { get; set; }
+        public bool Dispersion { get; set; }
+        public bool AlternateBackgrounds { get; set; }
+        public bool AdjustUsernameVisibility { get; set; }
+        public double UpdateRate { get; set; }
+        public int Framerate { get; set; }
+        public bool GenerateMask { get; set; }
+        public bool ChatRenderSharpening { get; set; }
+        public double EmoteScale { get; set; }
+        public double BadgeScale { get; set; }
+        public double EmojiScale { get; set; }
+        public double AvatarScale { get; set; }
+        public double VerticalScale { get; set; }
+        public double SidePaddingScale { get; set; }
+        public double SectionHeightScale { get; set; }
+        public double WordSpaceScale { get; set; }
+        public double EmoteSpaceScale { get; set; }
+        public double AccentStrokeScale { get; set; }
+        public double AccentIndentScale { get; set; }
+        public double OutlineScale { get; set; }
+        public double UsernameScale { get; set; }
+        public string IgnoreUsers { get; set; }
+        public string HighlightUsers { get; set; }
+        public string BannedWords { get; set; }
+        public int EmojiVendor { get; set; }
+        public int ChatBadgeMask { get; set; }
+        public string FfmpegInput { get; set; }
+        public string FfmpegOutput { get; set; }
+        public string VideoContainer { get; set; }
+        public string VideoCodec { get; set; }
+    }
+}

--- a/TwitchDownloaderWPF/Models/EnqueuePreset.cs
+++ b/TwitchDownloaderWPF/Models/EnqueuePreset.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace TwitchDownloaderWPF.Models
+{
+    public class EnqueuePreset
+    {
+        public string Name { get; set; }
+        public string Folder { get; set; }
+        public string Quality { get; set; }
+        public bool DownloadVideo { get; set; } = true;
+        public bool DelayDownload { get; set; }
+        public bool LiveDownload { get; set; }
+        public bool DownloadChat { get; set; }
+        public string ChatFormat { get; set; } = "JSON";
+        public bool ChatCompressGzip { get; set; }
+        public bool EmbedImages { get; set; }
+        public bool EmbedBttv { get; set; } = true;
+        public bool EmbedFfz { get; set; } = true;
+        public bool EmbedStv { get; set; } = true;
+        public bool DelayChat { get; set; }
+        public bool RenderChat { get; set; }
+    }
+}

--- a/TwitchDownloaderWPF/Models/LiveMonitorChannelSettings.cs
+++ b/TwitchDownloaderWPF/Models/LiveMonitorChannelSettings.cs
@@ -1,0 +1,25 @@
+namespace TwitchDownloaderWPF.Models
+{
+    /// <summary>
+    /// A full snapshot of all Live Monitor settings for one channel.
+    /// </summary>
+    public class LiveMonitorChannelSettings
+    {
+        public string Folder { get; set; } = "";
+        public string Quality { get; set; } = "Source";
+        public int DownloadMode { get; set; } = 0;
+        public int PollSeconds { get; set; } = 60;
+        public int Threads { get; set; } = 4;
+        public bool DownloadChat { get; set; } = false;
+        public bool AutoRender { get; set; } = false;
+        public string RenderPreset { get; set; } = "";
+        public bool TrimBeginning { get; set; } = false;
+        public int TrimBeginningHour { get; set; } = 0;
+        public int TrimBeginningMinute { get; set; } = 0;
+        public int TrimBeginningSecond { get; set; } = 0;
+        public bool TrimEnding { get; set; } = false;
+        public int TrimEndingHour { get; set; } = 0;
+        public int TrimEndingMinute { get; set; } = 0;
+        public int TrimEndingSecond { get; set; } = 0;
+    }
+}

--- a/TwitchDownloaderWPF/PageChatDownload.xaml
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml
@@ -128,6 +128,7 @@
                 </hc:SplitButton.DropDownContent>
             </hc:SplitButton>
             <Button x:Name="BtnCancel" Height="40" MinWidth="120" Margin="0,6,0,0" Content="{lex:Loc TaskCancel}" Click="BtnCancel_Click" Visibility="Collapsed" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="BtnSyncFromVod" Height="40" MinWidth="120" Margin="6,6,0,0" Content="← Sync from VOD" Click="BtnSyncFromVod_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
         <!-- RIGHT -->
         <StackPanel Grid.Column="4" Grid.Row="1" Grid.RowSpan="1" HorizontalAlignment="Right">

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -45,6 +45,8 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
         }
 
+        public bool IsActionInProgress => BtnCancel.Visibility == Visibility.Visible;
+
         private void Page_Initialized(object sender, EventArgs e)
         {
             SetEnabled(false);
@@ -694,6 +696,31 @@ namespace TwitchDownloaderWPF
 
             Settings.Default.ChatTextTimestampStyle = (int)TimestampFormat.None;
             Settings.Default.Save();
+        }
+
+        private void BtnSyncFromVod_Click(object sender, RoutedEventArgs e)
+        {
+            var vod = MainWindow.pageVodDownload;
+            if (vod.currentVideoId == 0)
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "No VOD is loaded on the VOD Download page.", "Nothing to Sync", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            // Copy URL
+            textUrl.Text = vod.textUrl.Text;
+
+            // Copy trim start
+            CheckTrimStart.IsChecked = vod.checkStart.IsChecked;
+            numStartHour.Value = vod.numStartHour.Value;
+            numStartMinute.Value = vod.numStartMinute.Value;
+            numStartSecond.Value = vod.numStartSecond.Value;
+
+            // Copy trim end
+            CheckTrimEnd.IsChecked = vod.checkEnd.IsChecked;
+            numEndHour.Value = vod.numEndHour.Value;
+            numEndMinute.Value = vod.numEndMinute.Value;
+            numEndSecond.Value = vod.numEndSecond.Value;
         }
     }
 }

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -56,7 +56,7 @@
                         <StackPanel Orientation="Vertical" Margin="5,10,5,5">
                             <TextBlock Text="{lex:Loc ChatFont}" HorizontalAlignment="Right" Margin="0,5,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Text="{lex:Loc ChatFontSize}" HorizontalAlignment="Right" Margin="0,20,0,0" Foreground="{DynamicResource AppText}"/>
-                            <TextBlock Text="{lex:Loc FontColor}" HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}"/>
+                            <TextBlock Text="{lex:Loc FontColor}" HorizontalAlignment="Right" Margin="0,20,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Text="{lex:Loc BackgroundColor}" HorizontalAlignment="Right" Margin="0,12,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Text="{lex:Loc AlternateBackgroundColor}" HorizontalAlignment="Right" Margin="0,12,0,0" Foreground="{DynamicResource AppText}"/>
                         </StackPanel>
@@ -115,6 +115,11 @@
                             <TextBox x:Name="textIgnoreUsersList" Margin="0,4,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Margin="0,10,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc BannedWordsList}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc BannedWordsListTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                             <TextBox x:Name="textBannedWordsList" Margin="0,4,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                            <TextBlock Margin="0,10,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc HighlightUsersList}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc HighlightUsersListTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                <TextBox x:Name="textHighlightUsersList" MinWidth="150" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                                <xctk:ColorPicker x:Name="colorHighlightUsers" SelectedColor="#FFD700" Width="50" UsingAlphaChannel="False" Margin="5,0,0,0" HorizontalAlignment="Left" Background="White" BorderBrush="{DynamicResource AppElementInnerBorder}" DropDownBackground="{DynamicResource AppElementInnerBackground}" Foreground="{DynamicResource AppText}" HeaderBackground="{DynamicResource AppElementInnerBackground}" HeaderForeground="{DynamicResource AppText}" TabBackground="{DynamicResource AppElementBorder}" TabForeground="{DynamicResource AppText}"/>
+                            </StackPanel>
                             <WrapPanel Orientation="Horizontal" Margin="0,10,0,0">
                                 <TextBlock Text="{lex:Loc EmojiVendor}" Margin="0,0,0,0" Foreground="{DynamicResource AppText}"/>
                                 <RadioButton x:Name="RadioEmojiNotoColor" IsChecked="True" Content="{lex:Loc EmojiVendorNotoColor}" Margin="3,0,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
@@ -136,6 +141,7 @@
                             <TextBlock Text="{lex:Loc AvatarScale}" HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Text="{lex:Loc OutlineScale}" HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}"/>
                             <TextBlock Text="{lex:Loc VerticalSpacingScale}" HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}"/>
+                            <TextBlock HorizontalAlignment="Right" Margin="0,14,0,0" Foreground="{DynamicResource AppText}" ToolTip="{lex:Loc ChatUsernameFontSizeTooltip}" Text="{lex:Loc ChatUsernameFontSize}"/>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="0,10,5,5">
                             <TextBox x:Name="textEmoteScale" Text="1.0" Width="50" HorizontalAlignment="Left" Margin="0,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
@@ -144,6 +150,7 @@
                             <TextBox x:Name="textAvatarScale" Text="1.0" Width="50" HorizontalAlignment="Left" Margin="0,2,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                             <TextBox x:Name="textOutlineScale" Text="1.0" Width="50" HorizontalAlignment="Left" Margin="0,2,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                             <TextBox x:Name="textVerticalScale" Text="1.0" Width="50" HorizontalAlignment="Left" Margin="0,2,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                            <TextBox x:Name="textUsernameScale" Text="1.0" Width="50" HorizontalAlignment="Left" Margin="0,2,0,0" ToolTip="{lex:Loc ChatUsernameFontSizeTooltip}" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="5,10,5,5">
                             <TextBlock Text="{lex:Loc SectionHeightScale}" HorizontalAlignment="Right" Margin="0,6, 0,0" Foreground="{DynamicResource AppText}"/>
@@ -226,11 +233,19 @@
             </TabItem>
         </TabControl>
 
-        <WrapPanel Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Margin="0,0,0,10" Orientation="Horizontal" HorizontalAlignment="Center">
-            <TextBlock Margin="3,8,3,3" Text="{lex:Loc JsonFile}" Foreground="{DynamicResource AppText}"/>
-            <TextBox x:Name="textJson" Margin="3" MinWidth="200" MaxWidth="400" TextChanged="TextJson_TextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-            <Button x:Name="btnBrowse" Margin="3" MinWidth="50" Content="{lex:Loc Browse}" Click="btnBrowse_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
-        </WrapPanel>
+        <StackPanel Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Margin="0,0,0,10" HorizontalAlignment="Center">
+            <WrapPanel Orientation="Horizontal" Margin="0,0,0,4">
+                <TextBlock Margin="3,8,3,3" Text="Preset:" Foreground="{DynamicResource AppText}"/>
+                <ComboBox x:Name="comboRenderPresets" Width="180" Margin="3,4,3,3" DisplayMemberPath="Name" SelectionChanged="ComboRenderPresets_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button Content="Save" Width="50" Margin="3,4,3,3" Click="BtnSaveRenderPreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <Button Content="Delete" Width="55" Margin="0,4,3,3" Click="BtnDeleteRenderPreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </WrapPanel>
+            <WrapPanel Orientation="Horizontal">
+                <TextBlock Margin="3,8,3,3" Text="{lex:Loc JsonFile}" Foreground="{DynamicResource AppText}"/>
+                <TextBox x:Name="textJson" Margin="3" MinWidth="200" MaxWidth="400" TextChanged="TextJson_TextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnBrowse" Margin="3" MinWidth="50" Content="{lex:Loc Browse}" Click="btnBrowse_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </WrapPanel>
+        </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,10">
             <hc:SplitButton x:Name="SplitBtnRender" Height="40" MinWidth="120" Margin="0,6,0,0" Content="{lex:Loc Render}" Click="SplitBtnRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >
                 <hc:SplitButton.DropDownContent>
@@ -250,17 +265,50 @@
                 <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             </StackPanel>
         </StackPanel>
-        <StackPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2">
-            <TextBlock Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}"/>
-            <RichTextBox Margin="0,3" IsReadOnly="True" Name="textLog" Height="230" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+        <DockPanel Grid.Column="4" Grid.Row="2" Grid.RowSpan="2" LastChildFill="True">
+            <TextBlock DockPanel.Dock="Top" Text="{lex:Loc LogHeader}" Foreground="{DynamicResource AppText}"/>
+            <RichTextBox DockPanel.Dock="Top" Margin="0,3" IsReadOnly="True" Name="textLog" Height="150" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0" />
                     </Style>
                 </RichTextBox.Resources>
             </RichTextBox>
-            <Button x:Name="BtnClearLog" MinWidth="50" IsEnabled="False" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
-        </StackPanel>
+            <Button DockPanel.Dock="Top" x:Name="BtnClearLog" MinWidth="50" IsEnabled="False" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+
+            <Separator DockPanel.Dock="Top" Margin="0,6,0,4"/>
+            <!-- Preview header: mode + duration + render + fullscreen -->
+            <WrapPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,4">
+                <TextBlock Text="Preview" Margin="0,5,6,0" Foreground="{DynamicResource AppText}" FontWeight="SemiBold"/>
+                <RadioButton x:Name="radioPreviewImage" Content="Image" IsChecked="True" Margin="0,4,4,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" Checked="RadioPreviewMode_Changed"/>
+                <RadioButton x:Name="radioPreviewVideo" Content="Video" Margin="0,4,4,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" Checked="RadioPreviewMode_Changed"/>
+                <TextBox x:Name="textPreviewDuration" Text="30" Width="32" Margin="0,2,2,2" ToolTip="Duration in seconds (video mode)" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <TextBlock Text="s" Margin="0,5,6,0" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnPreviewRender" Content="Preview" Margin="0,2,2,2" Padding="6,2" Click="BtnPreviewRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <Button x:Name="btnPreviewFullscreen" Content="⛶" Width="26" Margin="0,2,0,2" Padding="2" ToolTip="View full size" Click="BtnPreviewFullscreen_Click" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
+            </WrapPanel>
+            <!-- Position row -->
+            <WrapPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,4">
+                <TextBlock Text="Position:" Margin="0,5,4,0" Foreground="{DynamicResource AppText}"/>
+                <TextBox x:Name="textPreviewPos" Text="0:00:00" Width="70" Margin="0,2,4,2" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnPreviewMidpoint" Content="⊙ Midpoint" Margin="0,2,0,2" Padding="6,2" Click="BtnPreviewMidpoint_Click" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
+            </WrapPanel>
+            <!-- Video playback controls — dock bottom so they sit below the preview area -->
+            <WrapPanel DockPanel.Dock="Bottom" Orientation="Horizontal" x:Name="panelVideoPreview" Visibility="Collapsed" Margin="0,2,0,0">
+                <Button x:Name="btnPreviewPlayPause" Content="Play" MinWidth="50" Height="24" Padding="6,0" Margin="0,0,4,0" Click="BtnPreviewPlayPause_Click" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
+                <TextBlock x:Name="textPreviewTime" Text="0:00 / 0:00" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
+            </WrapPanel>
+            <!-- Chat-timeline slider — always represents full chat duration -->
+            <Slider DockPanel.Dock="Bottom" x:Name="sliderPreview" Minimum="0" Maximum="100" Margin="0,0,0,2" ValueChanged="SliderPreview_ValueChanged"/>
+            <ProgressBar DockPanel.Dock="Bottom" x:Name="progressPreview" Height="4" Margin="0,0,0,2" Visibility="Collapsed" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource ProgressBarForeground}"/>
+            <!-- Preview image/video area — fill child, expands to use all remaining space -->
+            <Border x:Name="borderPreviewImage" BorderBrush="{DynamicResource AppElementBorder}" BorderThickness="1" Margin="0,0,0,4" MinHeight="80" Background="{DynamicResource AppElementBackground}">
+                <Grid>
+                    <TextBlock x:Name="textPreviewStatus" Text="Click Preview to render" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource AppText}" Opacity="0.6"/>
+                    <Image x:Name="imgPreview" Stretch="Uniform" Visibility="Collapsed"/>
+                </Grid>
+            </Border>
+        </DockPanel>
 
         <!--STATUS BAR-->
         <StatusBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="6" Background="{DynamicResource StatusBarBackground}" BorderBrush="{DynamicResource StatusBarBorder}">

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -17,6 +18,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
+using System.Windows.Threading;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Options;
@@ -24,6 +26,7 @@ using TwitchDownloaderCore.TwitchObjects;
 using TwitchDownloaderWPF.Extensions;
 using TwitchDownloaderWPF.Models;
 using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.Services;
 using TwitchDownloaderWPF.Utils;
 using WpfAnimatedGif;
 using MessageBox = System.Windows.MessageBox;
@@ -41,11 +44,27 @@ namespace TwitchDownloaderWPF
         public string[] FileNames = [];
         private CancellationTokenSource _cancellationTokenSource;
 
+        // Preset support
+        private bool _applyingPreset = false;
+
+        // Embedded preview support
+        private readonly List<string> _previewTempFiles = new();
+        private CancellationTokenSource _previewCts;
+        private bool _previewIsPlaying = false;
+        private DispatcherTimer _previewTimer;
+        private double _previewMediaDuration = 30;
+        private double _chatTotalDuration = 0;
+        private bool _previewSliderUserDragging = true;
+        private List<BitmapImage> _previewFrames = new();
+        private int _currentPreviewFrameIdx = 0;
+
         public PageChatRender()
         {
             InitializeComponent();
             App.CultureServiceSingleton.CultureChanged += OnCultureChanged;
         }
+
+        public bool IsActionInProgress => BtnCancel.Visibility == Visibility.Visible;
 
         private void OnCultureChanged(object sender, CultureInfo e)
         {
@@ -97,6 +116,7 @@ namespace TwitchDownloaderWPF
             SKColor backgroundColor = new(colorBackground.SelectedColor.Value.R, colorBackground.SelectedColor.Value.G, colorBackground.SelectedColor.Value.B, colorBackground.SelectedColor.Value.A);
             SKColor altBackgroundColor = new(colorAlternateBackground.SelectedColor.Value.R, colorAlternateBackground.SelectedColor.Value.G, colorAlternateBackground.SelectedColor.Value.B, colorAlternateBackground.SelectedColor.Value.A);
             SKColor messageColor = new(colorFont.SelectedColor.Value.R, colorFont.SelectedColor.Value.G, colorFont.SelectedColor.Value.B);
+            SKColor highlightUsersColor = new(colorHighlightUsers.SelectedColor.Value.R, colorHighlightUsers.SelectedColor.Value.G, colorHighlightUsers.SelectedColor.Value.B);
             ChatRenderOptions options = new()
             {
                 OutputFile = filename,
@@ -112,6 +132,7 @@ namespace TwitchDownloaderWPF
                 Outline = checkOutline.IsChecked.GetValueOrDefault(),
                 Font = (string)comboFont.SelectedItem,
                 FontSize = numFontSize.Value,
+                UsernameFontScale = double.Parse(textUsernameScale.Text, CultureInfo.CurrentCulture),
                 UpdateRate = double.Parse(textUpdateTime.Text, CultureInfo.CurrentCulture),
                 EmoteScale = double.Parse(textEmoteScale.Text, CultureInfo.CurrentCulture),
                 BadgeScale = double.Parse(textBadgeScale.Text, CultureInfo.CurrentCulture),
@@ -125,6 +146,8 @@ namespace TwitchDownloaderWPF
                 AccentStrokeScale = double.Parse(textAccentStrokeScale.Text, CultureInfo.CurrentCulture),
                 VerticalSpacingScale = double.Parse(textVerticalScale.Text, CultureInfo.CurrentCulture),
                 IgnoreUsersArray = textIgnoreUsersList.Text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                HighlightUsersArray = textHighlightUsersList.Text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                HighlightUsersColor = highlightUsersColor,
                 BannedWordsArray = textBannedWordsList.Text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
                 Timestamp = checkTimestamp.IsChecked.GetValueOrDefault(),
                 MessageColor = messageColor,
@@ -174,6 +197,7 @@ namespace TwitchDownloaderWPF
                 textHeight.Text = Settings.Default.Height.ToString();
                 textWidth.Text = Settings.Default.Width.ToString();
                 numFontSize.Value = Settings.Default.FontSize;
+                textUsernameScale.Text = Settings.Default.UsernameFontScale.ToString("0.0#");
                 textUpdateTime.Text = Settings.Default.UpdateTime.ToString("0.0#");
                 colorFont.SelectedColor = System.Windows.Media.Color.FromRgb(Settings.Default.FontColorR, Settings.Default.FontColorG, Settings.Default.FontColorB);
                 textFramerate.Text = Settings.Default.Framerate.ToString();
@@ -194,6 +218,8 @@ namespace TwitchDownloaderWPF
                 textAccentIndentScale.Text = Settings.Default.AccentIndentScale.ToString("0.0#");
                 textOutlineScale.Text = Settings.Default.OutlineScale.ToString("0.0#");
                 textIgnoreUsersList.Text = Settings.Default.IgnoreUsersList;
+                textHighlightUsersList.Text = Settings.Default.HighlightUsersList;
+                colorHighlightUsers.SelectedColor = System.Windows.Media.Color.FromRgb(Settings.Default.HighlightUsersColorR, Settings.Default.HighlightUsersColorG, Settings.Default.HighlightUsersColorB);
                 textBannedWordsList.Text = Settings.Default.BannedWordsList;
                 checkOffline.IsChecked = Settings.Default.Offline;
                 checkRenderAvatars.IsChecked = Settings.Default.RenderUserAvatars;
@@ -310,6 +336,11 @@ namespace TwitchDownloaderWPF
             }
             Settings.Default.IgnoreUsersList = string.Join(",", textIgnoreUsersList.Text
                 .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+            Settings.Default.HighlightUsersList = string.Join(",", textHighlightUsersList.Text
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+            Settings.Default.HighlightUsersColorR = colorHighlightUsers.SelectedColor.GetValueOrDefault().R;
+            Settings.Default.HighlightUsersColorG = colorHighlightUsers.SelectedColor.GetValueOrDefault().G;
+            Settings.Default.HighlightUsersColorB = colorHighlightUsers.SelectedColor.GetValueOrDefault().B;
             Settings.Default.BannedWordsList = string.Join(",", textBannedWordsList.Text
                 .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
             if (RadioEmojiNotoColor.IsChecked == true)
@@ -330,6 +361,7 @@ namespace TwitchDownloaderWPF
                 Settings.Default.Height = int.Parse(textHeight.Text);
                 Settings.Default.Width = int.Parse(textWidth.Text);
                 Settings.Default.FontSize = (float)numFontSize.Value;
+                Settings.Default.UsernameFontScale = double.Parse(textUsernameScale.Text, CultureInfo.CurrentCulture);
                 Settings.Default.UpdateTime = double.Parse(textUpdateTime.Text, CultureInfo.CurrentCulture);
                 Settings.Default.Framerate = int.Parse(textFramerate.Text);
                 Settings.Default.EmoteScale = double.Parse(textEmoteScale.Text, CultureInfo.CurrentCulture);
@@ -376,6 +408,7 @@ namespace TwitchDownloaderWPF
                 _ = double.Parse(textEmojiScale.Text, CultureInfo.CurrentCulture);
                 _ = double.Parse(textAvatarScale.Text, CultureInfo.CurrentCulture);
                 _ = double.Parse(textVerticalScale.Text, CultureInfo.CurrentCulture);
+                _ = double.Parse(textUsernameScale.Text, CultureInfo.CurrentCulture);
                 _ = double.Parse(textSidePaddingScale.Text, CultureInfo.CurrentCulture);
                 _ = double.Parse(textSectionHeightScale.Text, CultureInfo.CurrentCulture);
                 _ = double.Parse(textWordSpaceScale.Text, CultureInfo.CurrentCulture);
@@ -475,12 +508,12 @@ namespace TwitchDownloaderWPF
             }
             comboFont.SelectedItem = "Inter Embedded";
 
-            Codec h264Codec = new Codec() { Name = "H264", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libx264 -preset:v veryfast -crf 18 -pix_fmt yuv420p \"{save_path}\"" };
-            Codec h264NvencCodec = new Codec() { Name = "H264 NVIDIA", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v h264_nvenc -preset:v p4 -cq 20 -pix_fmt yuv420p \"{save_path}\"" };
-            Codec h264AmfCodec = new Codec() { Name = "H264 AMD", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v h264_amf -preset:v p4 -cq 20 -pix_fmt yuv420p \"{save_path}\"" };
-            Codec h265Codec = new Codec() { Name = "H265", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libx265 -preset:v veryfast -crf 18 -pix_fmt yuv420p \"{save_path}\"" };
-            Codec h265NvencCodec = new Codec() { Name = "H265 NVIDIA", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v hevc_nvenc -preset:v p4 -cq 21 -pix_fmt yuv420p \"{save_path}\"" };
-            Codec h265AmfCodec = new Codec() { Name = "H265 AMD", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v hevc_amf -preset:v p4 -cq 21 -pix_fmt yuv420p \"{save_path}\"" };
+            Codec h264Codec = new Codec() { Name = "H264", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libx264 -preset:v veryfast -crf 18 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
+            Codec h264NvencCodec = new Codec() { Name = "H264 NVIDIA", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v h264_nvenc -preset:v p4 -cq 20 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
+            Codec h264AmfCodec = new Codec() { Name = "H264 AMD", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v h264_amf -preset:v p4 -cq 20 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
+            Codec h265Codec = new Codec() { Name = "H265", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libx265 -preset:v veryfast -crf 18 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
+            Codec h265NvencCodec = new Codec() { Name = "H265 NVIDIA", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v hevc_nvenc -preset:v p4 -cq 21 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
+            Codec h265AmfCodec = new Codec() { Name = "H265 AMD", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v hevc_amf -preset:v p4 -cq 21 -pix_fmt yuv420p -movflags +faststart \"{save_path}\"" };
             Codec vp8Codec = new Codec() { Name = "VP8", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libvpx -crf 18 -b:v 2M -pix_fmt yuva420p -auto-alt-ref 0 \"{save_path}\"" };
             Codec vp9Codec = new Codec() { Name = "VP9", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v libvpx-vp9 -crf 18 -b:v 2M -deadline realtime -quality realtime -speed 3 -pix_fmt yuva420p \"{save_path}\"" };
             Codec rleCodec = new Codec() { Name = "RLE", InputArgs = "-framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -", OutputArgs = "-c:v qtrle -pix_fmt argb \"{save_path}\"" };
@@ -504,11 +537,31 @@ namespace TwitchDownloaderWPF
             comboBadges.Items.Add(new CheckComboBoxItem { Content = Translations.Strings.BadgeMaskOthers, Tag = ChatBadgeType.Other });
 
             LoadSettings();
+            LoadRenderPresets();
+
+            _previewTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _previewTimer.Tick += PreviewTimer_Tick;
         }
 
         private void Page_Unloaded(object sender, RoutedEventArgs e)
         {
             SaveSettings();
+            _previewTimer?.Stop();
+            _previewCts?.Cancel();
+            _previewFrames = new();
+            Task.Run(async () =>
+            {
+                await Task.Delay(1500);
+                foreach (var f in _previewTempFiles)
+                {
+                    try
+                    {
+                        if (Directory.Exists(f)) Directory.Delete(f, recursive: true);
+                        else File.Delete(f);
+                    }
+                    catch { /* ignored */ }
+                }
+            });
         }
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)
@@ -767,6 +820,20 @@ namespace TwitchDownloaderWPF
 
             FileNames = textJson.Text.Split("&&", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             UpdateActionButtons(false);
+
+            // Update preview position slider when a new file is loaded
+            if (FileNames.Length > 0 && File.Exists(FileNames[0]))
+            {
+                _chatTotalDuration = TryReadChatDuration(FileNames[0]);
+                if (_chatTotalDuration > 0)
+                {
+                    sliderPreview.Maximum = _chatTotalDuration;
+                    double mid = _chatTotalDuration / 2.0;
+                    sliderPreview.Value = mid;
+                    var midTs = TimeSpan.FromSeconds(mid);
+                    textPreviewPos.Text = $"{(int)midTs.TotalHours}:{midTs.Minutes:D2}:{midTs.Seconds:D2}";
+                }
+            }
         }
 
         private void FfmpegParameter_MouseDown(object sender, MouseButtonEventArgs e)
@@ -799,6 +866,588 @@ namespace TwitchDownloaderWPF
                 return textFfmpegOutput;
 
             return null;
+        }
+
+        // ── Preset support ─────────────────────────────────────────────────
+
+        private void LoadRenderPresets()
+        {
+            _applyingPreset = true;
+            try
+            {
+                var presets = ChatRenderPresetService.Load();
+                comboRenderPresets.ItemsSource = presets;
+                comboRenderPresets.SelectedIndex = -1;
+                var lastName = Settings.Default.LastRenderPresetName;
+                if (!string.IsNullOrEmpty(lastName))
+                {
+                    var idx = presets.FindIndex(p => p.Name == lastName);
+                    if (idx >= 0) comboRenderPresets.SelectedIndex = idx;
+                }
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+        }
+
+        private void ComboRenderPresets_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_applyingPreset || !IsInitialized)
+                return;
+
+            if (comboRenderPresets.SelectedItem is ChatRenderPreset preset)
+            {
+                ApplyRenderPreset(preset);
+                Settings.Default.LastRenderPresetName = preset.Name;
+                Settings.Default.Save();
+            }
+        }
+
+        private void ApplyRenderPreset(ChatRenderPreset preset)
+        {
+            _applyingPreset = true;
+            try
+            {
+                if (preset.Width > 0) textWidth.Text = preset.Width.ToString();
+                if (preset.Height > 0) textHeight.Text = preset.Height.ToString();
+                if (!string.IsNullOrEmpty(preset.Font)) comboFont.SelectedItem = preset.Font;
+                if (preset.FontSize > 0) numFontSize.Value = preset.FontSize;
+
+                colorBackground.SelectedColor = System.Windows.Media.Color.FromArgb(
+                    (byte)preset.BackgroundColorA, (byte)preset.BackgroundColorR,
+                    (byte)preset.BackgroundColorG, (byte)preset.BackgroundColorB);
+                colorAlternateBackground.SelectedColor = System.Windows.Media.Color.FromArgb(
+                    (byte)preset.AltBackgroundColorA, (byte)preset.AltBackgroundColorR,
+                    (byte)preset.AltBackgroundColorG, (byte)preset.AltBackgroundColorB);
+                colorFont.SelectedColor = System.Windows.Media.Color.FromRgb(
+                    (byte)preset.MessageColorR, (byte)preset.MessageColorG, (byte)preset.MessageColorB);
+                colorHighlightUsers.SelectedColor = System.Windows.Media.Color.FromRgb(
+                    (byte)preset.HighlightUsersColorR, (byte)preset.HighlightUsersColorG, (byte)preset.HighlightUsersColorB);
+
+                checkOutline.IsChecked = preset.Outline;
+                checkTimestamp.IsChecked = preset.Timestamp;
+                checkBTTV.IsChecked = preset.Bttv;
+                checkFFZ.IsChecked = preset.Ffz;
+                checkSTV.IsChecked = preset.Stv;
+                checkSub.IsChecked = preset.SubMessages;
+                checkBadge.IsChecked = preset.Badges;
+                checkRenderAvatars.IsChecked = preset.RenderAvatars;
+                checkOffline.IsChecked = preset.Offline;
+                checkDispersion.IsChecked = preset.Dispersion;
+                checkAlternateMessageBackgrounds.IsChecked = preset.AlternateBackgrounds;
+                checkAdjustUsernameVisibility.IsChecked = preset.AdjustUsernameVisibility;
+
+                textUpdateTime.Text = preset.UpdateRate.ToString("0.0#", CultureInfo.CurrentCulture);
+                textFramerate.Text = preset.Framerate.ToString();
+                checkMask.IsChecked = preset.GenerateMask;
+                CheckRenderSharpening.IsChecked = preset.ChatRenderSharpening;
+
+                textEmoteScale.Text = preset.EmoteScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textBadgeScale.Text = preset.BadgeScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textEmojiScale.Text = preset.EmojiScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAvatarScale.Text = preset.AvatarScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textVerticalScale.Text = preset.VerticalScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textSidePaddingScale.Text = preset.SidePaddingScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textSectionHeightScale.Text = preset.SectionHeightScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textWordSpaceScale.Text = preset.WordSpaceScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textEmoteSpaceScale.Text = preset.EmoteSpaceScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAccentStrokeScale.Text = preset.AccentStrokeScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAccentIndentScale.Text = preset.AccentIndentScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textOutlineScale.Text = preset.OutlineScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textUsernameScale.Text = preset.UsernameScale.ToString("0.0#", CultureInfo.CurrentCulture);
+
+                textIgnoreUsersList.Text = preset.IgnoreUsers ?? "";
+                textHighlightUsersList.Text = preset.HighlightUsers ?? "";
+                textBannedWordsList.Text = preset.BannedWords ?? "";
+
+                RadioEmojiNotoColor.IsChecked = preset.EmojiVendor == (int)EmojiVendor.GoogleNotoColor;
+                RadioEmojiTwemoji.IsChecked = preset.EmojiVendor == (int)EmojiVendor.TwitterTwemoji;
+                RadioEmojiNone.IsChecked = preset.EmojiVendor == (int)EmojiVendor.None;
+
+                comboBadges.SelectedItems.Clear();
+                var badgeMask = (ChatBadgeType)preset.ChatBadgeMask;
+                foreach (CheckComboBoxItem item in comboBadges.Items)
+                {
+                    if (badgeMask.HasFlag((Enum)item.Tag))
+                        comboBadges.SelectedItems.Add(item);
+                }
+
+                if (!string.IsNullOrEmpty(preset.VideoContainer))
+                {
+                    foreach (VideoContainer container in comboFormat.Items)
+                    {
+                        if (container.Name == preset.VideoContainer)
+                        {
+                            comboFormat.SelectedItem = container;
+                            comboCodec.Items.Clear();
+                            foreach (Codec codec in container.SupportedCodecs)
+                            {
+                                comboCodec.Items.Add(codec);
+                                if (codec.Name == preset.VideoCodec)
+                                    comboCodec.SelectedItem = codec;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(preset.FfmpegInput)) textFfmpegInput.Text = preset.FfmpegInput;
+                if (!string.IsNullOrEmpty(preset.FfmpegOutput)) textFfmpegOutput.Text = preset.FfmpegOutput;
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+        }
+
+        private ChatRenderPreset GetCurrentRenderPreset()
+        {
+            int badgeMask = 0;
+            foreach (var item in comboBadges.SelectedItems)
+                badgeMask += (int)((CheckComboBoxItem)item).Tag;
+
+            int emojiVendor = RadioEmojiTwemoji.IsChecked == true
+                ? (int)EmojiVendor.TwitterTwemoji
+                : RadioEmojiNone.IsChecked == true
+                    ? (int)EmojiVendor.None
+                    : (int)EmojiVendor.GoogleNotoColor;
+
+            return new ChatRenderPreset
+            {
+                Width = int.TryParse(textWidth.Text, out var w) ? w : 0,
+                Height = int.TryParse(textHeight.Text, out var h) ? h : 0,
+                Font = comboFont.SelectedItem?.ToString(),
+                FontSize = numFontSize.Value,
+                BackgroundColorA = colorBackground.SelectedColor?.A ?? 255,
+                BackgroundColorR = colorBackground.SelectedColor?.R ?? 17,
+                BackgroundColorG = colorBackground.SelectedColor?.G ?? 17,
+                BackgroundColorB = colorBackground.SelectedColor?.B ?? 17,
+                AltBackgroundColorA = colorAlternateBackground.SelectedColor?.A ?? 255,
+                AltBackgroundColorR = colorAlternateBackground.SelectedColor?.R ?? 25,
+                AltBackgroundColorG = colorAlternateBackground.SelectedColor?.G ?? 25,
+                AltBackgroundColorB = colorAlternateBackground.SelectedColor?.B ?? 25,
+                MessageColorR = colorFont.SelectedColor?.R ?? 255,
+                MessageColorG = colorFont.SelectedColor?.G ?? 255,
+                MessageColorB = colorFont.SelectedColor?.B ?? 255,
+                HighlightUsersColorR = colorHighlightUsers.SelectedColor?.R ?? 255,
+                HighlightUsersColorG = colorHighlightUsers.SelectedColor?.G ?? 215,
+                HighlightUsersColorB = colorHighlightUsers.SelectedColor?.B ?? 0,
+                Outline = checkOutline.IsChecked.GetValueOrDefault(),
+                Timestamp = checkTimestamp.IsChecked.GetValueOrDefault(),
+                Bttv = checkBTTV.IsChecked.GetValueOrDefault(),
+                Ffz = checkFFZ.IsChecked.GetValueOrDefault(),
+                Stv = checkSTV.IsChecked.GetValueOrDefault(),
+                SubMessages = checkSub.IsChecked.GetValueOrDefault(),
+                Badges = checkBadge.IsChecked.GetValueOrDefault(),
+                RenderAvatars = checkRenderAvatars.IsChecked.GetValueOrDefault(),
+                Offline = checkOffline.IsChecked.GetValueOrDefault(),
+                Dispersion = checkDispersion.IsChecked.GetValueOrDefault(),
+                AlternateBackgrounds = checkAlternateMessageBackgrounds.IsChecked.GetValueOrDefault(),
+                AdjustUsernameVisibility = checkAdjustUsernameVisibility.IsChecked.GetValueOrDefault(),
+                UpdateRate = double.TryParse(textUpdateTime.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ur) ? ur : 0.5,
+                Framerate = int.TryParse(textFramerate.Text, out var fr) ? fr : 30,
+                GenerateMask = checkMask.IsChecked.GetValueOrDefault(),
+                ChatRenderSharpening = CheckRenderSharpening.IsChecked.GetValueOrDefault(),
+                EmoteScale = double.TryParse(textEmoteScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var es) ? es : 1.0,
+                BadgeScale = double.TryParse(textBadgeScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var bs) ? bs : 1.0,
+                EmojiScale = double.TryParse(textEmojiScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ejs) ? ejs : 1.0,
+                AvatarScale = double.TryParse(textAvatarScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var avs) ? avs : 1.0,
+                VerticalScale = double.TryParse(textVerticalScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var vs) ? vs : 1.0,
+                SidePaddingScale = double.TryParse(textSidePaddingScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var sps) ? sps : 1.0,
+                SectionHeightScale = double.TryParse(textSectionHeightScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var shs) ? shs : 1.0,
+                WordSpaceScale = double.TryParse(textWordSpaceScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var wss) ? wss : 1.0,
+                EmoteSpaceScale = double.TryParse(textEmoteSpaceScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ess) ? ess : 1.0,
+                AccentStrokeScale = double.TryParse(textAccentStrokeScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ass) ? ass : 1.0,
+                AccentIndentScale = double.TryParse(textAccentIndentScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ais) ? ais : 1.0,
+                OutlineScale = double.TryParse(textOutlineScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var os) ? os : 1.0,
+                UsernameScale = double.TryParse(textUsernameScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var us) ? us : 1.0,
+                IgnoreUsers = textIgnoreUsersList.Text,
+                HighlightUsers = textHighlightUsersList.Text,
+                BannedWords = textBannedWordsList.Text,
+                EmojiVendor = emojiVendor,
+                ChatBadgeMask = badgeMask,
+                FfmpegInput = textFfmpegInput.Text,
+                FfmpegOutput = textFfmpegOutput.Text,
+                VideoContainer = (comboFormat.SelectedItem as VideoContainer)?.Name,
+                VideoCodec = (comboCodec.SelectedItem as Codec)?.Name,
+            };
+        }
+
+        private void BtnSaveRenderPreset_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new WindowInputText("Save Preset", "Enter a name for this preset:", (comboRenderPresets.SelectedItem as ChatRenderPreset)?.Name ?? "")
+            {
+                Owner = Application.Current.MainWindow
+            };
+
+            if (dialog.ShowDialog() != true || string.IsNullOrWhiteSpace(dialog.InputValue))
+                return;
+
+            var preset = GetCurrentRenderPreset();
+            preset.Name = dialog.InputValue;
+            ChatRenderPresetService.AddOrUpdate(preset);
+
+            LoadRenderPresets();
+
+            var presets = ChatRenderPresetService.Load();
+            var savedIndex = presets.FindIndex(p => p.Name == preset.Name);
+            if (savedIndex >= 0)
+            {
+                _applyingPreset = true;
+                comboRenderPresets.SelectedIndex = savedIndex;
+                _applyingPreset = false;
+            }
+        }
+
+        private void BtnDeleteRenderPreset_Click(object sender, RoutedEventArgs e)
+        {
+            if (comboRenderPresets.SelectedItem is not ChatRenderPreset preset)
+                return;
+
+            var result = MessageBox.Show(Application.Current.MainWindow!, $"Delete preset '{preset.Name}'?", "Delete Preset", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (result != MessageBoxResult.Yes)
+                return;
+
+            ChatRenderPresetService.Delete(preset.Name);
+            LoadRenderPresets();
+        }
+
+        // ── Embedded preview support ───────────────────────────────────────
+
+        private static double TryReadChatDuration(string inputFile)
+        {
+            if (string.IsNullOrEmpty(inputFile) || !File.Exists(inputFile))
+                return 0;
+            try
+            {
+                var buffer = new byte[8192];
+                using var fs = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                int bytesRead = fs.Read(buffer, 0, buffer.Length);
+                var text = System.Text.Encoding.UTF8.GetString(buffer, 0, bytesRead);
+
+                var endMatch = Regex.Match(text, @"""end""\s*:\s*([\d.]+)");
+                var startMatch = Regex.Match(text, @"""start""\s*:\s*([\d.]+)");
+
+                double end = 0, start = 0;
+                if (endMatch.Success)
+                    double.TryParse(endMatch.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out end);
+                if (startMatch.Success)
+                    double.TryParse(startMatch.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out start);
+
+                return end > 0 ? (end - start) : 0;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private void RadioPreviewMode_Changed(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized) return;
+            bool imageMode = radioPreviewImage.IsChecked == true;
+            panelVideoPreview.Visibility = imageMode ? Visibility.Collapsed : Visibility.Visible;
+            if (!imageMode && _previewFrames.Count > 0)
+            {
+                sliderPreview.Maximum = _previewMediaDuration;
+            }
+            else if (_chatTotalDuration > 0)
+            {
+                sliderPreview.Maximum = _chatTotalDuration;
+            }
+        }
+
+        private void BtnPreviewMidpoint_Click(object sender, RoutedEventArgs e)
+        {
+            if (_chatTotalDuration > 0)
+            {
+                double mid = _chatTotalDuration / 2.0;
+                sliderPreview.Value = mid;
+                var ts = TimeSpan.FromSeconds(mid);
+                textPreviewPos.Text = $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}";
+            }
+        }
+
+        private void SliderPreview_ValueChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (!_previewSliderUserDragging || !IsInitialized) return;
+
+            bool imageMode = radioPreviewImage.IsChecked == true;
+            if (imageMode)
+            {
+                var ts = TimeSpan.FromSeconds(e.NewValue);
+                textPreviewPos.Text = $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}";
+            }
+            else if (_previewFrames.Count > 0)
+            {
+                int idx = (int)(e.NewValue * 4.0);
+                _currentPreviewFrameIdx = Math.Clamp(idx, 0, _previewFrames.Count - 1);
+                imgPreview.Source = _previewFrames[_currentPreviewFrameIdx];
+            }
+        }
+
+        private async void BtnPreviewRender_Click(object sender, RoutedEventArgs e)
+        {
+            if (FileNames.Length == 0 || string.IsNullOrWhiteSpace(FileNames[0]))
+            {
+                MessageBox.Show(Application.Current.MainWindow!, Translations.Strings.UnableToParseInputsMessage, Translations.Strings.UnableToParseInputs, MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            if (!ValidateInputs())
+            {
+                MessageBox.Show(Application.Current.MainWindow!, Translations.Strings.UnableToParseInputsMessage, Translations.Strings.UnableToParseInputs, MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            if (!TimeSpan.TryParse(textPreviewPos.Text, out TimeSpan pos))
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Invalid position. Use H:MM:SS format.", "Invalid Input", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            bool imageMode = radioPreviewImage.IsChecked == true;
+            int videoDuration = 30;
+            if (!imageMode && (!int.TryParse(textPreviewDuration.Text, out videoDuration) || videoDuration <= 0))
+                videoDuration = 30;
+
+            _previewCts?.Cancel();
+            _previewCts = new CancellationTokenSource();
+
+            _previewFrames = new();
+            _currentPreviewFrameIdx = 0;
+            _previewIsPlaying = false;
+            btnPreviewPlayPause.Content = "Play";
+            _previewTimer?.Stop();
+
+            var tempFile = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.mp4");
+            _previewTempFiles.Add(tempFile);
+
+            var options = GetOptions(tempFile);
+            options.InputFile = FileNames[0];
+            options.StartOverride = (int)pos.TotalSeconds;
+            options.GenerateMask = false;
+            options.EndOverride = imageMode
+                ? (int)pos.TotalSeconds + 2
+                : (int)pos.TotalSeconds + videoDuration;
+            if (imageMode) options.Framerate = 1;
+
+
+            Dispatcher.BeginInvoke(() =>
+            {
+                progressPreview.Visibility = Visibility.Visible;
+                progressPreview.IsIndeterminate = true;
+                btnPreviewRender.IsEnabled = false;
+                imgPreview.Visibility = Visibility.Collapsed;
+                panelVideoPreview.Visibility = Visibility.Collapsed;
+                textPreviewStatus.Text = "Rendering...";
+                textPreviewStatus.Visibility = Visibility.Visible;
+            });
+
+            string capturedTempFile = tempFile;
+            bool cancelled = false;
+            try
+            {
+                var progress = new WpfTaskProgress(
+                    pct => Dispatcher.BeginInvoke(() => { progressPreview.IsIndeterminate = false; progressPreview.Value = pct; }),
+                    _ => { });
+
+                var renderer = new ChatRenderer(options, progress);
+                await renderer.ParseJsonAsync(_previewCts.Token);
+                await renderer.RenderVideoAsync(_previewCts.Token);
+
+                if (_previewCts.Token.IsCancellationRequested)
+                {
+                    cancelled = true;
+                    return;
+                }
+
+                if (imageMode)
+                {
+                    // Extract first frame as PNG using ffmpeg
+                    var tempPng = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.png");
+                    _previewTempFiles.Add(tempPng);
+
+                    var psi = new ProcessStartInfo("ffmpeg", $"-y -i \"{capturedTempFile}\" -vframes 1 \"{tempPng}\"")
+                    {
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    using var ffmpegProcess = Process.Start(psi);
+                    if (ffmpegProcess != null)
+                        await ffmpegProcess.WaitForExitAsync(_previewCts.Token);
+
+                    if (File.Exists(tempPng) && new FileInfo(tempPng).Length > 0)
+                    {
+                        // Load on UI thread to avoid cross-thread bitmap issues
+                        Dispatcher.BeginInvoke(() =>
+                        {
+                            try
+                            {
+                                var bitmap = new BitmapImage();
+                                bitmap.BeginInit();
+                                bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                                bitmap.UriSource = new Uri(tempPng);
+                                bitmap.EndInit();
+                                bitmap.Freeze();
+                                imgPreview.Source = bitmap;
+                                imgPreview.Visibility = Visibility.Visible;
+                                textPreviewStatus.Visibility = Visibility.Collapsed;
+                            }
+                            catch (Exception bex)
+                            {
+                                textPreviewStatus.Text = $"Image load error: {bex.Message}";
+                                textPreviewStatus.Visibility = Visibility.Visible;
+                            }
+                        });
+                    }
+                    else
+                    {
+                        Dispatcher.BeginInvoke(() =>
+                        {
+                            textPreviewStatus.Text = "Frame extraction failed. Ensure ffmpeg is on PATH.";
+                            textPreviewStatus.Visibility = Visibility.Visible;
+                        });
+                    }
+                }
+                else
+                {
+                    // Video mode: extract frames via ffmpeg to avoid WMF codec dependency
+                    _previewMediaDuration = videoDuration;
+                    var tempFrameDir = Path.Combine(Path.GetTempPath(), $"tdw_prevframes_{Guid.NewGuid():N}");
+                    Directory.CreateDirectory(tempFrameDir);
+                    _previewTempFiles.Add(tempFrameDir);
+
+                    Dispatcher.BeginInvoke(() => { progressPreview.IsIndeterminate = true; progressPreview.Visibility = Visibility.Visible; });
+
+                    var framePsi = new ProcessStartInfo(options.FfmpegPath,
+                        $"-y -i \"{capturedTempFile}\" -vf fps=4 \"{tempFrameDir}\\frame%05d.png\"")
+                    {
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    };
+                    using var frameProc = Process.Start(framePsi);
+                    if (frameProc != null) await frameProc.WaitForExitAsync(_previewCts.Token);
+
+                    var frames = new List<BitmapImage>();
+                    foreach (var f in Directory.GetFiles(tempFrameDir, "frame*.png").OrderBy(x => x))
+                    {
+                        try
+                        {
+                            var bmp = new BitmapImage();
+                            bmp.BeginInit();
+                            bmp.CacheOption = BitmapCacheOption.OnLoad;
+                            bmp.UriSource = new Uri(f);
+                            bmp.EndInit();
+                            bmp.Freeze();
+                            frames.Add(bmp);
+                        }
+                        catch { /* skip unreadable frame */ }
+                    }
+
+                    _previewFrames = frames;
+                    _currentPreviewFrameIdx = 0;
+
+                    Dispatcher.BeginInvoke(() =>
+                    {
+                        sliderPreview.Maximum = videoDuration;
+                        if (_previewFrames.Count > 0)
+                        {
+                            imgPreview.Source = _previewFrames[0];
+                            imgPreview.Visibility = Visibility.Visible;
+                            panelVideoPreview.Visibility = Visibility.Visible;
+                            textPreviewStatus.Visibility = Visibility.Collapsed;
+                            _previewIsPlaying = true;
+                            btnPreviewPlayPause.Content = "Pause";
+                            textPreviewTime.Text = $"0:00 / {FormatPreviewTime(TimeSpan.FromSeconds(_previewMediaDuration))}";
+                            _previewTimer?.Start();
+                        }
+                        else
+                        {
+                            textPreviewStatus.Text = "Frame extraction failed. Ensure ffmpeg is on PATH.";
+                            textPreviewStatus.Visibility = Visibility.Visible;
+                        }
+                    });
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+                Dispatcher.BeginInvoke(() =>
+                {
+                    textPreviewStatus.Text = "Render canceled.";
+                    textPreviewStatus.Visibility = Visibility.Visible;
+                });
+            }
+            catch (Exception ex)
+            {
+                Dispatcher.BeginInvoke(() =>
+                {
+                    textPreviewStatus.Text = $"Render error: {ex.Message}";
+                    textPreviewStatus.Visibility = Visibility.Visible;
+                });
+            }
+            finally
+            {
+                Dispatcher.BeginInvoke(() =>
+                {
+                    progressPreview.Visibility = Visibility.Collapsed;
+                    btnPreviewRender.IsEnabled = true;
+                });
+            }
+        }
+
+        private void BtnPreviewFullscreen_Click(object sender, RoutedEventArgs e)
+        {
+            if (imgPreview.Source == null) return;
+
+            var win = new System.Windows.Window
+            {
+                Title = "Preview",
+                WindowState = WindowState.Maximized,
+                Background = System.Windows.Media.Brushes.Black
+            };
+            win.Content = new System.Windows.Controls.Image
+            {
+                Source = imgPreview.Source,
+                Stretch = System.Windows.Media.Stretch.Uniform
+            };
+            win.KeyDown += (s, ke) => { if (ke.Key == System.Windows.Input.Key.Escape || ke.Key == System.Windows.Input.Key.F11) win.Close(); };
+            win.Show();
+        }
+
+        private static string FormatPreviewTime(TimeSpan t) =>
+            t.TotalHours >= 1 ? $"{(int)t.TotalHours}:{t.Minutes:D2}:{t.Seconds:D2}" : $"{t.Minutes}:{t.Seconds:D2}";
+
+        private void BtnPreviewPlayPause_Click(object sender, RoutedEventArgs e)
+        {
+            if (_previewFrames.Count == 0) return;
+
+            if (_previewIsPlaying)
+            {
+                _previewIsPlaying = false;
+                btnPreviewPlayPause.Content = "Play";
+                _previewTimer?.Stop();
+            }
+            else
+            {
+                _previewIsPlaying = true;
+                btnPreviewPlayPause.Content = "Pause";
+                _previewTimer?.Start();
+            }
+        }
+
+        private void PreviewTimer_Tick(object sender, EventArgs e)
+        {
+            if (_previewFrames.Count == 0) return;
+            _currentPreviewFrameIdx = (_currentPreviewFrameIdx + 1) % _previewFrames.Count;
+            imgPreview.Source = _previewFrames[_currentPreviewFrameIdx];
+            double t = _currentPreviewFrameIdx / 4.0;
+            _previewSliderUserDragging = false;
+            sliderPreview.Value = Math.Min(t, _previewMediaDuration);
+            _previewSliderUserDragging = true;
+            textPreviewTime.Text = $"{FormatPreviewTime(TimeSpan.FromSeconds(t))} / {FormatPreviewTime(TimeSpan.FromSeconds(_previewMediaDuration))}";
         }
     }
 

--- a/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatUpdate.xaml.cs
@@ -46,6 +46,8 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
         }
 
+        public bool IsActionInProgress => BtnCancel.Visibility == Visibility.Visible;
+
         private async void btnBrowse_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog

--- a/TwitchDownloaderWPF/PageClipDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageClipDownload.xaml.cs
@@ -41,6 +41,8 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
         }
 
+        public bool IsActionInProgress => BtnCancel.Visibility == Visibility.Visible;
+
         private async void btnGetInfo_Click(object sender, RoutedEventArgs e)
         {
             await GetClipInfo();
@@ -59,7 +61,7 @@ namespace TwitchDownloaderWPF
             {
                 btnGetInfo.IsEnabled = false;
                 comboQuality.Items.Clear();
-                var clipRenderStatus = await TwitchHelper.GetShareClipRenderStatus(clipId);
+                var clipRenderStatus = await TwitchHelper.GetShareClipRenderStatus(clipId, Settings.Default.OAuth);
                 var clip = clipRenderStatus.data.clip;
 
                 var thumbUrl = clip.thumbnailURL;
@@ -271,6 +273,7 @@ namespace TwitchDownloaderWPF
             {
                 Filename = fileName,
                 Id = clipId,
+                Oauth = Settings.Default.OAuth,
                 Quality = comboQuality.Text,
                 ThrottleKib = Settings.Default.DownloadThrottleEnabled
                     ? Settings.Default.MaximumBandwidthKib

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,90,0">
             <TextBlock Text="Live Monitor" FontWeight="Bold" FontSize="18" Foreground="{DynamicResource AppText}"/>
             <TextBlock TextWrapping="Wrap" Margin="0,4,0,0" Foreground="{DynamicResource AppText}"
-                       Text="Monitors the channels below. When a channel goes live, the already-aired back-catalog is downloaded immediately (multi-threaded) while the live tail is recorded concurrently with ffmpeg. Chat can optionally be queued alongside. The channel must have VODs/archive enabled on Twitch."/>
+                       Text="Monitors the channels below and queues downloads when a channel goes live. The channel must have VODs/archive enabled on Twitch."/>
         </StackPanel>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
             <Button fa:Awesome.Content="Solid_DollarSign" x:Name="btnDonate" ToolTip="{lex:Loc DonateTooltip}" Height="26" Width="40" Click="btnDonate_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
@@ -54,7 +54,7 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                     <TextBlock Text="Quality:" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
-                    <ComboBox x:Name="comboQuality" SelectedIndex="0" MinWidth="120" Margin="6,0,0,0" ToolTip="Quality used once the stream ends and the VOD is downloaded" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+                    <ComboBox x:Name="comboQuality" SelectedIndex="0" MinWidth="120" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
                         <ComboBoxItem Content="Source"/>
                         <ComboBoxItem Content="1440p"/>
                         <ComboBoxItem Content="1080p"/>
@@ -73,9 +73,21 @@
                     <TextBlock Text="{lex:Loc VideoDownloadThreads}" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
                     <hc:NumericUpDown x:Name="numThreads" Value="4" Minimum="1" Maximum="50" Width="80" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 </StackPanel>
-                <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,10,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-                <CheckBox x:Name="checkSplitChapters" Content="Split VOD by chapters when stream ends (queues one download per chapter)" Margin="0,6,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Download mode:" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
+                    <ComboBox x:Name="comboDownloadMode" SelectedIndex="0" Margin="6,0,0,0"
+                              SelectionChanged="comboDownloadMode_SelectionChanged"
+                              Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+                        <ComboBoxItem Content="Live (back-catalog + concurrent ffmpeg recording)"
+                                      ToolTip="Downloads already-aired segments immediately (multi-threaded) while recording the live tail with ffmpeg at the same time."/>
+                        <ComboBoxItem Content="After stream ends (full VOD)"
+                                      ToolTip="Waits for the stream to finish, then queues a standard VOD download of the complete recording."/>
+                        <ComboBoxItem Content="After stream ends — split by chapters"
+                                      ToolTip="Waits for the stream to finish, then queues one VOD download per game chapter."/>
+                    </ComboBox>
+                </StackPanel>
+                <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,8,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                     <CheckBox x:Name="checkTrimStart" VerticalAlignment="Center" BorderBrush="{DynamicResource AppElementBorder}" Checked="checkTrimStart_CheckStateChanged" Unchecked="checkTrimStart_CheckStateChanged"/>
                     <TextBlock Text="Trim start" VerticalAlignment="Center" Margin="3,0,0,0" Foreground="{DynamicResource AppText}"/>
                     <hc:NumericUpDown x:Name="numTrimStartHour"   Minimum="0" Maximum="48" Value="0" Width="60" Margin="6,0,2,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
@@ -91,9 +103,10 @@
                     <hc:NumericUpDown x:Name="numTrimEndSecond" Minimum="0" Maximum="59" Value="0" Width="60" Margin="2,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     <TextBlock Text="h  m  s" VerticalAlignment="Center" Margin="4,0,0,0" FontSize="10" Foreground="{DynamicResource AppText}" Opacity="0.6"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                     <Button x:Name="btnToggle" Content="Start Monitoring" MinWidth="140" Height="34" Click="btnToggle_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
                     <TextBlock x:Name="textState" Text="Stopped" VerticalAlignment="Center" Margin="12,0,0,0" FontWeight="Bold" Foreground="{DynamicResource AppText}"/>
+                    <CheckBox x:Name="checkAutoStart" Content="Auto-start on launch" VerticalAlignment="Center" Margin="16,0,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" ToolTip="Automatically begin monitoring when the app starts (requires at least one channel and a valid output folder)"/>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -44,10 +44,31 @@
                 </StackPanel>
                 <ListBox x:Name="listChannels" Height="120" Margin="0,6,0,0" SelectionChanged="listChannels_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 <Button x:Name="btnRemoveChannel" Content="Remove Selected" Margin="0,4,0,0" Click="btnRemoveChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
-                <TextBlock Text="Render preset for selected channel:" Margin="0,8,0,0" FontSize="11" Opacity="0.75" Foreground="{DynamicResource AppText}"/>
-                <ComboBox x:Name="comboChannelPreset" Margin="0,3,0,0" SelectionChanged="comboChannelPreset_SelectionChanged"
-                          ToolTip="Override the render preset for the selected channel. Use '(default)' to inherit the global preset."
-                          Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <Button x:Name="btnSaveChannelSettings" Content="Save for channel" IsEnabled="False" MinWidth="118"
+                            ToolTip="Save the current page settings as the profile for the selected channel."
+                            Click="btnSaveChannelSettings_Click"
+                            Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                    <Button x:Name="btnLoadChannelSettings" Content="Load" IsEnabled="False" MinWidth="46" Margin="4,0,0,0"
+                            ToolTip="Apply the selected channel's saved settings to the page."
+                            Click="btnLoadChannelSettings_Click"
+                            Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                    <Button x:Name="btnClearChannelSettings" Content="Clear" IsEnabled="False" MinWidth="46" Margin="4,0,0,0"
+                            ToolTip="Remove the saved settings for this channel (reverts to page defaults)."
+                            Click="btnClearChannelSettings_Click"
+                            Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBlock Text="Copy from:" VerticalAlignment="Center" FontSize="11" Foreground="{DynamicResource AppText}"/>
+                    <ComboBox x:Name="comboCopyFrom" Margin="4,0,0,0" MinWidth="90"
+                              ToolTip="Channel whose saved settings will be copied to the selected channel."
+                              Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <Button x:Name="btnCopyChannelSettings" Content="Copy" IsEnabled="False" MinWidth="44" Margin="4,0,0,0"
+                            ToolTip="Copy the chosen channel's saved settings to the selected channel."
+                            Click="btnCopyChannelSettings_Click"
+                            Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                </StackPanel>
+                <TextBlock x:Name="textChannelSettingsStatus" Margin="0,4,0,0" FontSize="10" Opacity="0.7" Foreground="{DynamicResource AppText}" Text=""/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -42,8 +42,12 @@
                     <TextBox x:Name="textChannel" MinWidth="160" KeyDown="textChannel_KeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                     <Button x:Name="btnAddChannel" Content="Add" MinWidth="50" Margin="4,0,0,0" Click="btnAddChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
                 </StackPanel>
-                <ListBox x:Name="listChannels" Height="170" Margin="0,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <ListBox x:Name="listChannels" Height="120" Margin="0,6,0,0" SelectionChanged="listChannels_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 <Button x:Name="btnRemoveChannel" Content="Remove Selected" Margin="0,4,0,0" Click="btnRemoveChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <TextBlock Text="Render preset for selected channel:" Margin="0,8,0,0" FontSize="11" Opacity="0.75" Foreground="{DynamicResource AppText}"/>
+                <ComboBox x:Name="comboChannelPreset" Margin="0,3,0,0" SelectionChanged="comboChannelPreset_SelectionChanged"
+                          ToolTip="Override the render preset for the selected channel. Use '(default)' to inherit the global preset."
+                          Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">
@@ -86,7 +90,17 @@
                                       ToolTip="Waits for the stream to finish, then queues one VOD download per game chapter."/>
                     </ComboBox>
                 </StackPanel>
-                <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,8,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,8,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" Checked="checkChat_CheckStateChanged" Unchecked="checkChat_CheckStateChanged"/>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <CheckBox x:Name="checkAutoRender" Content="Also render chat after download" VerticalAlignment="Center"
+                              BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"
+                              ToolTip="Automatically queue a chat render once the chat download finishes. Uses the preset selected below (or per-channel override)."
+                              Checked="checkAutoRender_CheckStateChanged" Unchecked="checkAutoRender_CheckStateChanged"/>
+                    <ComboBox x:Name="comboRenderPreset" Margin="8,0,0,0" MinWidth="140"
+                              ToolTip="Default render preset used when no per-channel override is set."
+                              SelectionChanged="comboRenderPreset_SelectionChanged"
+                              Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                     <CheckBox x:Name="checkTrimStart" VerticalAlignment="Center" BorderBrush="{DynamicResource AppElementBorder}" Checked="checkTrimStart_CheckStateChanged" Unchecked="checkTrimStart_CheckStateChanged"/>
                     <TextBlock Text="Trim start" VerticalAlignment="Center" Margin="3,0,0,0" Foreground="{DynamicResource AppText}"/>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,90,0">
             <TextBlock Text="Live Monitor" FontWeight="Bold" FontSize="18" Foreground="{DynamicResource AppText}"/>
             <TextBlock TextWrapping="Wrap" Margin="0,4,0,0" Foreground="{DynamicResource AppText}"
-                       Text="Monitors the channels below. When a channel goes live, the in-progress VOD (and optionally chat) is added to the queue with 'delay until offline' enabled, so the entire stream is downloaded retroactively once it ends. The channel must have VODs/archive enabled on Twitch."/>
+                       Text="Monitors the channels below. When a channel goes live, the already-aired back-catalog is downloaded immediately (multi-threaded) while the live tail is recorded concurrently with ffmpeg. Chat can optionally be queued alongside. The channel must have VODs/archive enabled on Twitch."/>
         </StackPanel>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
             <Button fa:Awesome.Content="Solid_DollarSign" x:Name="btnDonate" ToolTip="{lex:Loc DonateTooltip}" Height="26" Width="40" Click="btnDonate_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
@@ -74,6 +74,23 @@
                     <hc:NumericUpDown x:Name="numThreads" Value="4" Minimum="1" Maximum="50" Width="80" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
                 </StackPanel>
                 <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,10,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <CheckBox x:Name="checkSplitChapters" Content="Split VOD by chapters when stream ends (queues one download per chapter)" Margin="0,6,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <CheckBox x:Name="checkTrimStart" VerticalAlignment="Center" BorderBrush="{DynamicResource AppElementBorder}" Checked="checkTrimStart_CheckStateChanged" Unchecked="checkTrimStart_CheckStateChanged"/>
+                    <TextBlock Text="Trim start" VerticalAlignment="Center" Margin="3,0,0,0" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimStartHour"   Minimum="0" Maximum="48" Value="0" Width="60" Margin="6,0,2,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimStartMinute" Minimum="0" Maximum="59" Value="0" Width="60" Margin="2,0,2,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimStartSecond" Minimum="0" Maximum="59" Value="0" Width="60" Margin="2,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <TextBlock Text="h  m  s" VerticalAlignment="Center" Margin="4,0,0,0" FontSize="10" Foreground="{DynamicResource AppText}" Opacity="0.6"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <CheckBox x:Name="checkTrimEnd" VerticalAlignment="Center" BorderBrush="{DynamicResource AppElementBorder}" Checked="checkTrimEnd_CheckStateChanged" Unchecked="checkTrimEnd_CheckStateChanged"/>
+                    <TextBlock Text="Trim end" VerticalAlignment="Center" Margin="3,0,0,0" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimEndHour"   Minimum="0" Maximum="48" Value="0" Width="60" Margin="6,0,2,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimEndMinute" Minimum="0" Maximum="59" Value="0" Width="60" Margin="2,0,2,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numTrimEndSecond" Minimum="0" Maximum="59" Value="0" Width="60" Margin="2,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <TextBlock Text="h  m  s" VerticalAlignment="Center" Margin="4,0,0,0" FontSize="10" Foreground="{DynamicResource AppText}" Opacity="0.6"/>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
                     <Button x:Name="btnToggle" Content="Start Monitoring" MinWidth="140" Height="34" Click="btnToggle_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
                     <TextBlock x:Name="textState" Text="Stopped" VerticalAlignment="Center" Margin="12,0,0,0" FontWeight="Bold" Foreground="{DynamicResource AppText}"/>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -1,0 +1,95 @@
+<Page x:Class="TwitchDownloaderWPF.PageLiveMonitor"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:lex="http://wpflocalizeextension.codeplex.com"
+      lex:LocalizeDictionary.DesignCulture=""
+      lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
+      lex:ResxLocalizationProvider.DefaultDictionary="Strings"
+      xmlns:hc="https://handyorg.github.io/handycontrol"
+      xmlns:fa="http://schemas.fontawesome.com/icons/"
+      mc:Ignorable="d"
+      d:DesignHeight="400" d:DesignWidth="800"
+      Title="PageLiveMonitor" Initialized="Page_Initialized" Loaded="Page_Loaded">
+    <Grid Background="{DynamicResource AppBackground}" Margin="20,15,20,10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,90,0">
+            <TextBlock Text="Live Monitor" FontWeight="Bold" FontSize="18" Foreground="{DynamicResource AppText}"/>
+            <TextBlock TextWrapping="Wrap" Margin="0,4,0,0" Foreground="{DynamicResource AppText}"
+                       Text="Monitors the channels below. When a channel goes live, the in-progress VOD (and optionally chat) is added to the queue with 'delay until offline' enabled, so the entire stream is downloaded retroactively once it ends. The channel must have VODs/archive enabled on Twitch."/>
+        </StackPanel>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+            <Button fa:Awesome.Content="Solid_DollarSign" x:Name="btnDonate" ToolTip="{lex:Loc DonateTooltip}" Height="26" Width="40" Click="btnDonate_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <Button fa:Awesome.Content="Solid_Cog" x:Name="btnSettings" Height="26" Width="40" Margin="4,0,0,0" Click="btnSettings_Click" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                <TextBlock Text="Channels (Twitch login names)" Foreground="{DynamicResource AppText}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBox x:Name="textChannel" MinWidth="160" KeyDown="textChannel_KeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <Button x:Name="btnAddChannel" Content="Add" MinWidth="50" Margin="4,0,0,0" Click="btnAddChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                </StackPanel>
+                <ListBox x:Name="listChannels" Height="170" Margin="0,6,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnRemoveChannel" Content="Remove Selected" Margin="0,4,0,0" Click="btnRemoveChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="1">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Save to:" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
+                    <TextBox x:Name="textFolder" MinWidth="280" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                    <Button x:Name="btnFolder" Content="..." MinWidth="34" Margin="4,0,0,0" Click="btnFolder_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Quality:" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
+                    <ComboBox x:Name="comboQuality" SelectedIndex="0" MinWidth="120" Margin="6,0,0,0" ToolTip="Quality used once the stream ends and the VOD is downloaded" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+                        <ComboBoxItem Content="Source"/>
+                        <ComboBoxItem Content="1440p"/>
+                        <ComboBoxItem Content="1080p"/>
+                        <ComboBoxItem Content="720p"/>
+                        <ComboBoxItem Content="480p"/>
+                        <ComboBoxItem Content="360p"/>
+                        <ComboBoxItem Content="160p"/>
+                        <ComboBoxItem Content="144p"/>
+                        <ComboBoxItem Content="Worst"/>
+                        <ComboBoxItem Content="Audio Only"/>
+                    </ComboBox>
+                    <TextBlock Text="Poll every (sec):" VerticalAlignment="Center" Margin="16,0,0,0" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numPoll" Value="60" Minimum="30" Maximum="3600" Width="80" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="{lex:Loc VideoDownloadThreads}" VerticalAlignment="Center" Foreground="{DynamicResource AppText}"/>
+                    <hc:NumericUpDown x:Name="numThreads" Value="4" Minimum="1" Maximum="50" Width="80" Margin="6,0,0,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                </StackPanel>
+                <CheckBox x:Name="checkChat" Content="Also download chat (JSON, gzip) for each recorded stream" Margin="0,10,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
+                    <Button x:Name="btnToggle" Content="Start Monitoring" MinWidth="140" Height="34" Click="btnToggle_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                    <TextBlock x:Name="textState" Text="Stopped" VerticalAlignment="Center" Margin="12,0,0,0" FontWeight="Bold" Foreground="{DynamicResource AppText}"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="2" Margin="0,14,0,0">
+            <TextBlock Text="Log" Foreground="{DynamicResource AppText}"/>
+            <RichTextBox x:Name="textLog" IsReadOnly="True" Margin="0,3,0,0" Height="150" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+                <RichTextBox.Resources>
+                    <Style TargetType="{x:Type Paragraph}">
+                        <Setter Property="Margin" Value="0"/>
+                    </Style>
+                </RichTextBox.Resources>
+            </RichTextBox>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -28,27 +29,25 @@ namespace TwitchDownloaderWPF
     /// </summary>
     public partial class PageLiveMonitor : Page
     {
-        // Download modes stored in LiveMonitorDownloadMode setting
+        // Download modes
         private const int ModeLive = 0;
         private const int ModeAfterEnd = 1;
         private const int ModeAfterEndSplit = 2;
 
-        private const string DefaultPresetItem = "(default)";
-
         private readonly ObservableCollection<string> _channels = new();
         private readonly HashSet<long> _queuedVodIds = new();
 
-        // vodId → (channel login, output folder, splitByChapters) for deferred downloads
-        private readonly Dictionary<long, (string channel, string folder, bool splitChapters)> _pendingDownloads = new();
+        // vodId → (channel login, settings snapshot) for deferred (post-stream) downloads
+        private readonly Dictionary<long, (string channel, LiveMonitorChannelSettings settings)> _pendingDownloads = new();
 
         // Render presets loaded from ChatRenderPresetService
         private List<ChatRenderPreset> _renderPresets = new();
 
-        // Per-channel render preset overrides: channel login → preset name
-        private Dictionary<string, string> _channelPresets = new();
+        // Per-channel full settings profiles
+        private Dictionary<string, LiveMonitorChannelSettings> _channelSettings = new();
 
-        // Guard flag to suppress SelectionChanged side effects during programmatic updates
-        private bool _suppressPresetSelectionChanged;
+        // Guard: suppresses SaveSettings() side-effects during programmatic combo updates
+        private bool _suppressSelectionChanged;
 
         private readonly DispatcherTimer _pollTimer = new();
         private bool _polling;
@@ -109,13 +108,16 @@ namespace TwitchDownloaderWPF
                 }
             }
 
-            // Load render presets and per-channel overrides
-            _channelPresets = LiveMonitorPresetService.Load();
+            // Load render presets and per-channel settings profiles
+            _channelSettings = LiveMonitorChannelSettingsService.Load();
             RefreshPresetCombos();
 
             // Restore auto-render settings
             checkAutoRender.IsChecked = Settings.Default.LiveMonitorAutoRender;
             UpdateAutoRenderEnabled();
+
+            // Initialise per-channel settings UI
+            RefreshChannelSettingsUI();
 
             // Defer auto-start so the main window has finished loading first
             if (Settings.Default.LiveMonitorAutoStart)
@@ -128,16 +130,14 @@ namespace TwitchDownloaderWPF
         // ── Render preset helpers ─────────────────────────────────────────────
 
         /// <summary>
-        /// Reloads the render preset lists and repopulates both combo boxes.
+        /// Reloads the render preset list and repopulates <see cref="comboRenderPreset"/>.
         /// </summary>
         private void RefreshPresetCombos()
         {
             _renderPresets = ChatRenderPresetService.Load();
-
             var presetNames = _renderPresets.Select(p => p.Name).ToList();
 
-            // comboRenderPreset: default preset for all channels
-            _suppressPresetSelectionChanged = true;
+            _suppressSelectionChanged = true;
             comboRenderPreset.Items.Clear();
             foreach (var name in presetNames)
                 comboRenderPreset.Items.Add(name);
@@ -147,79 +147,36 @@ namespace TwitchDownloaderWPF
                 comboRenderPreset.SelectedItem = savedDefault;
             else if (comboRenderPreset.Items.Count > 0)
                 comboRenderPreset.SelectedIndex = 0;
-            _suppressPresetSelectionChanged = false;
+            _suppressSelectionChanged = false;
 
-            // comboChannelPreset: per-channel override (first item = use default)
-            _suppressPresetSelectionChanged = true;
-            comboChannelPreset.Items.Clear();
-            comboChannelPreset.Items.Add(DefaultPresetItem);
-            foreach (var name in presetNames)
-                comboChannelPreset.Items.Add(name);
-            _suppressPresetSelectionChanged = false;
-
-            RefreshChannelPresetCombo();
             UpdateAutoRenderEnabled();
         }
 
         /// <summary>
-        /// Updates comboChannelPreset to reflect the selected channel's override (or default).
-        /// </summary>
-        private void RefreshChannelPresetCombo()
-        {
-            _suppressPresetSelectionChanged = true;
-            if (listChannels.SelectedItem is string channel &&
-                _channelPresets.TryGetValue(channel, out var presetName) &&
-                comboChannelPreset.Items.Contains(presetName))
-            {
-                comboChannelPreset.SelectedItem = presetName;
-            }
-            else
-            {
-                comboChannelPreset.SelectedIndex = comboChannelPreset.Items.Count > 0 ? 0 : -1;
-            }
-            _suppressPresetSelectionChanged = false;
-        }
-
-        /// <summary>
-        /// Enables/disables checkAutoRender and comboRenderPreset based on whether
-        /// chat download and presets are available.
+        /// Enables/disables auto-render controls based on whether chat download and presets are available.
         /// </summary>
         private void UpdateAutoRenderEnabled()
         {
             var chatEnabled = checkChat.IsChecked.GetValueOrDefault();
             var hasPresets = comboRenderPreset.Items.Count > 0;
 
-            // Auto-render checkbox and default-preset combo require chat download + at least one preset
             checkAutoRender.IsEnabled = chatEnabled && hasPresets;
             comboRenderPreset.IsEnabled = chatEnabled && hasPresets && checkAutoRender.IsChecked.GetValueOrDefault();
             if (!chatEnabled || !hasPresets)
                 checkAutoRender.IsChecked = false;
-
-            // Per-channel override can be set any time there are presets (selection is independent
-            // of whether auto-render is currently on)
-            comboChannelPreset.IsEnabled = hasPresets;
         }
 
         /// <summary>
-        /// Returns the render preset to use for a given channel login.
-        /// Per-channel override takes priority; falls back to the global default.
-        /// Returns null if no preset is available.
+        /// Returns the render preset to use for a given effective settings snapshot.
+        /// Falls back to the first available preset if the specified name is not found.
         /// </summary>
-        private ChatRenderPreset GetRenderPresetForChannel(string channel)
+        private ChatRenderPreset GetRenderPresetForSettings(LiveMonitorChannelSettings eff)
         {
-            // Per-channel override
-            if (_channelPresets.TryGetValue(channel, out var overrideName))
+            if (!string.IsNullOrEmpty(eff.RenderPreset))
             {
-                var found = _renderPresets.FirstOrDefault(p => p.Name == overrideName);
+                var found = _renderPresets.FirstOrDefault(p => p.Name == eff.RenderPreset);
                 if (found != null) return found;
             }
-
-            // Global default
-            var defaultName = comboRenderPreset.SelectedItem as string;
-            if (!string.IsNullOrEmpty(defaultName))
-                return _renderPresets.FirstOrDefault(p => p.Name == defaultName);
-
-            // Fallback: first available
             return _renderPresets.FirstOrDefault();
         }
 
@@ -303,6 +260,131 @@ namespace TwitchDownloaderWPF
                 _ => ".mp4",
             };
 
+        // ── Per-channel settings helpers ──────────────────────────────────────
+
+        /// <summary>
+        /// Captures the current page UI state as a <see cref="LiveMonitorChannelSettings"/> snapshot.
+        /// </summary>
+        private LiveMonitorChannelSettings GetCurrentPageSettings() => new()
+        {
+            Folder = textFolder.Text,
+            Quality = SelectedQuality,
+            DownloadMode = DownloadMode,
+            PollSeconds = (int)numPoll.Value,
+            Threads = (int)numThreads.Value,
+            DownloadChat = checkChat.IsChecked.GetValueOrDefault(),
+            AutoRender = checkAutoRender.IsChecked.GetValueOrDefault(),
+            RenderPreset = comboRenderPreset.SelectedItem as string ?? "",
+            TrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault(),
+            TrimBeginningHour = (int)numTrimStartHour.Value,
+            TrimBeginningMinute = (int)numTrimStartMinute.Value,
+            TrimBeginningSecond = (int)numTrimStartSecond.Value,
+            TrimEnding = checkTrimEnd.IsChecked.GetValueOrDefault(),
+            TrimEndingHour = (int)numTrimEndHour.Value,
+            TrimEndingMinute = (int)numTrimEndMinute.Value,
+            TrimEndingSecond = (int)numTrimEndSecond.Value,
+        };
+
+        /// <summary>
+        /// Applies a <see cref="LiveMonitorChannelSettings"/> snapshot to the page UI controls.
+        /// </summary>
+        private void ApplySettingsToPage(LiveMonitorChannelSettings s)
+        {
+            textFolder.Text = s.Folder;
+
+            foreach (ComboBoxItem item in comboQuality.Items)
+            {
+                if ((item.Content as string) == s.Quality)
+                {
+                    comboQuality.SelectedItem = item;
+                    break;
+                }
+            }
+
+            comboDownloadMode.SelectedIndex = Math.Clamp(s.DownloadMode, 0, 2);
+            numPoll.Value = Math.Max(30, s.PollSeconds);
+            numThreads.Value = Math.Max(1, s.Threads);
+
+            checkChat.IsChecked = s.DownloadChat;
+            checkAutoRender.IsChecked = s.AutoRender;
+
+            if (!string.IsNullOrEmpty(s.RenderPreset))
+            {
+                foreach (string item in comboRenderPreset.Items)
+                {
+                    if (item == s.RenderPreset)
+                    {
+                        comboRenderPreset.SelectedItem = item;
+                        break;
+                    }
+                }
+            }
+
+            numTrimStartHour.Value = s.TrimBeginningHour;
+            numTrimStartMinute.Value = s.TrimBeginningMinute;
+            numTrimStartSecond.Value = s.TrimBeginningSecond;
+            checkTrimStart.IsChecked = s.TrimBeginning;
+
+            numTrimEndHour.Value = s.TrimEndingHour;
+            numTrimEndMinute.Value = s.TrimEndingMinute;
+            numTrimEndSecond.Value = s.TrimEndingSecond;
+            checkTrimEnd.IsChecked = s.TrimEnding;
+
+            var isSplitMode = s.DownloadMode == ModeAfterEndSplit;
+            SetTrimControlsAvailable(!isSplitMode);
+            SetTrimStartEnabled(s.TrimBeginning && !isSplitMode);
+            SetTrimEndEnabled(s.TrimEnding && !isSplitMode);
+            UpdateAutoRenderEnabled();
+        }
+
+        /// <summary>
+        /// Returns the saved settings for <paramref name="channel"/> if they exist,
+        /// otherwise a snapshot of the current page state.
+        /// </summary>
+        private LiveMonitorChannelSettings GetEffectiveSettings(string channel) =>
+            _channelSettings.TryGetValue(channel, out var saved) ? saved : GetCurrentPageSettings();
+
+        /// <summary>
+        /// Refreshes the per-channel settings buttons, status label, and copy-from combo
+        /// to reflect the currently selected channel.
+        /// </summary>
+        private void RefreshChannelSettingsUI()
+        {
+            var channel = listChannels.SelectedItem as string;
+            var hasChannel = channel != null;
+            var hasSaved = hasChannel && _channelSettings.ContainsKey(channel!);
+
+            btnSaveChannelSettings.IsEnabled = hasChannel;
+            btnLoadChannelSettings.IsEnabled = hasSaved;
+            btnClearChannelSettings.IsEnabled = hasSaved;
+
+            textChannelSettingsStatus.Text = hasChannel
+                ? (hasSaved
+                    ? $"Custom settings saved for '{channel}'"
+                    : $"No saved settings for '{channel}' — using page defaults")
+                : "";
+
+            RefreshCopyFromCombo(channel);
+        }
+
+        /// <summary>
+        /// Rebuilds the copy-from combo with channels (other than <paramref name="selectedChannel"/>)
+        /// that have saved settings.
+        /// </summary>
+        private void RefreshCopyFromCombo(string selectedChannel)
+        {
+            comboCopyFrom.Items.Clear();
+            foreach (var ch in _channelSettings.Keys.OrderBy(x => x))
+            {
+                if (ch != selectedChannel)
+                    comboCopyFrom.Items.Add(ch);
+            }
+            if (comboCopyFrom.Items.Count > 0)
+                comboCopyFrom.SelectedIndex = 0;
+
+            btnCopyChannelSettings.IsEnabled = selectedChannel != null && comboCopyFrom.Items.Count > 0;
+        }
+
         // ── UI event handlers ─────────────────────────────────────────────────
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)
@@ -361,10 +443,7 @@ namespace TwitchDownloaderWPF
                 textLog.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}"));
         }
 
-        private void btnAddChannel_Click(object sender, RoutedEventArgs e)
-        {
-            AddChannel();
-        }
+        private void btnAddChannel_Click(object sender, RoutedEventArgs e) => AddChannel();
 
         private void textChannel_KeyDown(object sender, KeyEventArgs e)
         {
@@ -396,8 +475,7 @@ namespace TwitchDownloaderWPF
             textChannel.Clear();
             SaveSettings();
 
-            // If monitoring is already running, check this channel immediately rather
-            // than waiting for the next timer tick — it may already be live.
+            // If monitoring is already running, check this channel immediately
             if (IsMonitoring)
                 _ = PollAsync();
         }
@@ -407,9 +485,10 @@ namespace TwitchDownloaderWPF
             if (listChannels.SelectedItem is string channel)
             {
                 _channels.Remove(channel);
-                _channelPresets.Remove(channel);
-                LiveMonitorPresetService.Save(_channelPresets);
+                if (_channelSettings.Remove(channel))
+                    LiveMonitorChannelSettingsService.Save(_channelSettings);
                 SaveSettings();
+                RefreshChannelSettingsUI();
             }
         }
 
@@ -440,9 +519,13 @@ namespace TwitchDownloaderWPF
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(textFolder.Text) || !Directory.Exists(textFolder.Text))
+            // A valid global output folder is required for any channel that does not have its own saved settings
+            bool anyChannelNeedsGlobalFolder = _channels.Any(c => !_channelSettings.ContainsKey(c));
+            if (anyChannelNeedsGlobalFolder && (string.IsNullOrWhiteSpace(textFolder.Text) || !Directory.Exists(textFolder.Text)))
             {
-                MessageBox.Show(Application.Current.MainWindow!, "Choose a valid output folder.", "Live Monitor", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(Application.Current.MainWindow!,
+                    "Choose a valid output folder, or save per-channel settings for every monitored channel.",
+                    "Live Monitor", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
@@ -463,9 +546,12 @@ namespace TwitchDownloaderWPF
 
         private void TryAutoStart()
         {
-            if (IsMonitoring)
-                return;
-            if (_channels.Count == 0 || !Directory.Exists(textFolder.Text))
+            if (IsMonitoring) return;
+            if (_channels.Count == 0) return;
+
+            // Same folder check as btnToggle_Click
+            bool anyChannelNeedsGlobalFolder = _channels.Any(c => !_channelSettings.ContainsKey(c));
+            if (anyChannelNeedsGlobalFolder && !Directory.Exists(textFolder.Text))
                 return;
 
             AppendLog("Auto-starting monitoring (configured at launch).");
@@ -483,7 +569,7 @@ namespace TwitchDownloaderWPF
 
         private void listChannels_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            RefreshChannelPresetCombo();
+            RefreshChannelSettingsUI();
         }
 
         private void comboDownloadMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -507,23 +593,9 @@ namespace TwitchDownloaderWPF
             SaveSettings();
         }
 
-        private void comboChannelPreset_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_suppressPresetSelectionChanged) return;
-            if (listChannels?.SelectedItem is not string channel) return;
-
-            var selected = comboChannelPreset.SelectedItem as string;
-            if (string.IsNullOrEmpty(selected) || selected == DefaultPresetItem)
-                _channelPresets.Remove(channel);
-            else
-                _channelPresets[channel] = selected;
-
-            LiveMonitorPresetService.Save(_channelPresets);
-        }
-
         private void comboRenderPreset_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_suppressPresetSelectionChanged) return;
+            if (_suppressSelectionChanged) return;
             SaveSettings();
         }
 
@@ -538,6 +610,53 @@ namespace TwitchDownloaderWPF
             UpdateAutoRenderEnabled();
             SaveSettings();
         }
+
+        // ── Per-channel settings buttons ──────────────────────────────────────
+
+        private void btnSaveChannelSettings_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is not string channel) return;
+            _channelSettings[channel] = GetCurrentPageSettings();
+            LiveMonitorChannelSettingsService.Save(_channelSettings);
+            RefreshChannelSettingsUI();
+            AppendLog($"Saved settings for '{channel}'.");
+        }
+
+        private void btnLoadChannelSettings_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is not string channel) return;
+            if (!_channelSettings.TryGetValue(channel, out var settings)) return;
+            ApplySettingsToPage(settings);
+            SaveSettings();
+            AppendLog($"Loaded saved settings for '{channel}'.");
+        }
+
+        private void btnClearChannelSettings_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is not string channel) return;
+            _channelSettings.Remove(channel);
+            LiveMonitorChannelSettingsService.Save(_channelSettings);
+            RefreshChannelSettingsUI();
+            AppendLog($"Cleared saved settings for '{channel}' — will use page defaults.");
+        }
+
+        private void btnCopyChannelSettings_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is not string targetChannel) return;
+            if (comboCopyFrom.SelectedItem is not string sourceChannel) return;
+            if (!_channelSettings.TryGetValue(sourceChannel, out var source)) return;
+
+            // Deep-copy via JSON round-trip
+            var json = JsonSerializer.Serialize(source);
+            _channelSettings[targetChannel] = JsonSerializer.Deserialize<LiveMonitorChannelSettings>(json)!;
+
+            ApplySettingsToPage(_channelSettings[targetChannel]);
+            LiveMonitorChannelSettingsService.Save(_channelSettings);
+            RefreshChannelSettingsUI();
+            AppendLog($"Copied settings from '{sourceChannel}' to '{targetChannel}'.");
+        }
+
+        // ── Trim helpers ──────────────────────────────────────────────────────
 
         private void SetTrimControlsAvailable(bool available)
         {
@@ -575,8 +694,7 @@ namespace TwitchDownloaderWPF
 
         private async System.Threading.Tasks.Task PollAsync()
         {
-            if (_polling)
-                return;
+            if (_polling) return;
 
             _polling = true;
             try
@@ -597,7 +715,9 @@ namespace TwitchDownloaderWPF
                         if (info?.data?.video is null || info.data.video.status != "RECORDING")
                             continue;
 
-                        EnqueueRecording(channel, vodId, info);
+                        // Snapshot settings at detection time; used for the entire lifetime of this recording
+                        var eff = GetEffectiveSettings(channel);
+                        EnqueueRecording(channel, vodId, info, eff);
                         _queuedVodIds.Add(vodId);
                     }
                     catch (Exception ex)
@@ -616,10 +736,9 @@ namespace TwitchDownloaderWPF
 
         private async System.Threading.Tasks.Task CheckPendingDownloadsAsync()
         {
-            if (_pendingDownloads.Count == 0)
-                return;
+            if (_pendingDownloads.Count == 0) return;
 
-            foreach (var (vodId, (channel, folder, splitChapters)) in _pendingDownloads.ToArray())
+            foreach (var (vodId, (channel, settings)) in _pendingDownloads.ToArray())
             {
                 try
                 {
@@ -629,10 +748,10 @@ namespace TwitchDownloaderWPF
 
                     _pendingDownloads.Remove(vodId);
 
-                    if (splitChapters)
-                        await EnqueueChapterSplitsAsync(vodId, info, channel, folder);
+                    if (settings.DownloadMode == ModeAfterEndSplit)
+                        await EnqueueChapterSplitsAsync(vodId, info, channel, settings);
                     else
-                        EnqueueFinishedVod(vodId, info, channel, folder);
+                        EnqueueFinishedVod(vodId, info, channel, settings);
                 }
                 catch (Exception ex)
                 {
@@ -641,7 +760,7 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void EnqueueFinishedVod(long vodId, GqlVideoResponse info, string channel, string folder)
+        private void EnqueueFinishedVod(long vodId, GqlVideoResponse info, string channel, LiveMonitorChannelSettings settings)
         {
             var video = info.data.video;
             var vodLength = TimeSpan.FromSeconds(video.lengthSeconds);
@@ -650,23 +769,23 @@ namespace TwitchDownloaderWPF
             var streamerId = video.owner?.id;
             var game = video.game?.displayName ?? "";
             var createdAt = video.createdAt;
-            var ext = FilenameService.GuessVodFileExtension(SelectedQuality);
+            var ext = FilenameService.GuessVodFileExtension(settings.Quality);
 
-            var trimBeginning = checkTrimStart.IsChecked.GetValueOrDefault();
-            var trimEnding = checkTrimEnd.IsChecked.GetValueOrDefault();
+            var trimBeginning = settings.TrimBeginning;
+            var trimEnding = settings.TrimEnding;
             var trimStart = trimBeginning
-                ? new TimeSpan((int)numTrimStartHour.Value, (int)numTrimStartMinute.Value, (int)numTrimStartSecond.Value)
+                ? new TimeSpan(settings.TrimBeginningHour, settings.TrimBeginningMinute, settings.TrimBeginningSecond)
                 : TimeSpan.Zero;
             var trimEnd = trimEnding
-                ? new TimeSpan((int)numTrimEndHour.Value, (int)numTrimEndMinute.Value, (int)numTrimEndSecond.Value)
+                ? new TimeSpan(settings.TrimEndingHour, settings.TrimEndingMinute, settings.TrimEndingSecond)
                 : vodLength;
 
             var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
                 createdAt, streamer, streamerId, trimStart, trimEnd, vodLength, video.viewCount, game);
-            var vodPath = Path.Combine(folder, baseName + ext);
+            var vodPath = Path.Combine(settings.Folder, baseName + ext);
             TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
-            var options = BuildVodOptions(vodId, vodPath, trimStart, trimEnd, trimBeginning, trimEnding);
+            var options = BuildVodOptions(vodId, vodPath, trimStart, trimEnd, trimBeginning, trimEnding, settings);
             var task = new VodDownloadTask { DownloadOptions = options, Info = { Title = title.Length > 0 ? title : streamer } };
             task.ChangeStatus(TwitchTaskStatus.Ready);
             lock (PageQueue.taskLock) { PageQueue.taskList.Add(task); }
@@ -674,7 +793,7 @@ namespace TwitchDownloaderWPF
             AppendLog($"Stream ended — queued full VOD download for {vodId} ({title}).");
         }
 
-        private async System.Threading.Tasks.Task EnqueueChapterSplitsAsync(long vodId, GqlVideoResponse info, string channel, string folder)
+        private async System.Threading.Tasks.Task EnqueueChapterSplitsAsync(long vodId, GqlVideoResponse info, string channel, LiveMonitorChannelSettings settings)
         {
             var video = info.data.video;
             var vodLength = TimeSpan.FromSeconds(video.lengthSeconds);
@@ -683,7 +802,7 @@ namespace TwitchDownloaderWPF
             var streamerId = video.owner?.id;
             var game = video.game?.displayName ?? "";
             var createdAt = video.createdAt;
-            var ext = FilenameService.GuessVodFileExtension(SelectedQuality);
+            var ext = FilenameService.GuessVodFileExtension(settings.Quality);
 
             try
             {
@@ -695,9 +814,9 @@ namespace TwitchDownloaderWPF
                     AppendLog($"VOD {vodId} has only one chapter — queuing as single download.");
                     var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
                         createdAt, streamer, streamerId, TimeSpan.Zero, vodLength, vodLength, video.viewCount, game);
-                    var vodPath = Path.Combine(folder, baseName + ext);
+                    var vodPath = Path.Combine(settings.Folder, baseName + ext);
                     TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
-                    var singleOptions = BuildVodOptions(vodId, vodPath, TimeSpan.Zero, vodLength, false, false);
+                    var singleOptions = BuildVodOptions(vodId, vodPath, TimeSpan.Zero, vodLength, false, false, settings);
                     var singleTask = new VodDownloadTask { DownloadOptions = singleOptions, Info = { Title = title } };
                     singleTask.ChangeStatus(TwitchTaskStatus.Ready);
                     lock (PageQueue.taskLock) { PageQueue.taskList.Add(singleTask); }
@@ -720,10 +839,10 @@ namespace TwitchDownloaderWPF
                         var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
                             createdAt, streamer, streamerId, chapterStart, chapterEnd, vodLength, video.viewCount, gameName)
                             + $"_ch{i + 1:D2}";
-                        var vodPath = Path.Combine(folder, baseName + ext);
+                        var vodPath = Path.Combine(settings.Folder, baseName + ext);
                         TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
-                        var options = BuildVodOptions(vodId, vodPath, chapterStart, chapterEnd, true, true);
+                        var options = BuildVodOptions(vodId, vodPath, chapterStart, chapterEnd, true, true, settings);
                         var task = new VodDownloadTask
                         {
                             DownloadOptions = options,
@@ -740,18 +859,22 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private VideoDownloadOptions BuildVodOptions(long vodId, string filename, TimeSpan trimStart, TimeSpan trimEnd, bool trimBeginning, bool trimEnding)
+        private static VideoDownloadOptions BuildVodOptions(
+            long vodId, string filename,
+            TimeSpan trimStart, TimeSpan trimEnd,
+            bool trimBeginning, bool trimEnding,
+            LiveMonitorChannelSettings settings)
         {
             return new VideoDownloadOptions
             {
                 Id = vodId,
-                Quality = SelectedQuality,
+                Quality = settings.Quality,
                 Filename = filename,
                 TrimBeginning = trimBeginning,
                 TrimBeginningTime = trimStart,
                 TrimEnding = trimEnding,
                 TrimEndingTime = trimEnd,
-                DownloadThreads = (int)numThreads.Value,
+                DownloadThreads = settings.Threads,
                 ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
                 Oauth = Settings.Default.OAuth,
                 FfmpegPath = "ffmpeg",
@@ -761,7 +884,7 @@ namespace TwitchDownloaderWPF
             };
         }
 
-        private void EnqueueRecording(string channel, long vodId, GqlVideoResponse info)
+        private void EnqueueRecording(string channel, long vodId, GqlVideoResponse info, LiveMonitorChannelSettings eff)
         {
             var video = info.data.video;
             var streamer = video.owner?.displayName ?? channel;
@@ -769,32 +892,32 @@ namespace TwitchDownloaderWPF
             var createdAt = video.createdAt;
             var title = video.title ?? "";
             var game = video.game?.displayName ?? "";
-            var folder = textFolder.Text;
-            var mode = DownloadMode;
+            var folder = eff.Folder;
+            var mode = eff.DownloadMode;
 
             var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(), createdAt, streamer, streamerId,
                 TimeSpan.Zero, TimeSpan.FromSeconds(video.lengthSeconds), TimeSpan.FromSeconds(video.lengthSeconds), video.viewCount, game);
 
             if (mode == ModeLive)
             {
-                var vodPath = Path.Combine(folder, baseName + FilenameService.GuessVodFileExtension(SelectedQuality));
+                var vodPath = Path.Combine(folder, baseName + FilenameService.GuessVodFileExtension(eff.Quality));
                 TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
                 var liveOptions = new LiveStreamDownloadOptions
                 {
                     Id = vodId,
                     Channel = channel,
-                    Quality = SelectedQuality,
+                    Quality = eff.Quality,
                     Filename = vodPath,
-                    DownloadThreads = (int)numThreads.Value,
+                    DownloadThreads = eff.Threads,
                     ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
                     Oauth = Settings.Default.OAuth,
                     FfmpegPath = "ffmpeg",
                     TempFolder = Settings.Default.TempPath,
-                    TrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault(),
-                    TrimBeginningTime = new TimeSpan((int)numTrimStartHour.Value, (int)numTrimStartMinute.Value, (int)numTrimStartSecond.Value),
-                    TrimEnding = checkTrimEnd.IsChecked.GetValueOrDefault(),
-                    TrimEndingTime = new TimeSpan((int)numTrimEndHour.Value, (int)numTrimEndMinute.Value, (int)numTrimEndSecond.Value),
+                    TrimBeginning = eff.TrimBeginning,
+                    TrimBeginningTime = new TimeSpan(eff.TrimBeginningHour, eff.TrimBeginningMinute, eff.TrimBeginningSecond),
+                    TrimEnding = eff.TrimEnding,
+                    TrimEndingTime = new TimeSpan(eff.TrimEndingHour, eff.TrimEndingMinute, eff.TrimEndingSecond),
                 };
 
                 var downloadTask = new LiveStreamDownloadTask
@@ -813,17 +936,16 @@ namespace TwitchDownloaderWPF
             }
             else
             {
-                var splitChapters = mode == ModeAfterEndSplit;
-                _pendingDownloads[vodId] = (channel, folder, splitChapters);
+                _pendingDownloads[vodId] = (channel, eff);
 
-                if (splitChapters)
+                if (mode == ModeAfterEndSplit)
                     AppendLog($"'{channel}' is LIVE — will split VOD {vodId} by chapters when stream ends.");
                 else
                     AppendLog($"'{channel}' is LIVE — will queue full VOD {vodId} when stream ends.");
             }
 
             // ── Chat download (+ optional auto-render) ──────────────────────
-            if (!checkChat.IsChecked.GetValueOrDefault())
+            if (!eff.DownloadChat)
                 return;
 
             var chatBaseName = FilenameService.GetFilename(Settings.Default.TemplateChat, title, vodId.ToString(),
@@ -852,14 +974,12 @@ namespace TwitchDownloaderWPF
             {
                 PageQueue.taskList.Add(chatTask);
 
-                // Auto-render: queue a ChatRenderTask that waits for the chat download to finish
-                if (checkAutoRender.IsChecked.GetValueOrDefault())
+                if (eff.AutoRender)
                 {
-                    var preset = GetRenderPresetForChannel(channel);
+                    var preset = GetRenderPresetForSettings(eff);
                     if (preset != null)
                     {
-                        // Derive render output path from the chat file path
-                        var chatFile = chatOptions.Filename; // ends in .json.gz
+                        var chatFile = chatOptions.Filename;
                         var renderBase = chatFile.EndsWith(chatOptions.FileExtension, StringComparison.OrdinalIgnoreCase)
                             ? chatFile[..^chatOptions.FileExtension.Length]
                             : chatFile;

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -25,10 +24,17 @@ namespace TwitchDownloaderWPF
     /// </summary>
     public partial class PageLiveMonitor : Page
     {
+        // Download modes stored in LiveMonitorDownloadMode setting
+        private const int ModeLive = 0;
+        private const int ModeAfterEnd = 1;
+        private const int ModeAfterEndSplit = 2;
+
         private readonly ObservableCollection<string> _channels = new();
         private readonly HashSet<long> _queuedVodIds = new();
-        // vodId → (channel login, output folder) for streams waiting to be chapter-split
-        private readonly Dictionary<long, (string channel, string folder)> _pendingChapterSplits = new();
+
+        // vodId → (channel login, output folder, splitByChapters) for deferred downloads
+        private readonly Dictionary<long, (string channel, string folder, bool splitChapters)> _pendingDownloads = new();
+
         private readonly DispatcherTimer _pollTimer = new();
         private bool _polling;
 
@@ -54,9 +60,13 @@ namespace TwitchDownloaderWPF
             numPoll.Value = Math.Max(30, Settings.Default.LiveMonitorPollSeconds);
             numThreads.Value = Math.Max(1, Settings.Default.VodDownloadThreads);
             checkChat.IsChecked = Settings.Default.LiveMonitorDownloadChat;
-            checkSplitChapters.IsChecked = Settings.Default.LiveMonitorSplitChapters;
 
-            // Load H/M/S before the checkbox so that SaveSettings (fired by the Checked event) reads correct values
+            var downloadMode = Math.Clamp(Settings.Default.LiveMonitorDownloadMode, 0, 2);
+            comboDownloadMode.SelectedIndex = downloadMode;
+
+            checkAutoStart.IsChecked = Settings.Default.LiveMonitorAutoStart;
+
+            // Load H/M/S before checkbox so SaveSettings (fired by Checked event) reads correct values
             numTrimStartHour.Value = Settings.Default.LiveMonitorTrimBeginningHour;
             numTrimStartMinute.Value = Settings.Default.LiveMonitorTrimBeginningMinute;
             numTrimStartSecond.Value = Settings.Default.LiveMonitorTrimBeginningSecond;
@@ -67,8 +77,9 @@ namespace TwitchDownloaderWPF
             numTrimEndSecond.Value = Settings.Default.LiveMonitorTrimEndingSecond;
             checkTrimEnd.IsChecked = Settings.Default.LiveMonitorTrimEnding;
 
-            SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault());
-            SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
+            SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault() && downloadMode != ModeAfterEndSplit);
+            SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault() && downloadMode != ModeAfterEndSplit);
+            SetTrimControlsAvailable(downloadMode != ModeAfterEndSplit);
 
             var savedQuality = Settings.Default.LiveMonitorQuality;
             if (!string.IsNullOrWhiteSpace(savedQuality))
@@ -82,9 +93,14 @@ namespace TwitchDownloaderWPF
                     }
                 }
             }
+
+            // Defer auto-start so the main window has finished loading first
+            if (Settings.Default.LiveMonitorAutoStart)
+                Dispatcher.InvokeAsync(TryAutoStart, DispatcherPriority.Background);
         }
 
         private string SelectedQuality => (comboQuality.SelectedItem as ComboBoxItem)?.Content as string ?? "Source";
+        private int DownloadMode => comboDownloadMode.SelectedIndex;
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)
         {
@@ -115,7 +131,8 @@ namespace TwitchDownloaderWPF
             Settings.Default.VodDownloadThreads = (int)numThreads.Value;
             Settings.Default.LiveMonitorPollSeconds = (int)numPoll.Value;
             Settings.Default.LiveMonitorDownloadChat = checkChat.IsChecked.GetValueOrDefault();
-            Settings.Default.LiveMonitorSplitChapters = checkSplitChapters.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorDownloadMode = DownloadMode;
+            Settings.Default.LiveMonitorAutoStart = checkAutoStart.IsChecked.GetValueOrDefault();
 
             Settings.Default.LiveMonitorTrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault();
             Settings.Default.LiveMonitorTrimBeginningHour = (int)numTrimStartHour.Value;
@@ -220,7 +237,11 @@ namespace TwitchDownloaderWPF
             }
 
             SaveSettings();
+            StartMonitoring();
+        }
 
+        private void StartMonitoring()
+        {
             IsMonitoring = true;
             btnToggle.Content = "Stop Monitoring";
             textState.Text = "Monitoring";
@@ -230,6 +251,21 @@ namespace TwitchDownloaderWPF
             _ = PollAsync();
         }
 
+        /// <summary>
+        /// Called on a background dispatcher priority after init — silently starts monitoring
+        /// if auto-start is enabled and all conditions are met.
+        /// </summary>
+        private void TryAutoStart()
+        {
+            if (IsMonitoring)
+                return;
+            if (_channels.Count == 0 || !Directory.Exists(textFolder.Text))
+                return;
+
+            AppendLog("Auto-starting monitoring (configured at launch).");
+            StartMonitoring();
+        }
+
         private void StopMonitoring()
         {
             _pollTimer.Stop();
@@ -237,6 +273,30 @@ namespace TwitchDownloaderWPF
             btnToggle.Content = "Start Monitoring";
             textState.Text = "Stopped";
             AppendLog("Stopped monitoring.");
+        }
+
+        private void comboDownloadMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            // Trim is meaningless for split-by-chapters mode (chapter boundaries are the trim points)
+            var isSplitMode = comboDownloadMode.SelectedIndex == ModeAfterEndSplit;
+            SetTrimControlsAvailable(!isSplitMode);
+            if (isSplitMode)
+            {
+                SetTrimStartEnabled(false);
+                SetTrimEndEnabled(false);
+            }
+            else
+            {
+                SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault());
+                SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
+            }
+            SaveSettings();
+        }
+
+        private void SetTrimControlsAvailable(bool available)
+        {
+            checkTrimStart.IsEnabled = available;
+            checkTrimEnd.IsEnabled = available;
         }
 
         private void SetTrimStartEnabled(bool isEnabled)
@@ -298,7 +358,7 @@ namespace TwitchDownloaderWPF
                     }
                 }
 
-                await CheckPendingChapterSplitsAsync();
+                await CheckPendingDownloadsAsync();
             }
             finally
             {
@@ -306,12 +366,12 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private async System.Threading.Tasks.Task CheckPendingChapterSplitsAsync()
+        private async System.Threading.Tasks.Task CheckPendingDownloadsAsync()
         {
-            if (_pendingChapterSplits.Count == 0)
+            if (_pendingDownloads.Count == 0)
                 return;
 
-            foreach (var (vodId, (channel, folder)) in _pendingChapterSplits.ToArray())
+            foreach (var (vodId, (channel, folder, splitChapters)) in _pendingDownloads.ToArray())
             {
                 try
                 {
@@ -319,14 +379,54 @@ namespace TwitchDownloaderWPF
                     if (info?.data?.video is null || info.data.video.status == "RECORDING")
                         continue; // still live
 
-                    _pendingChapterSplits.Remove(vodId);
-                    await EnqueueChapterSplitsAsync(vodId, info, channel, folder);
+                    _pendingDownloads.Remove(vodId);
+
+                    if (splitChapters)
+                        await EnqueueChapterSplitsAsync(vodId, info, channel, folder);
+                    else
+                        EnqueueFinishedVod(vodId, info, channel, folder);
                 }
                 catch (Exception ex)
                 {
-                    AppendLog($"Error checking chapter split for VOD {vodId}: {ex.Message}");
+                    AppendLog($"Error checking deferred download for VOD {vodId}: {ex.Message}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Queues a single VodDownloadTask for a stream that has just ended (ModeAfterEnd).
+        /// </summary>
+        private void EnqueueFinishedVod(long vodId, GqlVideoResponse info, string channel, string folder)
+        {
+            var video = info.data.video;
+            var vodLength = TimeSpan.FromSeconds(video.lengthSeconds);
+            var title = video.title ?? "";
+            var streamer = video.owner?.displayName ?? channel;
+            var streamerId = video.owner?.id;
+            var game = video.game?.displayName ?? "";
+            var createdAt = video.createdAt;
+            var ext = FilenameService.GuessVodFileExtension(SelectedQuality);
+
+            var trimBeginning = checkTrimStart.IsChecked.GetValueOrDefault();
+            var trimEnding = checkTrimEnd.IsChecked.GetValueOrDefault();
+            var trimStart = trimBeginning
+                ? new TimeSpan((int)numTrimStartHour.Value, (int)numTrimStartMinute.Value, (int)numTrimStartSecond.Value)
+                : TimeSpan.Zero;
+            var trimEnd = trimEnding
+                ? new TimeSpan((int)numTrimEndHour.Value, (int)numTrimEndMinute.Value, (int)numTrimEndSecond.Value)
+                : vodLength;
+
+            var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
+                createdAt, streamer, streamerId, trimStart, trimEnd, vodLength, video.viewCount, game);
+            var vodPath = Path.Combine(folder, baseName + ext);
+            TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
+
+            var options = BuildVodOptions(vodId, vodPath, trimStart, trimEnd, trimBeginning, trimEnding);
+            var task = new VodDownloadTask { DownloadOptions = options, Info = { Title = title.Length > 0 ? title : streamer } };
+            task.ChangeStatus(TwitchTaskStatus.Ready);
+            lock (PageQueue.taskLock) { PageQueue.taskList.Add(task); }
+
+            AppendLog($"Stream ended — queued full VOD download for {vodId} ({title}).");
         }
 
         private async System.Threading.Tasks.Task EnqueueChapterSplitsAsync(long vodId, GqlVideoResponse info, string channel, string folder)
@@ -425,20 +525,14 @@ namespace TwitchDownloaderWPF
             var title = video.title ?? "";
             var game = video.game?.displayName ?? "";
             var folder = textFolder.Text;
+            var mode = DownloadMode;
 
             var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(), createdAt, streamer, streamerId,
                 TimeSpan.Zero, TimeSpan.FromSeconds(video.lengthSeconds), TimeSpan.FromSeconds(video.lengthSeconds), video.viewCount, game);
 
-            if (checkSplitChapters.IsChecked.GetValueOrDefault())
+            if (mode == ModeLive)
             {
-                // Track the VOD; chapter downloads will be queued once the stream ends
-                _pendingChapterSplits[vodId] = (channel, folder);
-                AppendLog($"'{channel}' is LIVE — will split VOD {vodId} by chapters when stream ends.");
-            }
-            else
-            {
-                // Use LiveStreamDownloadTask so the back-catalog is downloaded immediately with
-                // multiple threads while the live tail is recorded concurrently with ffmpeg.
+                // Download back-catalog immediately (multi-threaded) while recording the live tail with ffmpeg.
                 var vodPath = Path.Combine(folder, baseName + FilenameService.GuessVodFileExtension(SelectedQuality));
                 TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
@@ -472,6 +566,17 @@ namespace TwitchDownloaderWPF
                 }
 
                 AppendLog($"'{channel}' is LIVE — queued live download for VOD {vodId} (back-catalog + real-time recording).");
+            }
+            else
+            {
+                // Deferred: track the VOD and queue the download once the stream ends.
+                var splitChapters = mode == ModeAfterEndSplit;
+                _pendingDownloads[vodId] = (channel, folder, splitChapters);
+
+                if (splitChapters)
+                    AppendLog($"'{channel}' is LIVE — will split VOD {vodId} by chapters when stream ends.");
+                else
+                    AppendLog($"'{channel}' is LIVE — will queue full VOD {vodId} when stream ends.");
             }
 
             if (checkChat.IsChecked.GetValueOrDefault())

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -1,0 +1,325 @@
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Models;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Services;
+using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.TwitchTasks;
+
+namespace TwitchDownloaderWPF
+{
+    /// <summary>
+    /// Interaction logic for PageLiveMonitor.xaml
+    /// </summary>
+    public partial class PageLiveMonitor : Page
+    {
+        private readonly ObservableCollection<string> _channels = new();
+        private readonly HashSet<long> _queuedVodIds = new();
+        private readonly DispatcherTimer _pollTimer = new();
+        private bool _polling;
+
+        public bool IsMonitoring { get; private set; }
+
+        public PageLiveMonitor()
+        {
+            InitializeComponent();
+            _pollTimer.Tick += async (_, _) => await PollAsync();
+        }
+
+        private void Page_Initialized(object sender, EventArgs e)
+        {
+            listChannels.ItemsSource = _channels;
+
+            foreach (var channel in (Settings.Default.LiveMonitorChannels ?? "")
+                         .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                _channels.Add(channel.ToLowerInvariant());
+            }
+
+            textFolder.Text = Settings.Default.LiveMonitorFolder;
+            numPoll.Value = Math.Max(30, Settings.Default.LiveMonitorPollSeconds);
+            numThreads.Value = Math.Max(1, Settings.Default.VodDownloadThreads);
+            checkChat.IsChecked = Settings.Default.LiveMonitorDownloadChat;
+
+            var savedQuality = Settings.Default.LiveMonitorQuality;
+            if (!string.IsNullOrWhiteSpace(savedQuality))
+            {
+                foreach (ComboBoxItem item in comboQuality.Items)
+                {
+                    if ((item.Content as string) == savedQuality)
+                    {
+                        comboQuality.SelectedItem = item;
+                        break;
+                    }
+                }
+            }
+        }
+
+        private string SelectedQuality => (comboQuality.SelectedItem as ComboBoxItem)?.Content as string ?? "Source";
+
+        private void btnDonate_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo("https://www.buymeacoffee.com/lay295") { UseShellExecute = true });
+        }
+
+        private void btnSettings_Click(object sender, RoutedEventArgs e)
+        {
+            var settings = new WindowSettings
+            {
+                Owner = Application.Current.MainWindow,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+            settings.ShowDialog();
+            btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e)
+        {
+            btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void SaveSettings()
+        {
+            Settings.Default.LiveMonitorChannels = string.Join(",", _channels);
+            Settings.Default.LiveMonitorFolder = textFolder.Text;
+            Settings.Default.LiveMonitorQuality = SelectedQuality;
+            Settings.Default.VodDownloadThreads = (int)numThreads.Value;
+            Settings.Default.LiveMonitorPollSeconds = (int)numPoll.Value;
+            Settings.Default.LiveMonitorDownloadChat = checkChat.IsChecked.GetValueOrDefault();
+            Settings.Default.Save();
+        }
+
+        private void AppendLog(string message)
+        {
+            textLog.Dispatcher.BeginInvoke(() =>
+                textLog.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}"));
+        }
+
+        private void btnAddChannel_Click(object sender, RoutedEventArgs e)
+        {
+            AddChannel();
+        }
+
+        private void textChannel_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                AddChannel();
+                e.Handled = true;
+            }
+        }
+
+        private void AddChannel()
+        {
+            var name = textChannel.Text.Trim().ToLowerInvariant();
+            if (name.Length == 0)
+                return;
+
+            // Accept a pasted channel URL too
+            var slash = name.LastIndexOf('/');
+            if (slash >= 0)
+                name = name[(slash + 1)..];
+
+            if (name.Length == 0 || _channels.Contains(name))
+            {
+                textChannel.Clear();
+                return;
+            }
+
+            _channels.Add(name);
+            textChannel.Clear();
+            SaveSettings();
+
+            // If monitoring is already running, check this channel immediately rather
+            // than waiting for the next timer tick — it may already be live.
+            if (IsMonitoring)
+                _ = PollAsync();
+        }
+
+        private void btnRemoveChannel_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is string channel)
+            {
+                _channels.Remove(channel);
+                SaveSettings();
+            }
+        }
+
+        private void btnFolder_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFolderDialog();
+            if (Directory.Exists(textFolder.Text))
+                dialog.InitialDirectory = textFolder.Text;
+
+            if (dialog.ShowDialog() == true)
+            {
+                textFolder.Text = dialog.FolderName;
+                SaveSettings();
+            }
+        }
+
+        private void btnToggle_Click(object sender, RoutedEventArgs e)
+        {
+            if (IsMonitoring)
+            {
+                StopMonitoring();
+                return;
+            }
+
+            if (_channels.Count == 0)
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Add at least one channel to monitor.", "Live Monitor", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(textFolder.Text) || !Directory.Exists(textFolder.Text))
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Choose a valid output folder.", "Live Monitor", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            SaveSettings();
+
+            IsMonitoring = true;
+            btnToggle.Content = "Stop Monitoring";
+            textState.Text = "Monitoring";
+            _pollTimer.Interval = TimeSpan.FromSeconds(Math.Max(30, (int)numPoll.Value));
+            _pollTimer.Start();
+            AppendLog($"Started monitoring {_channels.Count} channel(s), polling every {(int)numPoll.Value}s.");
+            _ = PollAsync();
+        }
+
+        private void StopMonitoring()
+        {
+            _pollTimer.Stop();
+            IsMonitoring = false;
+            btnToggle.Content = "Start Monitoring";
+            textState.Text = "Stopped";
+            AppendLog("Stopped monitoring.");
+        }
+
+        private async System.Threading.Tasks.Task PollAsync()
+        {
+            if (_polling)
+                return;
+
+            _polling = true;
+            try
+            {
+                foreach (var channel in _channels.ToArray())
+                {
+                    try
+                    {
+                        var videos = await TwitchHelper.GetGqlVideos(channel, "", 1, "ARCHIVE");
+                        var node = videos?.data?.user?.videos?.edges?.FirstOrDefault()?.node;
+                        if (node is null || !long.TryParse(node.id, out var vodId))
+                            continue;
+
+                        if (_queuedVodIds.Contains(vodId))
+                            continue;
+
+                        var info = await TwitchHelper.GetVideoInfo(vodId);
+                        if (info?.data?.video is null || info.data.video.status != "RECORDING")
+                            continue;
+
+                        EnqueueRecording(channel, vodId, info);
+                        _queuedVodIds.Add(vodId);
+                    }
+                    catch (Exception ex)
+                    {
+                        AppendLog($"Error checking '{channel}': {ex.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                _polling = false;
+            }
+        }
+
+        private void EnqueueRecording(string channel, long vodId, TwitchDownloaderCore.TwitchObjects.Gql.GqlVideoResponse info)
+        {
+            var video = info.data.video;
+            var streamer = video.owner?.displayName ?? channel;
+            var streamerId = video.owner?.id;
+            var createdAt = video.createdAt;
+            var title = video.title ?? "";
+            var game = video.game?.displayName ?? "";
+
+            var folder = textFolder.Text;
+            var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(), createdAt, streamer, streamerId,
+                TimeSpan.Zero, TimeSpan.FromSeconds(video.lengthSeconds), TimeSpan.FromSeconds(video.lengthSeconds), video.viewCount, game);
+
+            // baseName may contain subfolders if the filename template includes path separators
+            var vodPath = Path.Combine(folder, baseName + ".mp4");
+            TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
+
+            // Use LiveStreamDownloadTask so the back-catalog is downloaded immediately with
+            // multiple threads while the live tail is recorded concurrently with ffmpeg.
+            // This is far better than DelayDownload (waiting hours for the broadcast to end).
+            var liveOptions = new LiveStreamDownloadOptions
+            {
+                Id = vodId,
+                Channel = channel,
+                Quality = SelectedQuality,
+                Filename = vodPath,
+                DownloadThreads = (int)numThreads.Value,
+                ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                Oauth = Settings.Default.OAuth,
+                FfmpegPath = "ffmpeg",
+                TempFolder = Settings.Default.TempPath,
+            };
+
+            var downloadTask = new LiveStreamDownloadTask
+            {
+                DownloadOptions = liveOptions,
+                Info = { Title = title.Length > 0 ? title : $"{streamer} live" }
+            };
+            downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+            lock (PageQueue.taskLock)
+            {
+                PageQueue.taskList.Add(downloadTask);
+            }
+
+            if (checkChat.IsChecked.GetValueOrDefault())
+            {
+                var chatOptions = new ChatDownloadOptions
+                {
+                    Id = vodId.ToString(),
+                    DownloadFormat = ChatFormat.Json,
+                    Compression = ChatCompression.Gzip,
+                    DelayDownload = true,
+                    DownloadThreads = 1,
+                    TempFolder = Settings.Default.TempPath,
+                };
+                chatOptions.Filename = Path.Combine(folder, baseName + chatOptions.FileExtension);
+
+                var chatTask = new ChatDownloadTask
+                {
+                    DownloadOptions = chatOptions,
+                    Info = { Title = title.Length > 0 ? title : $"{streamer} live chat" }
+                };
+                chatTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                lock (PageQueue.taskLock)
+                {
+                    PageQueue.taskList.Add(chatTask);
+                }
+            }
+
+            AppendLog($"'{channel}' is LIVE — queued live download for VOD {vodId} (back-catalog + real-time recording).");
+        }
+    }
+}

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -188,11 +188,16 @@ namespace TwitchDownloaderWPF
         {
             var chatEnabled = checkChat.IsChecked.GetValueOrDefault();
             var hasPresets = comboRenderPreset.Items.Count > 0;
+
+            // Auto-render checkbox and default-preset combo require chat download + at least one preset
             checkAutoRender.IsEnabled = chatEnabled && hasPresets;
             comboRenderPreset.IsEnabled = chatEnabled && hasPresets && checkAutoRender.IsChecked.GetValueOrDefault();
-            comboChannelPreset.IsEnabled = chatEnabled && hasPresets && checkAutoRender.IsChecked.GetValueOrDefault();
             if (!chatEnabled || !hasPresets)
                 checkAutoRender.IsChecked = false;
+
+            // Per-channel override can be set any time there are presets (selection is independent
+            // of whether auto-render is currently on)
+            comboChannelPreset.IsEnabled = hasPresets;
         }
 
         /// <summary>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.Win32;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -10,11 +11,14 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using TwitchDownloaderCore;
+using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Models;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Services;
 using TwitchDownloaderCore.TwitchObjects.Gql;
+using TwitchDownloaderWPF.Models;
 using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.Services;
 using TwitchDownloaderWPF.TwitchTasks;
 
 namespace TwitchDownloaderWPF
@@ -29,11 +33,22 @@ namespace TwitchDownloaderWPF
         private const int ModeAfterEnd = 1;
         private const int ModeAfterEndSplit = 2;
 
+        private const string DefaultPresetItem = "(default)";
+
         private readonly ObservableCollection<string> _channels = new();
         private readonly HashSet<long> _queuedVodIds = new();
 
         // vodId → (channel login, output folder, splitByChapters) for deferred downloads
         private readonly Dictionary<long, (string channel, string folder, bool splitChapters)> _pendingDownloads = new();
+
+        // Render presets loaded from ChatRenderPresetService
+        private List<ChatRenderPreset> _renderPresets = new();
+
+        // Per-channel render preset overrides: channel login → preset name
+        private Dictionary<string, string> _channelPresets = new();
+
+        // Guard flag to suppress SelectionChanged side effects during programmatic updates
+        private bool _suppressPresetSelectionChanged;
 
         private readonly DispatcherTimer _pollTimer = new();
         private bool _polling;
@@ -94,6 +109,14 @@ namespace TwitchDownloaderWPF
                 }
             }
 
+            // Load render presets and per-channel overrides
+            _channelPresets = LiveMonitorPresetService.Load();
+            RefreshPresetCombos();
+
+            // Restore auto-render settings
+            checkAutoRender.IsChecked = Settings.Default.LiveMonitorAutoRender;
+            UpdateAutoRenderEnabled();
+
             // Defer auto-start so the main window has finished loading first
             if (Settings.Default.LiveMonitorAutoStart)
                 Dispatcher.InvokeAsync(TryAutoStart, DispatcherPriority.Background);
@@ -101,6 +124,181 @@ namespace TwitchDownloaderWPF
 
         private string SelectedQuality => (comboQuality.SelectedItem as ComboBoxItem)?.Content as string ?? "Source";
         private int DownloadMode => comboDownloadMode.SelectedIndex;
+
+        // ── Render preset helpers ─────────────────────────────────────────────
+
+        /// <summary>
+        /// Reloads the render preset lists and repopulates both combo boxes.
+        /// </summary>
+        private void RefreshPresetCombos()
+        {
+            _renderPresets = ChatRenderPresetService.Load();
+
+            var presetNames = _renderPresets.Select(p => p.Name).ToList();
+
+            // comboRenderPreset: default preset for all channels
+            _suppressPresetSelectionChanged = true;
+            comboRenderPreset.Items.Clear();
+            foreach (var name in presetNames)
+                comboRenderPreset.Items.Add(name);
+
+            var savedDefault = Settings.Default.LiveMonitorAutoRenderPreset;
+            if (!string.IsNullOrEmpty(savedDefault) && presetNames.Contains(savedDefault))
+                comboRenderPreset.SelectedItem = savedDefault;
+            else if (comboRenderPreset.Items.Count > 0)
+                comboRenderPreset.SelectedIndex = 0;
+            _suppressPresetSelectionChanged = false;
+
+            // comboChannelPreset: per-channel override (first item = use default)
+            _suppressPresetSelectionChanged = true;
+            comboChannelPreset.Items.Clear();
+            comboChannelPreset.Items.Add(DefaultPresetItem);
+            foreach (var name in presetNames)
+                comboChannelPreset.Items.Add(name);
+            _suppressPresetSelectionChanged = false;
+
+            RefreshChannelPresetCombo();
+            UpdateAutoRenderEnabled();
+        }
+
+        /// <summary>
+        /// Updates comboChannelPreset to reflect the selected channel's override (or default).
+        /// </summary>
+        private void RefreshChannelPresetCombo()
+        {
+            _suppressPresetSelectionChanged = true;
+            if (listChannels.SelectedItem is string channel &&
+                _channelPresets.TryGetValue(channel, out var presetName) &&
+                comboChannelPreset.Items.Contains(presetName))
+            {
+                comboChannelPreset.SelectedItem = presetName;
+            }
+            else
+            {
+                comboChannelPreset.SelectedIndex = comboChannelPreset.Items.Count > 0 ? 0 : -1;
+            }
+            _suppressPresetSelectionChanged = false;
+        }
+
+        /// <summary>
+        /// Enables/disables checkAutoRender and comboRenderPreset based on whether
+        /// chat download and presets are available.
+        /// </summary>
+        private void UpdateAutoRenderEnabled()
+        {
+            var chatEnabled = checkChat.IsChecked.GetValueOrDefault();
+            var hasPresets = comboRenderPreset.Items.Count > 0;
+            checkAutoRender.IsEnabled = chatEnabled && hasPresets;
+            comboRenderPreset.IsEnabled = chatEnabled && hasPresets && checkAutoRender.IsChecked.GetValueOrDefault();
+            comboChannelPreset.IsEnabled = chatEnabled && hasPresets && checkAutoRender.IsChecked.GetValueOrDefault();
+            if (!chatEnabled || !hasPresets)
+                checkAutoRender.IsChecked = false;
+        }
+
+        /// <summary>
+        /// Returns the render preset to use for a given channel login.
+        /// Per-channel override takes priority; falls back to the global default.
+        /// Returns null if no preset is available.
+        /// </summary>
+        private ChatRenderPreset GetRenderPresetForChannel(string channel)
+        {
+            // Per-channel override
+            if (_channelPresets.TryGetValue(channel, out var overrideName))
+            {
+                var found = _renderPresets.FirstOrDefault(p => p.Name == overrideName);
+                if (found != null) return found;
+            }
+
+            // Global default
+            var defaultName = comboRenderPreset.SelectedItem as string;
+            if (!string.IsNullOrEmpty(defaultName))
+                return _renderPresets.FirstOrDefault(p => p.Name == defaultName);
+
+            // Fallback: first available
+            return _renderPresets.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Builds <see cref="ChatRenderOptions"/> from a saved preset without requiring
+        /// the PageChatRender UI to be active.
+        /// </summary>
+        private static ChatRenderOptions ChatRenderOptionsFromPreset(
+            ChatRenderPreset p, string inputFile, string outputFile)
+        {
+            var bgColor = new SKColor((byte)p.BackgroundColorR, (byte)p.BackgroundColorG, (byte)p.BackgroundColorB, (byte)p.BackgroundColorA);
+            var altBgColor = new SKColor((byte)p.AltBackgroundColorR, (byte)p.AltBackgroundColorG, (byte)p.AltBackgroundColorB, (byte)p.AltBackgroundColorA);
+            var msgColor = new SKColor((byte)p.MessageColorR, (byte)p.MessageColorG, (byte)p.MessageColorB);
+            var highlightColor = new SKColor((byte)p.HighlightUsersColorR, (byte)p.HighlightUsersColorG, (byte)p.HighlightUsersColorB);
+
+            var inputArgs = p.ChatRenderSharpening
+                ? (p.FfmpegInput ?? "") + " -filter_complex \"smartblur=lr=1:ls=-1.0\""
+                : (p.FfmpegInput ?? "");
+
+            return new ChatRenderOptions
+            {
+                InputFile = inputFile,
+                OutputFile = outputFile,
+                BackgroundColor = bgColor,
+                AlternateBackgroundColor = altBgColor,
+                AlternateMessageBackgrounds = p.AlternateBackgrounds,
+                ChatHeight = p.Height,
+                ChatWidth = p.Width,
+                BttvEmotes = p.Bttv,
+                FfzEmotes = p.Ffz,
+                StvEmotes = p.Stv,
+                Outline = p.Outline,
+                Font = string.IsNullOrEmpty(p.Font) ? "Inter Embedded" : p.Font,
+                FontSize = p.FontSize,
+                UsernameFontScale = p.UsernameScale,
+                UpdateRate = p.UpdateRate,
+                EmoteScale = p.EmoteScale,
+                BadgeScale = p.BadgeScale,
+                EmojiScale = p.EmojiScale,
+                AvatarScale = p.AvatarScale,
+                SidePaddingScale = p.SidePaddingScale,
+                SectionHeightScale = p.SectionHeightScale,
+                WordSpacingScale = p.WordSpaceScale,
+                EmoteSpacingScale = p.EmoteSpaceScale,
+                AccentIndentScale = p.AccentIndentScale,
+                AccentStrokeScale = p.AccentStrokeScale,
+                VerticalSpacingScale = p.VerticalScale,
+                IgnoreUsersArray = (p.IgnoreUsers ?? "").Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                HighlightUsersArray = (p.HighlightUsers ?? "").Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                HighlightUsersColor = highlightColor,
+                BannedWordsArray = (p.BannedWords ?? "").Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                Timestamp = p.Timestamp,
+                MessageColor = msgColor,
+                Framerate = p.Framerate,
+                InputArgs = inputArgs,
+                OutputArgs = p.FfmpegOutput ?? "",
+                MessageFontStyle = SKFontStyle.Normal,
+                UsernameFontStyle = SKFontStyle.Bold,
+                GenerateMask = p.GenerateMask,
+                OutlineSize = 4.0 * p.OutlineScale,
+                FfmpegPath = "ffmpeg",
+                TempFolder = Settings.Default.TempPath,
+                SubMessages = p.SubMessages,
+                ChatBadges = p.Badges,
+                Offline = p.Offline,
+                RenderUserAvatars = p.RenderAvatars,
+                AllowUnlistedEmotes = true,
+                DisperseCommentOffsets = p.Dispersion,
+                AdjustUsernameVisibility = p.AdjustUsernameVisibility,
+                EmojiVendor = (EmojiVendor)p.EmojiVendor,
+                ChatBadgeMask = p.ChatBadgeMask,
+            };
+        }
+
+        private static string GetRenderExtension(string videoContainer) =>
+            (videoContainer ?? "MP4").ToUpperInvariant() switch
+            {
+                "MOV" => ".mov",
+                "MKV" => ".mkv",
+                "WEBM" => ".webm",
+                _ => ".mp4",
+            };
+
+        // ── UI event handlers ─────────────────────────────────────────────────
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)
         {
@@ -116,6 +314,9 @@ namespace TwitchDownloaderWPF
             };
             settings.ShowDialog();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
+
+            // Re-load presets in case the user added/edited them in Settings
+            RefreshPresetCombos();
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
@@ -133,6 +334,8 @@ namespace TwitchDownloaderWPF
             Settings.Default.LiveMonitorDownloadChat = checkChat.IsChecked.GetValueOrDefault();
             Settings.Default.LiveMonitorDownloadMode = DownloadMode;
             Settings.Default.LiveMonitorAutoStart = checkAutoStart.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorAutoRender = checkAutoRender.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorAutoRenderPreset = comboRenderPreset.SelectedItem as string ?? "";
 
             Settings.Default.LiveMonitorTrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault();
             Settings.Default.LiveMonitorTrimBeginningHour = (int)numTrimStartHour.Value;
@@ -199,6 +402,8 @@ namespace TwitchDownloaderWPF
             if (listChannels.SelectedItem is string channel)
             {
                 _channels.Remove(channel);
+                _channelPresets.Remove(channel);
+                LiveMonitorPresetService.Save(_channelPresets);
                 SaveSettings();
             }
         }
@@ -251,10 +456,6 @@ namespace TwitchDownloaderWPF
             _ = PollAsync();
         }
 
-        /// <summary>
-        /// Called on a background dispatcher priority after init — silently starts monitoring
-        /// if auto-start is enabled and all conditions are met.
-        /// </summary>
         private void TryAutoStart()
         {
             if (IsMonitoring)
@@ -275,9 +476,17 @@ namespace TwitchDownloaderWPF
             AppendLog("Stopped monitoring.");
         }
 
+        private void listChannels_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            RefreshChannelPresetCombo();
+        }
+
         private void comboDownloadMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            // Trim is meaningless for split-by-chapters mode (chapter boundaries are the trim points)
+            // Guard: fires during XAML init before the trim controls exist yet
+            if (checkTrimStart is null || checkTrimEnd is null)
+                return;
+
             var isSplitMode = comboDownloadMode.SelectedIndex == ModeAfterEndSplit;
             SetTrimControlsAvailable(!isSplitMode);
             if (isSplitMode)
@@ -290,6 +499,38 @@ namespace TwitchDownloaderWPF
                 SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault());
                 SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
             }
+            SaveSettings();
+        }
+
+        private void comboChannelPreset_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressPresetSelectionChanged) return;
+            if (listChannels?.SelectedItem is not string channel) return;
+
+            var selected = comboChannelPreset.SelectedItem as string;
+            if (string.IsNullOrEmpty(selected) || selected == DefaultPresetItem)
+                _channelPresets.Remove(channel);
+            else
+                _channelPresets[channel] = selected;
+
+            LiveMonitorPresetService.Save(_channelPresets);
+        }
+
+        private void comboRenderPreset_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressPresetSelectionChanged) return;
+            SaveSettings();
+        }
+
+        private void checkChat_CheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            UpdateAutoRenderEnabled();
+            SaveSettings();
+        }
+
+        private void checkAutoRender_CheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            UpdateAutoRenderEnabled();
             SaveSettings();
         }
 
@@ -324,6 +565,8 @@ namespace TwitchDownloaderWPF
             SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
             SaveSettings();
         }
+
+        // ── Polling / download logic ──────────────────────────────────────────
 
         private async System.Threading.Tasks.Task PollAsync()
         {
@@ -393,9 +636,6 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        /// <summary>
-        /// Queues a single VodDownloadTask for a stream that has just ended (ModeAfterEnd).
-        /// </summary>
         private void EnqueueFinishedVod(long vodId, GqlVideoResponse info, string channel, string folder)
         {
             var video = info.data.video;
@@ -532,7 +772,6 @@ namespace TwitchDownloaderWPF
 
             if (mode == ModeLive)
             {
-                // Download back-catalog immediately (multi-threaded) while recording the live tail with ffmpeg.
                 var vodPath = Path.Combine(folder, baseName + FilenameService.GuessVodFileExtension(SelectedQuality));
                 TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
@@ -569,7 +808,6 @@ namespace TwitchDownloaderWPF
             }
             else
             {
-                // Deferred: track the VOD and queue the download once the stream ends.
                 var splitChapters = mode == ModeAfterEndSplit;
                 _pendingDownloads[vodId] = (channel, folder, splitChapters);
 
@@ -579,29 +817,65 @@ namespace TwitchDownloaderWPF
                     AppendLog($"'{channel}' is LIVE — will queue full VOD {vodId} when stream ends.");
             }
 
-            if (checkChat.IsChecked.GetValueOrDefault())
+            // ── Chat download (+ optional auto-render) ──────────────────────
+            if (!checkChat.IsChecked.GetValueOrDefault())
+                return;
+
+            var chatBaseName = FilenameService.GetFilename(Settings.Default.TemplateChat, title, vodId.ToString(),
+                createdAt, streamer, streamerId, TimeSpan.Zero, TimeSpan.FromSeconds(video.lengthSeconds),
+                TimeSpan.FromSeconds(video.lengthSeconds), video.viewCount, game);
+
+            var chatOptions = new ChatDownloadOptions
             {
-                var chatOptions = new ChatDownloadOptions
-                {
-                    Id = vodId.ToString(),
-                    DownloadFormat = ChatFormat.Json,
-                    Compression = ChatCompression.Gzip,
-                    DelayDownload = true,
-                    DownloadThreads = 1,
-                    TempFolder = Settings.Default.TempPath,
-                };
-                chatOptions.Filename = Path.Combine(folder, baseName + chatOptions.FileExtension);
+                Id = vodId.ToString(),
+                DownloadFormat = ChatFormat.Json,
+                Compression = ChatCompression.Gzip,
+                DelayDownload = true,
+                DownloadThreads = 1,
+                TempFolder = Settings.Default.TempPath,
+            };
+            chatOptions.Filename = Path.Combine(folder, chatBaseName + chatOptions.FileExtension);
 
-                var chatTask = new ChatDownloadTask
-                {
-                    DownloadOptions = chatOptions,
-                    Info = { Title = title.Length > 0 ? title : $"{streamer} live chat" }
-                };
-                chatTask.ChangeStatus(TwitchTaskStatus.Ready);
+            var chatTask = new ChatDownloadTask
+            {
+                DownloadOptions = chatOptions,
+                Info = { Title = title.Length > 0 ? $"{title} — Chat" : $"{streamer} live — Chat" }
+            };
+            chatTask.ChangeStatus(TwitchTaskStatus.Ready);
 
-                lock (PageQueue.taskLock)
+            lock (PageQueue.taskLock)
+            {
+                PageQueue.taskList.Add(chatTask);
+
+                // Auto-render: queue a ChatRenderTask that waits for the chat download to finish
+                if (checkAutoRender.IsChecked.GetValueOrDefault())
                 {
-                    PageQueue.taskList.Add(chatTask);
+                    var preset = GetRenderPresetForChannel(channel);
+                    if (preset != null)
+                    {
+                        // Derive render output path from the chat file path
+                        var chatFile = chatOptions.Filename; // ends in .json.gz
+                        var renderBase = chatFile.EndsWith(chatOptions.FileExtension, StringComparison.OrdinalIgnoreCase)
+                            ? chatFile[..^chatOptions.FileExtension.Length]
+                            : chatFile;
+                        var renderPath = renderBase + GetRenderExtension(preset.VideoContainer);
+
+                        var renderOptions = ChatRenderOptionsFromPreset(preset, chatFile, renderPath);
+                        var renderTask = new ChatRenderTask
+                        {
+                            DownloadOptions = renderOptions,
+                            DependantTask = chatTask,
+                            Info = { Title = title.Length > 0 ? $"{title} — Chat Render" : $"{streamer} live — Chat Render" }
+                        };
+                        renderTask.ChangeStatus(TwitchTaskStatus.Waiting);
+                        PageQueue.taskList.Add(renderTask);
+
+                        AppendLog($"'{channel}' — will auto-render chat using preset '{preset.Name}' once download finishes.");
+                    }
+                    else
+                    {
+                        AppendLog($"'{channel}' — auto-render skipped: no render preset available.");
+                    }
                 }
             }
         }

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -14,6 +14,7 @@ using TwitchDownloaderCore;
 using TwitchDownloaderCore.Models;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Services;
+using TwitchDownloaderCore.TwitchObjects.Gql;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.TwitchTasks;
 
@@ -26,6 +27,8 @@ namespace TwitchDownloaderWPF
     {
         private readonly ObservableCollection<string> _channels = new();
         private readonly HashSet<long> _queuedVodIds = new();
+        // vodId → (channel login, output folder) for streams waiting to be chapter-split
+        private readonly Dictionary<long, (string channel, string folder)> _pendingChapterSplits = new();
         private readonly DispatcherTimer _pollTimer = new();
         private bool _polling;
 
@@ -51,6 +54,21 @@ namespace TwitchDownloaderWPF
             numPoll.Value = Math.Max(30, Settings.Default.LiveMonitorPollSeconds);
             numThreads.Value = Math.Max(1, Settings.Default.VodDownloadThreads);
             checkChat.IsChecked = Settings.Default.LiveMonitorDownloadChat;
+            checkSplitChapters.IsChecked = Settings.Default.LiveMonitorSplitChapters;
+
+            // Load H/M/S before the checkbox so that SaveSettings (fired by the Checked event) reads correct values
+            numTrimStartHour.Value = Settings.Default.LiveMonitorTrimBeginningHour;
+            numTrimStartMinute.Value = Settings.Default.LiveMonitorTrimBeginningMinute;
+            numTrimStartSecond.Value = Settings.Default.LiveMonitorTrimBeginningSecond;
+            checkTrimStart.IsChecked = Settings.Default.LiveMonitorTrimBeginning;
+
+            numTrimEndHour.Value = Settings.Default.LiveMonitorTrimEndingHour;
+            numTrimEndMinute.Value = Settings.Default.LiveMonitorTrimEndingMinute;
+            numTrimEndSecond.Value = Settings.Default.LiveMonitorTrimEndingSecond;
+            checkTrimEnd.IsChecked = Settings.Default.LiveMonitorTrimEnding;
+
+            SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault());
+            SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
 
             var savedQuality = Settings.Default.LiveMonitorQuality;
             if (!string.IsNullOrWhiteSpace(savedQuality))
@@ -97,6 +115,18 @@ namespace TwitchDownloaderWPF
             Settings.Default.VodDownloadThreads = (int)numThreads.Value;
             Settings.Default.LiveMonitorPollSeconds = (int)numPoll.Value;
             Settings.Default.LiveMonitorDownloadChat = checkChat.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorSplitChapters = checkSplitChapters.IsChecked.GetValueOrDefault();
+
+            Settings.Default.LiveMonitorTrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorTrimBeginningHour = (int)numTrimStartHour.Value;
+            Settings.Default.LiveMonitorTrimBeginningMinute = (int)numTrimStartMinute.Value;
+            Settings.Default.LiveMonitorTrimBeginningSecond = (int)numTrimStartSecond.Value;
+
+            Settings.Default.LiveMonitorTrimEnding = checkTrimEnd.IsChecked.GetValueOrDefault();
+            Settings.Default.LiveMonitorTrimEndingHour = (int)numTrimEndHour.Value;
+            Settings.Default.LiveMonitorTrimEndingMinute = (int)numTrimEndMinute.Value;
+            Settings.Default.LiveMonitorTrimEndingSecond = (int)numTrimEndSecond.Value;
+
             Settings.Default.Save();
         }
 
@@ -209,6 +239,32 @@ namespace TwitchDownloaderWPF
             AppendLog("Stopped monitoring.");
         }
 
+        private void SetTrimStartEnabled(bool isEnabled)
+        {
+            numTrimStartHour.IsEnabled = isEnabled;
+            numTrimStartMinute.IsEnabled = isEnabled;
+            numTrimStartSecond.IsEnabled = isEnabled;
+        }
+
+        private void SetTrimEndEnabled(bool isEnabled)
+        {
+            numTrimEndHour.IsEnabled = isEnabled;
+            numTrimEndMinute.IsEnabled = isEnabled;
+            numTrimEndSecond.IsEnabled = isEnabled;
+        }
+
+        private void checkTrimStart_CheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            SetTrimStartEnabled(checkTrimStart.IsChecked.GetValueOrDefault());
+            SaveSettings();
+        }
+
+        private void checkTrimEnd_CheckStateChanged(object sender, RoutedEventArgs e)
+        {
+            SetTrimEndEnabled(checkTrimEnd.IsChecked.GetValueOrDefault());
+            SaveSettings();
+        }
+
         private async System.Threading.Tasks.Task PollAsync()
         {
             if (_polling)
@@ -241,6 +297,8 @@ namespace TwitchDownloaderWPF
                         AppendLog($"Error checking '{channel}': {ex.Message}");
                     }
                 }
+
+                await CheckPendingChapterSplitsAsync();
             }
             finally
             {
@@ -248,7 +306,117 @@ namespace TwitchDownloaderWPF
             }
         }
 
-        private void EnqueueRecording(string channel, long vodId, TwitchDownloaderCore.TwitchObjects.Gql.GqlVideoResponse info)
+        private async System.Threading.Tasks.Task CheckPendingChapterSplitsAsync()
+        {
+            if (_pendingChapterSplits.Count == 0)
+                return;
+
+            foreach (var (vodId, (channel, folder)) in _pendingChapterSplits.ToArray())
+            {
+                try
+                {
+                    var info = await TwitchHelper.GetVideoInfo(vodId);
+                    if (info?.data?.video is null || info.data.video.status == "RECORDING")
+                        continue; // still live
+
+                    _pendingChapterSplits.Remove(vodId);
+                    await EnqueueChapterSplitsAsync(vodId, info, channel, folder);
+                }
+                catch (Exception ex)
+                {
+                    AppendLog($"Error checking chapter split for VOD {vodId}: {ex.Message}");
+                }
+            }
+        }
+
+        private async System.Threading.Tasks.Task EnqueueChapterSplitsAsync(long vodId, GqlVideoResponse info, string channel, string folder)
+        {
+            var video = info.data.video;
+            var vodLength = TimeSpan.FromSeconds(video.lengthSeconds);
+            var title = video.title ?? "";
+            var streamer = video.owner?.displayName ?? channel;
+            var streamerId = video.owner?.id;
+            var game = video.game?.displayName ?? "";
+            var createdAt = video.createdAt;
+            var ext = FilenameService.GuessVodFileExtension(SelectedQuality);
+
+            try
+            {
+                var chapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(vodId, video);
+                var chapters = chapterResponse.data.video.moments.edges;
+
+                if (chapters.Count <= 1)
+                {
+                    AppendLog($"VOD {vodId} has only one chapter — queuing as single download.");
+                    var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
+                        createdAt, streamer, streamerId, TimeSpan.Zero, vodLength, vodLength, video.viewCount, game);
+                    var vodPath = Path.Combine(folder, baseName + ext);
+                    TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
+                    var singleOptions = BuildVodOptions(vodId, vodPath, TimeSpan.Zero, vodLength, false, false);
+                    var singleTask = new VodDownloadTask { DownloadOptions = singleOptions, Info = { Title = title } };
+                    singleTask.ChangeStatus(TwitchTaskStatus.Ready);
+                    lock (PageQueue.taskLock) { PageQueue.taskList.Add(singleTask); }
+                    return;
+                }
+
+                AppendLog($"Stream ended — enqueueing {chapters.Count} chapter downloads for VOD {vodId} ({title}).");
+
+                lock (PageQueue.taskLock)
+                {
+                    for (int i = 0; i < chapters.Count; i++)
+                    {
+                        var chapter = chapters[i].node;
+                        var startSec = chapter.positionMilliseconds / 1000;
+                        var endSec = startSec + chapter.durationMilliseconds / 1000;
+                        var chapterStart = TimeSpan.FromSeconds(startSec);
+                        var chapterEnd = TimeSpan.FromSeconds(Math.Min(endSec, (int)vodLength.TotalSeconds));
+                        var gameName = chapter.details?.game?.displayName ?? chapter.description ?? game;
+
+                        var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(),
+                            createdAt, streamer, streamerId, chapterStart, chapterEnd, vodLength, video.viewCount, gameName)
+                            + $"_ch{i + 1:D2}";
+                        var vodPath = Path.Combine(folder, baseName + ext);
+                        TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
+
+                        var options = BuildVodOptions(vodId, vodPath, chapterStart, chapterEnd, true, true);
+                        var task = new VodDownloadTask
+                        {
+                            DownloadOptions = options,
+                            Info = { Title = $"{title} — {gameName} (Ch. {i + 1})" }
+                        };
+                        task.ChangeStatus(TwitchTaskStatus.Ready);
+                        PageQueue.taskList.Add(task);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"Failed to enqueue chapter splits for VOD {vodId}: {ex.Message}");
+            }
+        }
+
+        private VideoDownloadOptions BuildVodOptions(long vodId, string filename, TimeSpan trimStart, TimeSpan trimEnd, bool trimBeginning, bool trimEnding)
+        {
+            return new VideoDownloadOptions
+            {
+                Id = vodId,
+                Quality = SelectedQuality,
+                Filename = filename,
+                TrimBeginning = trimBeginning,
+                TrimBeginningTime = trimStart,
+                TrimEnding = trimEnding,
+                TrimEndingTime = trimEnd,
+                DownloadThreads = (int)numThreads.Value,
+                ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                Oauth = Settings.Default.OAuth,
+                FfmpegPath = "ffmpeg",
+                TempFolder = Settings.Default.TempPath,
+                TrimMode = VideoTrimMode.Exact,
+                FileCollisionCallback = info => info,
+            };
+        }
+
+        private void EnqueueRecording(string channel, long vodId, GqlVideoResponse info)
         {
             var video = info.data.video;
             var streamer = video.owner?.displayName ?? channel;
@@ -256,41 +424,54 @@ namespace TwitchDownloaderWPF
             var createdAt = video.createdAt;
             var title = video.title ?? "";
             var game = video.game?.displayName ?? "";
-
             var folder = textFolder.Text;
+
             var baseName = FilenameService.GetFilename(Settings.Default.TemplateVod, title, vodId.ToString(), createdAt, streamer, streamerId,
                 TimeSpan.Zero, TimeSpan.FromSeconds(video.lengthSeconds), TimeSpan.FromSeconds(video.lengthSeconds), video.viewCount, game);
 
-            // baseName may contain subfolders if the filename template includes path separators
-            var vodPath = Path.Combine(folder, baseName + ".mp4");
-            TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
-
-            // Use LiveStreamDownloadTask so the back-catalog is downloaded immediately with
-            // multiple threads while the live tail is recorded concurrently with ffmpeg.
-            // This is far better than DelayDownload (waiting hours for the broadcast to end).
-            var liveOptions = new LiveStreamDownloadOptions
+            if (checkSplitChapters.IsChecked.GetValueOrDefault())
             {
-                Id = vodId,
-                Channel = channel,
-                Quality = SelectedQuality,
-                Filename = vodPath,
-                DownloadThreads = (int)numThreads.Value,
-                ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
-                Oauth = Settings.Default.OAuth,
-                FfmpegPath = "ffmpeg",
-                TempFolder = Settings.Default.TempPath,
-            };
-
-            var downloadTask = new LiveStreamDownloadTask
+                // Track the VOD; chapter downloads will be queued once the stream ends
+                _pendingChapterSplits[vodId] = (channel, folder);
+                AppendLog($"'{channel}' is LIVE — will split VOD {vodId} by chapters when stream ends.");
+            }
+            else
             {
-                DownloadOptions = liveOptions,
-                Info = { Title = title.Length > 0 ? title : $"{streamer} live" }
-            };
-            downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+                // Use LiveStreamDownloadTask so the back-catalog is downloaded immediately with
+                // multiple threads while the live tail is recorded concurrently with ffmpeg.
+                var vodPath = Path.Combine(folder, baseName + FilenameService.GuessVodFileExtension(SelectedQuality));
+                TwitchHelper.CreateDirectory(Path.GetDirectoryName(vodPath));
 
-            lock (PageQueue.taskLock)
-            {
-                PageQueue.taskList.Add(downloadTask);
+                var liveOptions = new LiveStreamDownloadOptions
+                {
+                    Id = vodId,
+                    Channel = channel,
+                    Quality = SelectedQuality,
+                    Filename = vodPath,
+                    DownloadThreads = (int)numThreads.Value,
+                    ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                    Oauth = Settings.Default.OAuth,
+                    FfmpegPath = "ffmpeg",
+                    TempFolder = Settings.Default.TempPath,
+                    TrimBeginning = checkTrimStart.IsChecked.GetValueOrDefault(),
+                    TrimBeginningTime = new TimeSpan((int)numTrimStartHour.Value, (int)numTrimStartMinute.Value, (int)numTrimStartSecond.Value),
+                    TrimEnding = checkTrimEnd.IsChecked.GetValueOrDefault(),
+                    TrimEndingTime = new TimeSpan((int)numTrimEndHour.Value, (int)numTrimEndMinute.Value, (int)numTrimEndSecond.Value),
+                };
+
+                var downloadTask = new LiveStreamDownloadTask
+                {
+                    DownloadOptions = liveOptions,
+                    Info = { Title = title.Length > 0 ? title : $"{streamer} live" }
+                };
+                downloadTask.ChangeStatus(TwitchTaskStatus.Ready);
+
+                lock (PageQueue.taskLock)
+                {
+                    PageQueue.taskList.Add(downloadTask);
+                }
+
+                AppendLog($"'{channel}' is LIVE — queued live download for VOD {vodId} (back-catalog + real-time recording).");
             }
 
             if (checkChat.IsChecked.GetValueOrDefault())
@@ -318,8 +499,6 @@ namespace TwitchDownloaderWPF
                     PageQueue.taskList.Add(chatTask);
                 }
             }
-
-            AppendLog($"'{channel}' is LIVE — queued live download for VOD {vodId} (back-catalog + real-time recording).");
         }
     }
 }

--- a/TwitchDownloaderWPF/PageQueue.xaml
+++ b/TwitchDownloaderWPF/PageQueue.xaml
@@ -137,6 +137,13 @@
                 <Button x:Name="btnUrlList" Content="{lex:Loc UrlList}" Margin="0,11,0,0" Width="165" Click="btnUrlList_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
                 <Button x:Name="btnVods" Content="{lex:Loc SearchVods}" Margin="0,8,0,0" Width="165" Click="btnVods_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
                 <Button x:Name="btnClips" Content="{lex:Loc SearchClips}" Margin="0,8,0,0" Width="165" Click="btnClips_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <hc:Divider Content="When Queue Finishes" HorizontalAlignment="Center" Margin="0,10,0,0" FontWeight="Bold" MinWidth="180" LineStroke="{DynamicResource AppDivider}" Foreground="{DynamicResource AppDividerText}"/>
+                <ComboBox x:Name="comboQueueFinish" Margin="0,8,0,0" Width="165" SelectionChanged="ComboQueueFinish_SelectionChanged" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}">
+                    <ComboBoxItem Content="Do Nothing" IsSelected="True"/>
+                    <ComboBoxItem Content="Sleep"/>
+                    <ComboBoxItem Content="Hibernate"/>
+                    <ComboBoxItem Content="Shutdown"/>
+                </ComboBox>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/TwitchDownloaderWPF/PageQueue.xaml.cs
+++ b/TwitchDownloaderWPF/PageQueue.xaml.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -19,6 +20,7 @@ namespace TwitchDownloaderWPF
         public static readonly object taskLock = new object();
         public static ObservableCollection<TwitchTask> taskList { get; } = new();
         private static readonly BackgroundWorker taskManager = new BackgroundWorker();
+        private static volatile string _queueFinishAction = "Do Nothing";
 
         public PageQueue()
         {
@@ -59,6 +61,9 @@ namespace TwitchDownloaderWPF
                             case VodDownloadTask:
                                 currentVod++;
                                 break;
+                            case LiveStreamDownloadTask:
+                                currentVod++;
+                                break;
                             case ClipDownloadTask:
                                 currentClip++;
                                 break;
@@ -85,6 +90,10 @@ namespace TwitchDownloaderWPF
                                 currentVod++;
                                 task.RunAsync();
                                 break;
+                            case LiveStreamDownloadTask when currentVod < maxVod:
+                                currentVod++;
+                                task.RunAsync();
+                                break;
                             case ClipDownloadTask when currentClip < maxClip:
                                 currentClip++;
                                 task.RunAsync();
@@ -103,10 +112,69 @@ namespace TwitchDownloaderWPF
                                 break;
                         }
                     }
+
+                    // Queue-finish action
+                    if (_queueFinishAction != "Do Nothing" && taskList.Count > 0)
+                    {
+                        bool allTerminal = taskList.All(t => t.Status is TwitchTaskStatus.Finished or TwitchTaskStatus.Failed or TwitchTaskStatus.Canceled);
+                        if (allTerminal)
+                        {
+                            bool allSucceeded = taskList.All(t => t.Status == TwitchTaskStatus.Finished);
+                            bool anyFailed = taskList.Any(t => t.Status == TwitchTaskStatus.Failed);
+                            var action = _queueFinishAction;
+                            _queueFinishAction = "Do Nothing";
+                            // Reset combo on UI thread
+                            Application.Current.Dispatcher.BeginInvoke(() =>
+                            {
+                                if (MainWindow.pageQueue?.comboQueueFinish is { } c) c.SelectedIndex = 0;
+                            });
+                            if (allSucceeded)
+                            {
+                                // All tasks finished successfully — execute the action
+                                System.Threading.Tasks.Task.Run(async () =>
+                                {
+                                    await System.Threading.Tasks.Task.Delay(2000);
+                                    ExecuteQueueFinishAction(action);
+                                });
+                            }
+                            else if (anyFailed)
+                            {
+                                // One or more tasks failed — notify and skip the action
+                                Application.Current.Dispatcher.BeginInvoke(() =>
+                                {
+                                    NotificationService.Show(
+                                        "Queue finished with errors",
+                                        $"'{action}' was not executed because one or more tasks failed.",
+                                        isError: true);
+                                });
+                            }
+                            // else all cancelled — reset silently (already done above)
+                        }
+                    }
                 }
 
                 Thread.Sleep(1000);
             }
+        }
+
+        [System.Runtime.InteropServices.DllImport("Powrprof.dll", SetLastError = true)]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        private static extern bool SetSuspendState(bool hibernate, bool forceCritical, bool disableWakeEvent);
+
+        private static void ExecuteQueueFinishAction(string action)
+        {
+            switch (action)
+            {
+                case "Sleep":     SetSuspendState(false, false, false); break;
+                case "Hibernate": SetSuspendState(true, false, false); break;
+                case "Shutdown":  Process.Start(new ProcessStartInfo("shutdown", "/s /t 30") { UseShellExecute = true }); break;
+            }
+        }
+
+        private void ComboQueueFinish_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count > 0)
+                _queueFinishAction = (e.AddedItems[0] as ComboBoxItem)?.Content?.ToString() ?? "Do Nothing";
         }
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -71,7 +71,6 @@
                 <TextBlock HorizontalAlignment="Right" Margin="0,15,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc VideoTrimMode}"/><Hyperlink ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc VideoTrimModeTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
                 <TextBlock Text="{lex:Loc TrimVideo}" HorizontalAlignment="Right" Margin="0,10,0,0" Foreground="{DynamicResource AppText}" />
                 <TextBlock Text="{lex:Loc VideoDownloadThreads}" HorizontalAlignment="Right" Margin="0,46,0,0" Foreground="{DynamicResource AppText}" />
-                <TextBlock HorizontalAlignment="Right" Margin="0,21,0,0" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc Oauth}"/><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc OauthTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
             </StackPanel>
             <StackPanel>
                 <TextBlock x:Name="labelLength" Text="0:0:0" Margin="5,0,0,0" Foreground="{DynamicResource AppText}" />
@@ -96,7 +95,6 @@
                         <hc:NumericUpDown Margin="3,-1,0,0" Minimum="0" Maximum="59" Value="0" x:Name="numEndSecond" ValueChanged="numEndSecond_ValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                     </StackPanel>
                     <hc:NumericUpDown Margin="0,5,0,0" Minimum="1" Value="4" Maximum="20" x:Name="numDownloadThreads" HorizontalAlignment="Left" ValueChanged="numDownloadThreads_ValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
-                    <TextBox x:Name="TextOauth" Margin="0,8,3,3" MinWidth="200" MaxWidth="400" TextChanged="TextOauth_TextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>
@@ -105,10 +103,12 @@
                 <hc:SplitButton.DropDownContent>
                     <StackPanel>
                         <MenuItem x:Name="MenuItemEnqueue" Header="{lex:Loc EnqueueDownload}" Click="MenuItemEnqueue_Click"/>
+                        <MenuItem x:Name="MenuItemSplitByChapters" Header="Split by chapters..." Click="MenuItemSplitByChapters_Click"/>
                     </StackPanel>
                 </hc:SplitButton.DropDownContent>
             </hc:SplitButton>
             <Button x:Name="BtnCancel" Height="40" MinWidth="120" Margin="0,6,0,0" Content="{lex:Loc TaskCancel}" Click="BtnCancel_Click" Visibility="Collapsed" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="BtnSyncToChat" Height="40" MinWidth="120" Margin="6,6,0,0" Content="→ Sync to Chat" Click="BtnSyncToChat_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </StackPanel>
         <!-- RIGHT -->
         <StackPanel Grid.Column="4" Grid.Row="1" Grid.RowSpan="1" HorizontalAlignment="Right">

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -684,6 +684,12 @@ namespace TwitchDownloaderWPF
 
         private void BtnSyncToChat_Click(object sender, RoutedEventArgs e)
         {
+            if (currentVideoId == 0)
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "No VOD is loaded on the VOD Download page.", "Nothing to Sync", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
             var chat = MainWindow.pageChatDownload;
 
             // Copy URL

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -39,12 +39,15 @@ namespace TwitchDownloaderWPF
         public int viewCount;
         public string game;
         public string streamerId;
+        public bool vodIsLive;
         private CancellationTokenSource _cancellationTokenSource;
 
         public PageVodDownload()
         {
             InitializeComponent();
         }
+
+        public bool IsActionInProgress => BtnCancel.Visibility == Visibility.Visible;
 
         private void SetEnabled(bool isEnabled)
         {
@@ -97,7 +100,7 @@ namespace TwitchDownloaderWPF
             try
             {
                 Task<GqlVideoResponse> taskVideoInfo = TwitchHelper.GetVideoInfo(videoId);
-                Task<GqlVideoTokenResponse> taskAccessToken = TwitchHelper.GetVideoToken(videoId, TextOauth.Text);
+                Task<GqlVideoTokenResponse> taskAccessToken = TwitchHelper.GetVideoToken(videoId, Settings.Default.OAuth);
                 await Task.WhenAll(taskVideoInfo, taskAccessToken);
 
                 if (taskAccessToken.Result.data.videoPlaybackAccessToken is null)
@@ -174,6 +177,7 @@ namespace TwitchDownloaderWPF
                 labelLength.Text = vodLength.ToString("c");
                 viewCount = taskVideoInfo.Result.data.video.viewCount;
                 game = taskVideoInfo.Result.data.video.game?.displayName ?? Translations.Strings.UnknownGame;
+                vodIsLive = string.Equals(taskVideoInfo.Result.data.video.status, "recording", StringComparison.OrdinalIgnoreCase);
 
                 UpdateVideoSizeEstimates();
 
@@ -215,7 +219,7 @@ namespace TwitchDownloaderWPF
                     checkStart.IsChecked == true ? new TimeSpan((int)numStartHour.Value, (int)numStartMinute.Value, (int)numStartSecond.Value) : TimeSpan.Zero,
                     checkEnd.IsChecked == true ? new TimeSpan((int)numEndHour.Value, (int)numEndMinute.Value, (int)numEndSecond.Value) : vodLength,
                     vodLength, viewCount, game) + FilenameService.GuessVodFileExtension(((ComboBoxItem)comboQuality.SelectedItem).Tag.ToString())),
-                Oauth = TextOauth.Text,
+                Oauth = Settings.Default.OAuth,
                 Quality = ((ComboBoxItem)comboQuality.SelectedItem).Tag.ToString(),
                 Id = currentVideoId,
                 TrimBeginning = checkStart.IsChecked.GetValueOrDefault(),
@@ -355,7 +359,6 @@ namespace TwitchDownloaderWPF
             SetEnabledTrimEnd(false);
             WebRequest.DefaultWebProxy = null;
             numDownloadThreads.Value = Settings.Default.VodDownloadThreads;
-            TextOauth.Text = Settings.Default.OAuth;
             _ = (VideoTrimMode)Settings.Default.VodTrimMode switch
             {
                 VideoTrimMode.Exact => RadioTrimExact.IsChecked = true,
@@ -368,15 +371,6 @@ namespace TwitchDownloaderWPF
             if (this.IsInitialized && numDownloadThreads.IsEnabled)
             {
                 Settings.Default.VodDownloadThreads = (int)numDownloadThreads.Value;
-                Settings.Default.Save();
-            }
-        }
-
-        private void TextOauth_TextChanged(object sender, RoutedEventArgs e)
-        {
-            if (this.IsInitialized)
-            {
-                Settings.Default.OAuth = TextOauth.Text;
                 Settings.Default.Save();
             }
         }
@@ -589,6 +583,127 @@ namespace TwitchDownloaderWPF
                 Settings.Default.VodTrimMode = (int)VideoTrimMode.Exact;
                 Settings.Default.Save();
             }
+        }
+
+        private async void MenuItemSplitByChapters_Click(object sender, RoutedEventArgs e)
+        {
+            if (currentVideoId == 0)
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Please load a VOD first.", "No VOD Loaded", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                btnGetInfo.IsEnabled = false;
+                SplitBtnDownload.IsEnabled = false;
+
+                var videoInfo = new TwitchDownloaderCore.TwitchObjects.Gql.VideoInfo
+                {
+                    lengthSeconds = (int)vodLength.TotalSeconds,
+                    game = new TwitchDownloaderCore.TwitchObjects.Gql.Game { displayName = game }
+                };
+
+                var chapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(currentVideoId, videoInfo);
+                var chapters = chapterResponse.data.video.moments.edges;
+
+                if (chapters.Count <= 1)
+                {
+                    MessageBox.Show(Application.Current.MainWindow!, "This VOD has only one chapter — nothing to split.", "Single Chapter", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var msg = $"Enqueue {chapters.Count} separate downloads (one per chapter)?";
+                if (MessageBox.Show(Application.Current.MainWindow!, msg, "Split by Chapters", MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                    return;
+
+                string folder = Settings.Default.QueueFolder;
+                string quality = ((ComboBoxItem)comboQuality.SelectedItem).Tag.ToString();
+                string ext = FilenameService.GuessVodFileExtension(quality);
+                var trimMode = RadioTrimSafe.IsChecked == true ? VideoTrimMode.Safe : VideoTrimMode.Exact;
+
+                lock (PageQueue.taskLock)
+                {
+                    for (int i = 0; i < chapters.Count; i++)
+                    {
+                        var chapter = chapters[i].node;
+                        var startSec = chapter.positionMilliseconds / 1000;
+                        var endSec = startSec + chapter.durationMilliseconds / 1000;
+                        var chapterStart = TimeSpan.FromSeconds(startSec);
+                        var chapterEnd = TimeSpan.FromSeconds(Math.Min(endSec, (int)vodLength.TotalSeconds));
+                        var gameName = chapter.details?.game?.displayName ?? chapter.description ?? game;
+
+                        var options = new VideoDownloadOptions
+                        {
+                            DownloadThreads = (int)numDownloadThreads.Value,
+                            ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                            Filename = Path.Combine(folder,
+                                FilenameService.GetFilename(Settings.Default.TemplateVod, textTitle.Text, currentVideoId.ToString(),
+                                    currentVideoTime, textStreamer.Text, streamerId,
+                                    chapterStart, chapterEnd, vodLength, viewCount, gameName) + $"_ch{i + 1:D2}" + ext),
+                            Oauth = Settings.Default.OAuth,
+                            Quality = quality,
+                            Id = currentVideoId,
+                            TrimBeginning = true,
+                            TrimBeginningTime = chapterStart,
+                            TrimEnding = true,
+                            TrimEndingTime = chapterEnd,
+                            FfmpegPath = "ffmpeg",
+                            TempFolder = Settings.Default.TempPath,
+                            TrimMode = trimMode
+                        };
+
+                        var task = new TwitchTasks.VodDownloadTask
+                        {
+                            DownloadOptions = options,
+                            Info =
+                            {
+                                Title = $"{textTitle.Text} — {gameName} (Ch. {i + 1})",
+                                Thumbnail = imgThumbnail.Source
+                            }
+                        };
+                        PageQueue.taskList.Add(task);
+                    }
+                }
+
+                // Navigate to queue to show the newly added tasks
+                if (Application.Current.MainWindow is MainWindow mw)
+                    mw.Main.Content = MainWindow.pageQueue;
+            }
+            catch (Exception ex)
+            {
+                AppendLog(Translations.Strings.ErrorLog + ex.Message);
+                MessageBox.Show(Application.Current.MainWindow!, "Failed to fetch chapters: " + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                btnGetInfo.IsEnabled = true;
+                SplitBtnDownload.IsEnabled = true;
+            }
+        }
+
+        private void BtnSyncToChat_Click(object sender, RoutedEventArgs e)
+        {
+            var chat = MainWindow.pageChatDownload;
+
+            // Copy URL
+            chat.textUrl.Text = textUrl.Text;
+
+            // Copy trim start
+            chat.CheckTrimStart.IsChecked = checkStart.IsChecked;
+            chat.numStartHour.Value = numStartHour.Value;
+            chat.numStartMinute.Value = numStartMinute.Value;
+            chat.numStartSecond.Value = numStartSecond.Value;
+
+            // Copy trim end
+            chat.CheckTrimEnd.IsChecked = checkEnd.IsChecked;
+            chat.numEndHour.Value = numEndHour.Value;
+            chat.numEndMinute.Value = numEndMinute.Value;
+            chat.numEndSecond.Value = numEndSecond.Value;
+
+            // Navigate to chat download page
+            if (Application.Current.MainWindow is MainWindow mw)
+                mw.Main.Content = MainWindow.pageChatDownload;
         }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -57,6 +57,18 @@ namespace TwitchDownloaderWPF.Properties {
                 this["FontSize"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public double UsernameFontScale {
+            get {
+                return ((double)(this["UsernameFontScale"]));
+            }
+            set {
+                this["UsernameFontScale"] = value;
+            }
+        }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
@@ -441,6 +453,18 @@ namespace TwitchDownloaderWPF.Properties {
                 this["UpgradeRequired"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool SettingsImported {
+            get {
+                return ((bool)(this["SettingsImported"]));
+            }
+            set {
+                this["SettingsImported"] = value;
+            }
+        }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
@@ -595,6 +619,114 @@ namespace TwitchDownloaderWPF.Properties {
             }
             set {
                 this["IgnoreUsersList"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string HighlightUsersList {
+            get {
+                return ((string)(this["HighlightUsersList"]));
+            }
+            set {
+                this["HighlightUsersList"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("255")]
+        public byte HighlightUsersColorR {
+            get {
+                return ((byte)(this["HighlightUsersColorR"]));
+            }
+            set {
+                this["HighlightUsersColorR"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("215")]
+        public byte HighlightUsersColorG {
+            get {
+                return ((byte)(this["HighlightUsersColorG"]));
+            }
+            set {
+                this["HighlightUsersColorG"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public byte HighlightUsersColorB {
+            get {
+                return ((byte)(this["HighlightUsersColorB"]));
+            }
+            set {
+                this["HighlightUsersColorB"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LiveMonitorChannels {
+            get {
+                return ((string)(this["LiveMonitorChannels"]));
+            }
+            set {
+                this["LiveMonitorChannels"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("60")]
+        public int LiveMonitorPollSeconds {
+            get {
+                return ((int)(this["LiveMonitorPollSeconds"]));
+            }
+            set {
+                this["LiveMonitorPollSeconds"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorDownloadChat {
+            get {
+                return ((bool)(this["LiveMonitorDownloadChat"]));
+            }
+            set {
+                this["LiveMonitorDownloadChat"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LiveMonitorFolder {
+            get {
+                return ((string)(this["LiveMonitorFolder"]));
+            }
+            set {
+                this["LiveMonitorFolder"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LiveMonitorQuality {
+            get {
+                return ((string)(this["LiveMonitorQuality"]));
+            }
+            set {
+                this["LiveMonitorQuality"] = value;
             }
         }
         
@@ -1026,6 +1158,42 @@ namespace TwitchDownloaderWPF.Properties {
             }
             set {
                 this["AvatarScale"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool NotifyOnTaskComplete {
+            get {
+                return ((bool)(this["NotifyOnTaskComplete"]));
+            }
+            set {
+                this["NotifyOnTaskComplete"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastEnqueuePresetName {
+            get {
+                return ((string)(this["LastEnqueuePresetName"]));
+            }
+            set {
+                this["LastEnqueuePresetName"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastRenderPresetName {
+            get {
+                return ((string)(this["LastRenderPresetName"]));
+            }
+            set {
+                this["LastRenderPresetName"] = value;
             }
         }
     }

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -708,13 +708,25 @@ namespace TwitchDownloaderWPF.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool LiveMonitorSplitChapters {
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorDownloadMode {
             get {
-                return ((bool)(this["LiveMonitorSplitChapters"]));
+                return ((int)(this["LiveMonitorDownloadMode"]));
             }
             set {
-                this["LiveMonitorSplitChapters"] = value;
+                this["LiveMonitorDownloadMode"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorAutoStart {
+            get {
+                return ((bool)(this["LiveMonitorAutoStart"]));
+            }
+            set {
+                this["LiveMonitorAutoStart"] = value;
             }
         }
 

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -708,6 +708,18 @@ namespace TwitchDownloaderWPF.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorSplitChapters {
+            get {
+                return ((bool)(this["LiveMonitorSplitChapters"]));
+            }
+            set {
+                this["LiveMonitorSplitChapters"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string LiveMonitorFolder {
             get {
@@ -729,7 +741,103 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LiveMonitorQuality"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorTrimBeginning {
+            get {
+                return ((bool)(this["LiveMonitorTrimBeginning"]));
+            }
+            set {
+                this["LiveMonitorTrimBeginning"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimBeginningHour {
+            get {
+                return ((int)(this["LiveMonitorTrimBeginningHour"]));
+            }
+            set {
+                this["LiveMonitorTrimBeginningHour"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimBeginningMinute {
+            get {
+                return ((int)(this["LiveMonitorTrimBeginningMinute"]));
+            }
+            set {
+                this["LiveMonitorTrimBeginningMinute"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimBeginningSecond {
+            get {
+                return ((int)(this["LiveMonitorTrimBeginningSecond"]));
+            }
+            set {
+                this["LiveMonitorTrimBeginningSecond"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorTrimEnding {
+            get {
+                return ((bool)(this["LiveMonitorTrimEnding"]));
+            }
+            set {
+                this["LiveMonitorTrimEnding"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimEndingHour {
+            get {
+                return ((int)(this["LiveMonitorTrimEndingHour"]));
+            }
+            set {
+                this["LiveMonitorTrimEndingHour"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimEndingMinute {
+            get {
+                return ((int)(this["LiveMonitorTrimEndingMinute"]));
+            }
+            set {
+                this["LiveMonitorTrimEndingMinute"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int LiveMonitorTrimEndingSecond {
+            get {
+                return ((int)(this["LiveMonitorTrimEndingSecond"]));
+            }
+            set {
+                this["LiveMonitorTrimEndingSecond"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -1316,5 +1316,29 @@ namespace TwitchDownloaderWPF.Properties {
                 this["LastRenderPresetName"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LiveMonitorAutoRender {
+            get {
+                return ((bool)(this["LiveMonitorAutoRender"]));
+            }
+            set {
+                this["LiveMonitorAutoRender"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LiveMonitorAutoRenderPreset {
+            get {
+                return ((string)(this["LiveMonitorAutoRenderPreset"]));
+            }
+            set {
+                this["LiveMonitorAutoRenderPreset"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -326,6 +326,12 @@
     <Setting Name="LastRenderPresetName" Type="System.String" Scope="User">
       <Value Profile="(Default)"></Value>
     </Setting>
+    <Setting Name="LiveMonitorAutoRender" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LiveMonitorAutoRenderPreset" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -11,6 +11,9 @@
     <Setting Name="FontSize" Type="System.Single" Scope="User">
       <Value Profile="(Default)">24</Value>
     </Setting>
+    <Setting Name="UsernameFontScale" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
     <Setting Name="Outline" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
@@ -107,6 +110,9 @@
     <Setting Name="UpgradeRequired" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="SettingsImported" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="ChatBadges" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -144,6 +150,33 @@
       <Value Profile="(Default)">System</Value>
     </Setting>
     <Setting Name="IgnoreUsersList" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="HighlightUsersList" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="HighlightUsersColorR" Type="System.Byte" Scope="User">
+      <Value Profile="(Default)">255</Value>
+    </Setting>
+    <Setting Name="HighlightUsersColorG" Type="System.Byte" Scope="User">
+      <Value Profile="(Default)">215</Value>
+    </Setting>
+    <Setting Name="HighlightUsersColorB" Type="System.Byte" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorChannels" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LiveMonitorPollSeconds" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">60</Value>
+    </Setting>
+    <Setting Name="LiveMonitorDownloadChat" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LiveMonitorFolder" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LiveMonitorQuality" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ChatBadgeMask" Type="System.Int32" Scope="User">
@@ -253,6 +286,15 @@
     </Setting>
     <Setting Name="AvatarScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
+    </Setting>
+    <Setting Name="NotifyOnTaskComplete" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LastEnqueuePresetName" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="LastRenderPresetName" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -173,7 +173,10 @@
     <Setting Name="LiveMonitorDownloadChat" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="LiveMonitorSplitChapters" Type="System.Boolean" Scope="User">
+    <Setting Name="LiveMonitorDownloadMode" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorAutoStart" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="LiveMonitorFolder" Type="System.String" Scope="User">

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -173,11 +173,38 @@
     <Setting Name="LiveMonitorDownloadChat" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LiveMonitorSplitChapters" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="LiveMonitorFolder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="LiveMonitorQuality" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LiveMonitorTrimBeginning" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimBeginningHour" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimBeginningMinute" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimBeginningSecond" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimEnding" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimEndingHour" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimEndingMinute" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LiveMonitorTrimEndingSecond" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="ChatBadgeMask" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>

--- a/TwitchDownloaderWPF/Services/ChatRenderPresetService.cs
+++ b/TwitchDownloaderWPF/Services/ChatRenderPresetService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using TwitchDownloaderWPF.Models;
+
+namespace TwitchDownloaderWPF.Services
+{
+    public static class ChatRenderPresetService
+    {
+        private static readonly string _filePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TwitchDownloaderWPF",
+            "ChatRenderPresets.json");
+
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        public static List<ChatRenderPreset> Load()
+        {
+            try
+            {
+                if (!File.Exists(_filePath))
+                    return new List<ChatRenderPreset>();
+
+                var json = File.ReadAllText(_filePath);
+                return JsonSerializer.Deserialize<List<ChatRenderPreset>>(json, _jsonOptions) ?? new List<ChatRenderPreset>();
+            }
+            catch
+            {
+                return new List<ChatRenderPreset>();
+            }
+        }
+
+        public static void Save(List<ChatRenderPreset> presets)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                var json = JsonSerializer.Serialize(presets, _jsonOptions);
+                File.WriteAllText(_filePath, json);
+            }
+            catch { /* Silently ignore save errors */ }
+        }
+
+        public static void AddOrUpdate(ChatRenderPreset preset)
+        {
+            var presets = Load();
+            var existing = presets.FindIndex(p => p.Name == preset.Name);
+            if (existing >= 0)
+                presets[existing] = preset;
+            else
+                presets.Add(preset);
+            Save(presets);
+        }
+
+        public static void Delete(string name)
+        {
+            var presets = Load();
+            presets.RemoveAll(p => p.Name == name);
+            Save(presets);
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Services/EnqueuePresetService.cs
+++ b/TwitchDownloaderWPF/Services/EnqueuePresetService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using TwitchDownloaderWPF.Models;
+
+namespace TwitchDownloaderWPF.Services
+{
+    public static class EnqueuePresetService
+    {
+        private static readonly string _filePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TwitchDownloaderWPF",
+            "EnqueuePresets.json");
+
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        public static List<EnqueuePreset> Load()
+        {
+            try
+            {
+                if (!File.Exists(_filePath))
+                    return new List<EnqueuePreset>();
+
+                var json = File.ReadAllText(_filePath);
+                return JsonSerializer.Deserialize<List<EnqueuePreset>>(json, _jsonOptions) ?? new List<EnqueuePreset>();
+            }
+            catch
+            {
+                return new List<EnqueuePreset>();
+            }
+        }
+
+        public static void Save(List<EnqueuePreset> presets)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                var json = JsonSerializer.Serialize(presets, _jsonOptions);
+                File.WriteAllText(_filePath, json);
+            }
+            catch { /* Silently ignore save errors */ }
+        }
+
+        public static void AddOrUpdate(EnqueuePreset preset)
+        {
+            var presets = Load();
+            var existing = presets.FindIndex(p => p.Name == preset.Name);
+            if (existing >= 0)
+                presets[existing] = preset;
+            else
+                presets.Add(preset);
+            Save(presets);
+        }
+
+        public static void Delete(string name)
+        {
+            var presets = Load();
+            presets.RemoveAll(p => p.Name == name);
+            Save(presets);
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Services/LiveMonitorChannelSettingsService.cs
+++ b/TwitchDownloaderWPF/Services/LiveMonitorChannelSettingsService.cs
@@ -2,40 +2,41 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using TwitchDownloaderWPF.Models;
 
 namespace TwitchDownloaderWPF.Services
 {
     /// <summary>
-    /// Persists per-channel render-preset overrides for the Live Monitor.
-    /// Key = channel login (lowercase), Value = render preset name.
+    /// Persists per-channel full settings profiles for the Live Monitor.
+    /// Key = channel login (lowercase), Value = full settings snapshot.
     /// </summary>
-    public static class LiveMonitorPresetService
+    public static class LiveMonitorChannelSettingsService
     {
         private static readonly string FilePath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "TwitchDownloaderWPF",
-            "LiveMonitorChannelPresets.json");
+            "LiveMonitorChannelSettings.json");
 
         private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
-        public static Dictionary<string, string> Load()
+        public static Dictionary<string, LiveMonitorChannelSettings> Load()
         {
             try
             {
                 if (!File.Exists(FilePath))
-                    return new Dictionary<string, string>();
+                    return new Dictionary<string, LiveMonitorChannelSettings>();
 
                 var json = File.ReadAllText(FilePath);
-                return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions)
-                       ?? new Dictionary<string, string>();
+                return JsonSerializer.Deserialize<Dictionary<string, LiveMonitorChannelSettings>>(json, JsonOptions)
+                       ?? new Dictionary<string, LiveMonitorChannelSettings>();
             }
             catch
             {
-                return new Dictionary<string, string>();
+                return new Dictionary<string, LiveMonitorChannelSettings>();
             }
         }
 
-        public static void Save(Dictionary<string, string> map)
+        public static void Save(Dictionary<string, LiveMonitorChannelSettings> map)
         {
             try
             {

--- a/TwitchDownloaderWPF/Services/LiveMonitorPresetService.cs
+++ b/TwitchDownloaderWPF/Services/LiveMonitorPresetService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace TwitchDownloaderWPF.Services
+{
+    /// <summary>
+    /// Persists per-channel render-preset overrides for the Live Monitor.
+    /// Key = channel login (lowercase), Value = render preset name.
+    /// </summary>
+    public static class LiveMonitorPresetService
+    {
+        private static readonly string FilePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TwitchDownloaderWPF",
+            "LiveMonitorChannelPresets.json");
+
+        private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+        public static Dictionary<string, string> Load()
+        {
+            try
+            {
+                if (!File.Exists(FilePath))
+                    return new Dictionary<string, string>();
+
+                var json = File.ReadAllText(FilePath);
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions)
+                       ?? new Dictionary<string, string>();
+            }
+            catch
+            {
+                return new Dictionary<string, string>();
+            }
+        }
+
+        public static void Save(Dictionary<string, string> map)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(FilePath)!;
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                File.WriteAllText(FilePath, JsonSerializer.Serialize(map, JsonOptions));
+            }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Services/NotificationService.cs
+++ b/TwitchDownloaderWPF/Services/NotificationService.cs
@@ -1,0 +1,16 @@
+using System.Windows;
+
+namespace TwitchDownloaderWPF.Services
+{
+    public static class NotificationService
+    {
+        public static void Show(string title, string message, bool isError)
+        {
+            Application.Current.Dispatcher.BeginInvoke(() =>
+            {
+                var toast = new WindowToast(title, message, isError);
+                toast.Show();
+            });
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -428,6 +428,24 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("ChatFontSize", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Username Size:.
+        /// </summary>
+        public static string ChatUsernameFontSize {
+            get {
+                return ResourceManager.GetString("ChatUsernameFontSize", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to the username font size tooltip.
+        /// </summary>
+        public static string ChatUsernameFontSizeTooltip {
+            get {
+                return ResourceManager.GetString("ChatUsernameFontSizeTooltip", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Height: ähnelt.
@@ -1344,6 +1362,24 @@ namespace TwitchDownloaderWPF.Translations {
         public static string IgnoreUsersListTooltip {
             get {
                 return ResourceManager.GetString("IgnoreUsersListTooltip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Highlight Users List .
+        /// </summary>
+        public static string HighlightUsersList {
+            get {
+                return ResourceManager.GetString("HighlightUsersList", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to the highlight users list tooltip.
+        /// </summary>
+        public static string HighlightUsersListTooltip {
+            get {
+                return ResourceManager.GetString("HighlightUsersListTooltip", resourceCulture);
             }
         }
         
@@ -2658,6 +2694,30 @@ namespace TwitchDownloaderWPF.Translations {
         public static string VerboseErrorOutput {
             get {
                 return ResourceManager.GetString("VerboseErrorOutput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tasks Still Running.
+        /// </summary>
+        public static string LiveMonitor {
+            get {
+                return ResourceManager.GetString("LiveMonitor", resourceCulture);
+            }
+        }
+
+        public static string ExitWhileRunningTitle {
+            get {
+                return ResourceManager.GetString("ExitWhileRunningTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to the exit-while-running confirmation.
+        /// </summary>
+        public static string ExitWhileRunningMessage {
+            get {
+                return ResourceManager.GetString("ExitWhileRunningMessage", resourceCulture);
             }
         }
         

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -179,6 +179,12 @@
   <data name="ChatFontSize" xml:space="preserve">
     <value>Font Size:</value>
   </data>
+  <data name="ChatUsernameFontSize" xml:space="preserve">
+    <value>Username Size:</value>
+  </data>
+  <data name="ChatUsernameFontSizeTooltip" xml:space="preserve">
+    <value>Username size relative to the message font size. 1.0 = same size as the message text, 2.0 = twice as large.</value>
+  </data>
   <data name="ChatHeight" xml:space="preserve">
     <value>Height:</value>
   </data>
@@ -311,6 +317,13 @@
   </data>
   <data name="IgnoreUsersListTooltip" xml:space="preserve">
     <value>List of usernames - comma separated, spaces around commas ignored, NOT case-sensitive.</value>
+  </data>
+  <data name="HighlightUsersList" xml:space="preserve">
+    <value>Highlight Users List </value>
+    <comment>Leave a trailing space</comment>
+  </data>
+  <data name="HighlightUsersListTooltip" xml:space="preserve">
+    <value>List of usernames whose names will be drawn in the chosen highlight color - comma separated, spaces around commas ignored, NOT case-sensitive.</value>
   </data>
   <data name="InvalidClipLinkId" xml:space="preserve">
     <value>Invalid Clip Link/ID</value>
@@ -540,6 +553,15 @@
   </data>
   <data name="UrlList" xml:space="preserve">
     <value>URL List</value>
+  </data>
+  <data name="LiveMonitor" xml:space="preserve">
+    <value>Live Monitor</value>
+  </data>
+  <data name="ExitWhileRunningTitle" xml:space="preserve">
+    <value>Tasks Still Running</value>
+  </data>
+  <data name="ExitWhileRunningMessage" xml:space="preserve">
+    <value>One or more downloads or renders are still in progress. If you exit now, they will be canceled and any partial files may be left behind.\n\nAre you sure you want to exit?</value>
   </data>
   <data name="VerboseErrorOutput" xml:space="preserve">
     <value>Verbose Error Output</value>
@@ -1036,6 +1058,12 @@
   </data>
   <data name="DelayDownload" xml:space="preserve">
     <value>Delay Download Until Broadcast Finished</value>
+  </data>
+  <data name="LiveDownload" xml:space="preserve">
+    <value>Live Download (record stream in real time)</value>
+  </data>
+  <data name="LiveDownloadTooltip" xml:space="preserve">
+    <value>Starts recording the live stream immediately and keeps recording until the broadcast ends or you cancel. If VODs are enabled on the channel, the stream's backlog (the portion that aired before you started recording) will also be downloaded automatically. Use this instead of "Delay Download Until Broadcast Finished" if you want a real-time recording rather than waiting for the full VOD afterward.</value>
   </data>
   <data name="ReduceMotion" xml:space="preserve">
     <value>Reduce Motion:</value>

--- a/TwitchDownloaderWPF/TwitchTasks/LiveStreamDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/LiveStreamDownloadTask.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderWPF.Utils;
+
+namespace TwitchDownloaderWPF.TwitchTasks
+{
+    internal class LiveStreamDownloadTask : TwitchTask
+    {
+        public LiveStreamDownloadOptions DownloadOptions { get; init; }
+        public override string TaskType { get; } = Translations.Strings.VodDownload;
+        public override string OutputFile => DownloadOptions.Filename;
+
+        public override void Reinitialize()
+        {
+            Progress = 0;
+            TokenSource = new CancellationTokenSource();
+            Exception = null;
+            CanReinitialize = false;
+            ChangeStatus(TwitchTaskStatus.Ready);
+        }
+
+        public override bool CanRun()
+        {
+            return Status == TwitchTaskStatus.Ready;
+        }
+
+        public override async Task RunAsync()
+        {
+            var progress = new WpfTaskProgress(i => Progress = i, s => DisplayStatus = s);
+
+            if (TokenSource.IsCancellationRequested)
+            {
+                TokenSource.Dispose();
+                ChangeStatus(TwitchTaskStatus.Canceled);
+                CanReinitialize = true;
+                return;
+            }
+
+            var downloader = new LiveStreamDownloader(DownloadOptions, progress);
+            ChangeStatus(TwitchTaskStatus.Running);
+
+            try
+            {
+                await downloader.DownloadAsync(TokenSource.Token);
+                if (TokenSource.IsCancellationRequested)
+                {
+                    ChangeStatus(TwitchTaskStatus.Canceled);
+                    CanReinitialize = true;
+                }
+                else
+                {
+                    progress.ReportProgress(100);
+                    ChangeStatus(TwitchTaskStatus.Finished);
+                }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException && TokenSource.IsCancellationRequested)
+            {
+                // The recording was stopped by the user - whatever was captured is kept.
+                ChangeStatus(TwitchTaskStatus.Canceled);
+                CanReinitialize = true;
+            }
+            catch (Exception ex)
+            {
+                ChangeStatus(TwitchTaskStatus.Failed);
+                Exception = ex;
+                CanReinitialize = true;
+            }
+            TokenSource.Dispose();
+            GC.Collect(-1, GCCollectionMode.Default, false);
+        }
+    }
+}

--- a/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/TwitchTask.cs
@@ -111,6 +111,14 @@ namespace TwitchDownloaderWPF.TwitchTasks
                     _ => null
                 };
             }
+
+            if (Settings.Default.NotifyOnTaskComplete)
+            {
+                if (newStatus == TwitchTaskStatus.Finished)
+                    NotificationService.Show(Info.Title ?? TaskType, "Download complete", false);
+                else if (newStatus == TwitchTaskStatus.Failed)
+                    NotificationService.Show(Info.Title ?? TaskType, "Task failed", true);
+            }
         }
 
         protected async Task<bool> DelayUntilVideoOffline(long videoId, ITaskLogger logger)

--- a/TwitchDownloaderWPF/WindowInputText.xaml
+++ b/TwitchDownloaderWPF/WindowInputText.xaml
@@ -1,0 +1,20 @@
+<Window x:Class="TwitchDownloaderWPF.WindowInputText"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Input"
+        WindowStyle="SingleBorderWindow"
+        ResizeMode="NoResize"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        MinWidth="300"
+        Background="{DynamicResource AppBackground}">
+    <StackPanel Margin="12">
+        <TextBlock x:Name="TextPrompt" Margin="0,0,0,6" Foreground="{DynamicResource AppText}" TextWrapping="Wrap"/>
+        <TextBox x:Name="TextInputBox" MinWidth="260" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" KeyDown="TextInput_KeyDown"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Content="OK" Width="70" Margin="0,0,6,0" IsDefault="True" Click="BtnOk_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button Content="Cancel" Width="70" IsCancel="True" Click="BtnCancel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/TwitchDownloaderWPF/WindowInputText.xaml.cs
+++ b/TwitchDownloaderWPF/WindowInputText.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace TwitchDownloaderWPF
+{
+    public partial class WindowInputText : Window
+    {
+        public string InputValue { get; private set; } = "";
+
+        public WindowInputText(string title, string prompt, string defaultValue = "")
+        {
+            InitializeComponent();
+            Title = title;
+            TextPrompt.Text = prompt;
+            TextInputBox.Text = defaultValue;
+            TextInputBox.SelectAll();
+        }
+
+        protected override void OnContentRendered(System.EventArgs e)
+        {
+            base.OnContentRendered(e);
+            TextInputBox.Focus();
+        }
+
+        private void BtnOk_Click(object sender, RoutedEventArgs e)
+        {
+            InputValue = TextInputBox.Text.Trim();
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void TextInput_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                InputValue = TextInputBox.Text.Trim();
+                DialogResult = true;
+            }
+        }
+    }
+}

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -10,7 +10,7 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
         lex:ResxLocalizationProvider.DefaultDictionary="Strings"
         mc:Ignorable="d"
-        Title="{lex:Loc TitleEnqueueOptions}" MinHeight="300" Height="300" MinWidth="500" Width="500" SizeToContent="WidthAndHeight" SourceInitialized="Window_OnSourceInitialized" Background="{DynamicResource AppBackground}">
+        Title="{lex:Loc TitleEnqueueOptions}" MinHeight="300" Height="300" MinWidth="500" Width="500" SizeToContent="WidthAndHeight" SourceInitialized="Window_OnSourceInitialized" Loaded="WindowQueueOptions_Loaded" Background="{DynamicResource AppBackground}">
     <Window.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="behave:TextBoxTripleClickBehavior.TripleClickSelectLine" Value="True" />
@@ -28,6 +28,12 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Vertical" Grid.Column="1" Grid.Row="1">
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
+                <TextBlock Text="Preset:" Margin="0,5,5,0" Foreground="{DynamicResource AppText}"/>
+                <ComboBox x:Name="comboPresets" Width="200" Margin="0,0,5,0" SelectionChanged="ComboPresets_SelectionChanged" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}" DisplayMemberPath="Name"/>
+                <Button Content="Save" Width="50" Margin="0,0,4,0" Click="BtnSavePreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <Button Content="Delete" Width="55" Click="BtnDeletePreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </StackPanel>
             <WrapPanel Orientation="Horizontal">
                 <TextBlock Text="{lex:Loc DownloadFolder}" HorizontalAlignment="Left" Margin="0,6,0,0" VerticalAlignment="Top" Foreground="{DynamicResource AppText}"/>
                 <TextBox x:Name="textFolder" HorizontalAlignment="Left" Height="23" Margin="3,0,0,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" MinWidth="300" TextChanged="TextFolder_OnTextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
@@ -48,7 +54,9 @@
                     <ComboBoxItem Content="Worst" />
                 </ComboBox>
             </StackPanel>
-            <CheckBox x:Name="checkDelay" Content="{lex:Loc DelayDownload}" HorizontalAlignment="Left" Margin="25,0,0,0" VerticalAlignment="Top" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" IsEnabled="False" />
+            <CheckBox x:Name="checkDelay" Content="{lex:Loc DelayDownload}" HorizontalAlignment="Left" Margin="25,0,0,0" VerticalAlignment="Top" Checked="checkDelay_Checked" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" IsEnabled="False" />
+            <CheckBox x:Name="checkLive" Content="{lex:Loc LiveDownload}" ToolTip="{lex:Loc LiveDownloadTooltip}" HorizontalAlignment="Left" Margin="25,2,0,0" VerticalAlignment="Top" Checked="checkLive_Checked" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" IsEnabled="False" />
+            <CheckBox x:Name="checkSplitByChapters" Content="Split by chapters" HorizontalAlignment="Left" Margin="25,2,0,0" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <CheckBox x:Name="checkChat" Content="{lex:Loc DownloadChat}" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Checked="checkChat_Checked" Unchecked="checkChat_Unchecked" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <StackPanel Margin="20,0,0,0">
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -10,6 +11,7 @@ using TwitchDownloaderCore;
 using TwitchDownloaderCore.Models;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Services;
+using TwitchDownloaderWPF.Models;
 using TwitchDownloaderWPF.Properties;
 using TwitchDownloaderWPF.Services;
 using TwitchDownloaderWPF.TwitchTasks;
@@ -25,6 +27,8 @@ namespace TwitchDownloaderWPF
 
         private readonly List<TaskData> _dataList;
         private readonly Page _parentPage;
+        private bool _applyingPreset = false;
+        private bool _isVodSource = false;
 
         public WindowQueueOptions(Page page)
         {
@@ -32,26 +36,32 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
 
             textFolder.Text = Settings.Default.QueueFolder;
+            LoadPresets();
 
             TextPreferredQuality.Visibility = Visibility.Collapsed;
             ComboPreferredQuality.Visibility = Visibility.Collapsed;
 
             if (page is PageVodDownload)
             {
+                _isVodSource = true;
                 checkVideo.IsChecked = true;
                 checkVideo.IsEnabled = false;
+                checkDelay.IsEnabled = true;
+                checkLive.IsEnabled = true;
             }
             else if (page is PageClipDownload)
             {
                 checkVideo.IsChecked = true;
                 checkVideo.IsEnabled = false;
                 checkDelay.Visibility = Visibility.Collapsed;
+                checkLive.Visibility = Visibility.Collapsed;
                 checkDelayChat.Visibility = Visibility.Collapsed;
             }
             else if (page is PageChatDownload chatPage)
             {
                 checkVideo.Visibility = Visibility.Collapsed;
                 checkDelay.Visibility = Visibility.Collapsed;
+                checkLive.Visibility = Visibility.Collapsed;
                 checkChat.IsChecked = true;
                 checkChat.IsEnabled = false;
                 TextDownloadFormat.Visibility = Visibility.Collapsed;
@@ -77,6 +87,7 @@ namespace TwitchDownloaderWPF
             {
                 checkVideo.Visibility = Visibility.Collapsed;
                 checkDelay.Visibility = Visibility.Collapsed;
+                checkLive.Visibility = Visibility.Collapsed;
                 checkChat.Visibility = Visibility.Collapsed;
                 TextDownloadFormat.Visibility = Visibility.Collapsed;
                 radioJson.Visibility = Visibility.Collapsed;
@@ -94,6 +105,7 @@ namespace TwitchDownloaderWPF
             {
                 checkVideo.Visibility = Visibility.Collapsed;
                 checkDelay.Visibility = Visibility.Collapsed;
+                checkLive.Visibility = Visibility.Collapsed;
                 checkChat.Visibility = Visibility.Collapsed;
                 TextDownloadFormat.Visibility = Visibility.Collapsed;
                 radioJson.Visibility = Visibility.Collapsed;
@@ -116,6 +128,7 @@ namespace TwitchDownloaderWPF
             InitializeComponent();
 
             textFolder.Text = Settings.Default.QueueFolder;
+            LoadPresets();
 
             if (_dataList.Any(x => !x.Id.All(char.IsDigit)))
             {
@@ -126,10 +139,18 @@ namespace TwitchDownloaderWPF
             if (_dataList.Any(x => x.Id.All(char.IsDigit)))
             {
                 ComboPreferredQuality.Items.Add(new ComboBoxItem { Content = "Audio Only" });
+
+                checkVideo.IsChecked = true;
+                checkDelay.Visibility = Visibility.Visible;
+                checkDelay.IsEnabled = true;
+                checkLive.Visibility = Visibility.Visible;
+                checkLive.IsEnabled = true;
+                ComboPreferredQuality.IsEnabled = true;
             }
             else
             {
                 checkDelay.Visibility = Visibility.Collapsed;
+                checkLive.Visibility = Visibility.Collapsed;
             }
 
             var preferredQuality = Settings.Default.PreferredQuality;
@@ -148,12 +169,121 @@ namespace TwitchDownloaderWPF
             return Dispatcher.Invoke(() => FileCollisionService.HandleCollisionCallback(fileInfo, Application.Current.MainWindow));
         }
 
-        private void btnQueue_Click(object sender, RoutedEventArgs e)
+        private async void btnQueue_Click(object sender, RoutedEventArgs e)
         {
             if (_parentPage != null)
             {
                 if (_parentPage is PageVodDownload vodDownloadPage)
                 {
+                    // Handle Split by Chapters
+                    if (checkSplitByChapters.IsChecked == true)
+                    {
+                        string chaptersFolder = textFolder.Text;
+                        if (!Directory.Exists(chaptersFolder))
+                        {
+                            try { TwitchHelper.CreateDirectory(chaptersFolder); }
+                            catch (Exception ex)
+                            {
+                                MessageBox.Show(this, Translations.Strings.InvalidFolderPathMessage, Translations.Strings.InvalidFolderPath, MessageBoxButton.OK, MessageBoxImage.Error);
+                                if (Settings.Default.VerboseErrors)
+                                    MessageBox.Show(this, ex.ToString(), Translations.Strings.VerboseErrorOutput, MessageBoxButton.OK, MessageBoxImage.Error);
+                                return;
+                            }
+                        }
+
+                        if (vodDownloadPage.currentVideoId == 0)
+                        {
+                            MessageBox.Show(this, "Please load a VOD first.", "No VOD Loaded", MessageBoxButton.OK, MessageBoxImage.Information);
+                            return;
+                        }
+
+                        try
+                        {
+                            btnQueue.IsEnabled = false;
+                            var videoInfo = new TwitchDownloaderCore.TwitchObjects.Gql.VideoInfo
+                            {
+                                lengthSeconds = (int)vodDownloadPage.vodLength.TotalSeconds,
+                                game = new TwitchDownloaderCore.TwitchObjects.Gql.Game { displayName = vodDownloadPage.game }
+                            };
+
+                            var chapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(vodDownloadPage.currentVideoId, videoInfo);
+                            var chapters = chapterResponse.data.video.moments.edges;
+
+                            if (chapters.Count == 0)
+                            {
+                                MessageBox.Show(this, "Could not retrieve chapter data for this VOD.", "No Chapters", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                return;
+                            }
+
+                            VideoDownloadOptions baseOptions = vodDownloadPage.GetOptions(null, textFolder.Text);
+                            baseOptions.DelayDownload = checkDelay.IsChecked.GetValueOrDefault();
+                            baseOptions.FileCollisionCallback = HandleFileCollisionCallback;
+
+                            string quality = baseOptions.Quality;
+                            string ext = TwitchDownloaderCore.Services.FilenameService.GuessVodFileExtension(quality);
+
+                            lock (PageQueue.taskLock)
+                            {
+                                for (int i = 0; i < chapters.Count; i++)
+                                {
+                                    var chapter = chapters[i].node;
+                                    var startSec = chapter.positionMilliseconds / 1000;
+                                    var endSec = startSec + chapter.durationMilliseconds / 1000;
+                                    var chapterStart = TimeSpan.FromSeconds(startSec);
+                                    var chapterEnd = TimeSpan.FromSeconds(Math.Min(endSec, (int)vodDownloadPage.vodLength.TotalSeconds));
+                                    var gameName = chapter.details?.game?.displayName ?? chapter.description ?? vodDownloadPage.game;
+
+                                    var options = new VideoDownloadOptions
+                                    {
+                                        DownloadThreads = baseOptions.DownloadThreads,
+                                        ThrottleKib = baseOptions.ThrottleKib,
+                                        Oauth = baseOptions.Oauth,
+                                        Quality = quality,
+                                        Id = vodDownloadPage.currentVideoId,
+                                        TrimBeginning = true,
+                                        TrimBeginningTime = chapterStart,
+                                        TrimEnding = true,
+                                        TrimEndingTime = chapterEnd,
+                                        FfmpegPath = "ffmpeg",
+                                        TempFolder = Settings.Default.TempPath,
+                                        TrimMode = baseOptions.TrimMode,
+                                        DelayDownload = checkDelay.IsChecked.GetValueOrDefault(),
+                                        FileCollisionCallback = HandleFileCollisionCallback,
+                                    };
+                                    options.Filename = Path.Combine(chaptersFolder,
+                                        TwitchDownloaderCore.Services.FilenameService.GetFilename(Settings.Default.TemplateVod,
+                                            vodDownloadPage.textTitle.Text, vodDownloadPage.currentVideoId.ToString(),
+                                            vodDownloadPage.currentVideoTime, vodDownloadPage.textStreamer.Text, vodDownloadPage.streamerId,
+                                            chapterStart, chapterEnd, vodDownloadPage.vodLength, vodDownloadPage.viewCount, gameName)
+                                        + $"_ch{i + 1:D2}" + ext);
+
+                                    var task = new TwitchTasks.VodDownloadTask
+                                    {
+                                        DownloadOptions = options,
+                                        Info =
+                                        {
+                                            Title = $"{vodDownloadPage.textTitle.Text} — {gameName} (Ch. {i + 1})",
+                                            Thumbnail = vodDownloadPage.imgThumbnail.Source
+                                        }
+                                    };
+                                    PageQueue.taskList.Add(task);
+                                }
+                            }
+
+                            this.Close();
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(this, "Failed to fetch chapters: " + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            return;
+                        }
+                        finally
+                        {
+                            btnQueue.IsEnabled = true;
+                        }
+                    }
+
                     string folderPath = textFolder.Text;
                     if (!Directory.Exists(folderPath))
                     {
@@ -178,19 +308,51 @@ namespace TwitchDownloaderWPF
                     downloadOptions.DelayDownload = checkDelay.IsChecked.GetValueOrDefault();
                     downloadOptions.FileCollisionCallback = HandleFileCollisionCallback;
 
-                    VodDownloadTask downloadTask = new VodDownloadTask
+                    if (checkLive.IsChecked.GetValueOrDefault())
                     {
-                        DownloadOptions = downloadOptions,
-                        Info =
+                        var liveOptions = new LiveStreamDownloadOptions
                         {
-                            Title = vodDownloadPage.textTitle.Text,
-                            Thumbnail = vodDownloadPage.imgThumbnail.Source
-                        }
-                    };
+                            Id = downloadOptions.Id,
+                            Quality = downloadOptions.Quality,
+                            Filename = downloadOptions.Filename,
+                            Oauth = Settings.Default.OAuth,
+                            FfmpegPath = "ffmpeg",
+                            DownloadThreads = downloadOptions.DownloadThreads,
+                            ThrottleKib = downloadOptions.ThrottleKib,
+                            TempFolder = downloadOptions.TempFolder,
+                        };
 
-                    lock (PageQueue.taskLock)
+                        var liveTask = new LiveStreamDownloadTask
+                        {
+                            DownloadOptions = liveOptions,
+                            Info =
+                            {
+                                Title = vodDownloadPage.textTitle.Text,
+                                Thumbnail = vodDownloadPage.imgThumbnail.Source
+                            }
+                        };
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(liveTask);
+                        }
+                    }
+                    else
                     {
-                        PageQueue.taskList.Add(downloadTask);
+                        VodDownloadTask downloadTask = new VodDownloadTask
+                        {
+                            DownloadOptions = downloadOptions,
+                            Info =
+                            {
+                                Title = vodDownloadPage.textTitle.Text,
+                                Thumbnail = vodDownloadPage.imgThumbnail.Source
+                            }
+                        };
+
+                        lock (PageQueue.taskLock)
+                        {
+                            PageQueue.taskList.Add(downloadTask);
+                        }
                     }
 
                     if (checkChat.IsChecked.GetValueOrDefault())
@@ -302,6 +464,7 @@ namespace TwitchDownloaderWPF
                             clipDownloadPage.currentVideoTime, clipDownloadPage.textStreamer.Text, clipDownloadPage.streamerId, TimeSpan.Zero, clipDownloadPage.clipLength,
                             clipDownloadPage.clipLength, clipDownloadPage.viewCount, clipDownloadPage.game, clipDownloadPage.clipperName, clipDownloadPage.clipperId) + ".mp4"),
                         Id = clipDownloadPage.clipId,
+                        Oauth = Settings.Default.OAuth,
                         Quality = clipDownloadPage.comboQuality.Text,
                         ThrottleKib = Settings.Default.DownloadThrottleEnabled
                             ? Settings.Default.MaximumBandwidthKib
@@ -576,11 +739,11 @@ namespace TwitchDownloaderWPF
             }
             else if (_dataList.Count > 0)
             {
-                EnqueueDataList();
+                await EnqueueDataList();
             }
         }
 
-        private void EnqueueDataList()
+        private async Task EnqueueDataList()
         {
             string folderPath = textFolder.Text;
             if (!Directory.Exists(folderPath))
@@ -608,12 +771,77 @@ namespace TwitchDownloaderWPF
                 {
                     if (taskData.Id.All(char.IsDigit))
                     {
+                        long vodId = long.Parse(taskData.Id);
+                        string quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string;
+                        string ext = FilenameService.GuessVodFileExtension(quality);
+                        var vodLength = TimeSpan.FromSeconds(taskData.Length);
+
+                        if (checkSplitByChapters.IsChecked == true && !checkLive.IsChecked.GetValueOrDefault())
+                        {
+                            try
+                            {
+                                var videoInfo = new TwitchDownloaderCore.TwitchObjects.Gql.VideoInfo
+                                {
+                                    lengthSeconds = taskData.Length,
+                                    game = new TwitchDownloaderCore.TwitchObjects.Gql.Game { displayName = taskData.Game }
+                                };
+                                var chapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(vodId, videoInfo);
+                                var chapters = chapterResponse.data.video.moments.edges;
+
+                                lock (PageQueue.taskLock)
+                                {
+                                    for (int i = 0; i < chapters.Count; i++)
+                                    {
+                                        var chapter = chapters[i].node;
+                                        var startSec = chapter.positionMilliseconds / 1000;
+                                        var endSec = startSec + chapter.durationMilliseconds / 1000;
+                                        var chapterStart = TimeSpan.FromSeconds(startSec);
+                                        var chapterEnd = TimeSpan.FromSeconds(Math.Min(endSec, taskData.Length));
+                                        var gameName = chapter.details?.game?.displayName ?? chapter.description ?? taskData.Game;
+
+                                        var options = new VideoDownloadOptions
+                                        {
+                                            Oauth = Settings.Default.OAuth,
+                                            TempFolder = Settings.Default.TempPath,
+                                            Id = vodId,
+                                            Quality = quality,
+                                            FfmpegPath = "ffmpeg",
+                                            TrimBeginning = true,
+                                            TrimBeginningTime = chapterStart,
+                                            TrimEnding = true,
+                                            TrimEndingTime = chapterEnd,
+                                            TrimMode = VideoTrimMode.Safe,
+                                            DownloadThreads = Settings.Default.VodDownloadThreads,
+                                            ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                                            FileCollisionCallback = HandleFileCollisionCallback,
+                                            DelayDownload = checkDelay.IsChecked.GetValueOrDefault(),
+                                            Filename = Path.Combine(folderPath,
+                                                FilenameService.GetFilename(Settings.Default.TemplateVod, taskData.Title, taskData.Id, taskData.Time, taskData.StreamerName, taskData.StreamerId,
+                                                    chapterStart, chapterEnd, vodLength, taskData.Views, gameName)
+                                                + $"_ch{i + 1:D2}" + ext)
+                                        };
+
+                                        PageQueue.taskList.Add(new VodDownloadTask
+                                        {
+                                            DownloadOptions = options,
+                                            Info = { Title = $"{taskData.Title} — {gameName} (Ch. {i + 1})", Thumbnail = taskData.Thumbnail }
+                                        });
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                MessageBox.Show(this, $"Failed to fetch chapters for {taskData.Title}: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            }
+                            continue;
+                        }
+
                         VideoDownloadOptions downloadOptions = new VideoDownloadOptions
                         {
                             Oauth = Settings.Default.OAuth,
                             TempFolder = Settings.Default.TempPath,
-                            Id = long.Parse(taskData.Id),
-                            Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
+                            Id = vodId,
+                            Quality = quality,
                             FfmpegPath = "ffmpeg",
                             TrimBeginning = false,
                             TrimEnding = false,
@@ -626,22 +854,54 @@ namespace TwitchDownloaderWPF
                         };
                         downloadOptions.Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateVod, taskData.Title, taskData.Id, taskData.Time, taskData.StreamerName, taskData.StreamerId,
                             downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero,
-                            downloadOptions.TrimEnding ? downloadOptions.TrimEndingTime : TimeSpan.FromSeconds(taskData.Length),
-                            TimeSpan.FromSeconds(taskData.Length), taskData.Views, taskData.Game) + FilenameService.GuessVodFileExtension(downloadOptions.Quality));
+                            downloadOptions.TrimEnding ? downloadOptions.TrimEndingTime : vodLength,
+                            vodLength, taskData.Views, taskData.Game) + ext);
 
-                        VodDownloadTask downloadTask = new VodDownloadTask
+                        if (checkLive.IsChecked.GetValueOrDefault())
                         {
-                            DownloadOptions = downloadOptions,
-                            Info =
+                            var liveOptions = new LiveStreamDownloadOptions
                             {
-                                Title = taskData.Title,
-                                Thumbnail = taskData.Thumbnail
-                            }
-                        };
+                                Id = downloadOptions.Id,
+                                Quality = downloadOptions.Quality,
+                                Filename = downloadOptions.Filename,
+                                Oauth = Settings.Default.OAuth,
+                                FfmpegPath = "ffmpeg",
+                                DownloadThreads = downloadOptions.DownloadThreads,
+                                ThrottleKib = downloadOptions.ThrottleKib,
+                                TempFolder = downloadOptions.TempFolder,
+                            };
 
-                        lock (PageQueue.taskLock)
+                            var liveTask = new LiveStreamDownloadTask
+                            {
+                                DownloadOptions = liveOptions,
+                                Info =
+                                {
+                                    Title = taskData.Title,
+                                    Thumbnail = taskData.Thumbnail
+                                }
+                            };
+
+                            lock (PageQueue.taskLock)
+                            {
+                                PageQueue.taskList.Add(liveTask);
+                            }
+                        }
+                        else
                         {
-                            PageQueue.taskList.Add(downloadTask);
+                            VodDownloadTask downloadTask = new VodDownloadTask
+                            {
+                                DownloadOptions = downloadOptions,
+                                Info =
+                                {
+                                    Title = taskData.Title,
+                                    Thumbnail = taskData.Thumbnail
+                                }
+                            };
+
+                            lock (PageQueue.taskLock)
+                            {
+                                PageQueue.taskList.Add(downloadTask);
+                            }
                         }
                     }
                     else
@@ -649,6 +909,7 @@ namespace TwitchDownloaderWPF
                         ClipDownloadOptions downloadOptions = new ClipDownloadOptions
                         {
                             Id = taskData.Id,
+                            Oauth = Settings.Default.OAuth,
                             Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
                             Filename = Path.Combine(folderPath, FilenameService.GetFilename(Settings.Default.TemplateClip, taskData.Title, taskData.Id, taskData.Time, taskData.StreamerName, taskData.StreamerId,
                                 TimeSpan.Zero, TimeSpan.FromSeconds(taskData.Length), TimeSpan.FromSeconds(taskData.Length), taskData.Views, taskData.Game, taskData.ClipperName, taskData.ClipperId) + ".mp4"),
@@ -860,12 +1121,29 @@ namespace TwitchDownloaderWPF
             App.RequestTitleBarChange();
         }
 
+        private void WindowQueueOptions_Loaded(object sender, RoutedEventArgs e)
+        {
+        }
+
+        private void checkDelay_Checked(object sender, RoutedEventArgs e)
+        {
+            if (IsInitialized && checkLive.IsChecked.GetValueOrDefault())
+                checkLive.IsChecked = false;
+        }
+
+        private void checkLive_Checked(object sender, RoutedEventArgs e)
+        {
+            if (IsInitialized && checkDelay.IsChecked.GetValueOrDefault())
+                checkDelay.IsChecked = false;
+        }
+
         private void CheckVideo_OnChecked(object sender, RoutedEventArgs e)
         {
             if (this.IsInitialized)
             {
                 ComboPreferredQuality.IsEnabled = checkVideo.IsChecked.GetValueOrDefault();
                 checkDelay.IsEnabled = checkVideo.IsChecked.GetValueOrDefault();
+                checkLive.IsEnabled = checkVideo.IsChecked.GetValueOrDefault();
                 try
                 {
                     var newBrush = (Brush)Application.Current.Resources[checkVideo.IsChecked.GetValueOrDefault() ? "AppText" : "AppTextDisabled"];
@@ -891,7 +1169,174 @@ namespace TwitchDownloaderWPF
             if (!IsInitialized)
                 return;
 
-            CheckBttvEmbed.IsEnabled = CheckFfzEmbed.IsEnabled = CheckStvEmbed.IsEnabled = checkEmbed.IsChecked.GetValueOrDefault();
+            bool embedEnabled = checkEmbed.IsChecked.GetValueOrDefault();
+            CheckBttvEmbed.IsEnabled = CheckFfzEmbed.IsEnabled = CheckStvEmbed.IsEnabled = embedEnabled;
+            CheckBttvEmbed.IsChecked = CheckFfzEmbed.IsChecked = CheckStvEmbed.IsChecked = embedEnabled;
+        }
+
+        private void LoadPresets()
+        {
+            EnqueuePreset presetToApply = null;
+            _applyingPreset = true;
+            try
+            {
+                var presets = EnqueuePresetService.Load();
+                comboPresets.ItemsSource = presets;
+                comboPresets.SelectedIndex = -1;
+                var lastName = Settings.Default.LastEnqueuePresetName;
+                if (!string.IsNullOrEmpty(lastName))
+                {
+                    var idx = presets.FindIndex(p => p.Name == lastName);
+                    if (idx >= 0)
+                    {
+                        comboPresets.SelectedIndex = idx;
+                        presetToApply = presets[idx];
+                    }
+                }
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+
+            if (presetToApply != null)
+                ApplyPreset(presetToApply);
+        }
+
+        private void ComboPresets_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_applyingPreset || !IsInitialized)
+                return;
+
+            if (comboPresets.SelectedItem is EnqueuePreset preset)
+            {
+                ApplyPreset(preset);
+                Settings.Default.LastEnqueuePresetName = preset.Name;
+                Settings.Default.Save();
+            }
+        }
+
+        private void ApplyPreset(EnqueuePreset preset)
+        {
+            _applyingPreset = true;
+            try
+            {
+                if (preset.Folder != null)
+                    textFolder.Text = preset.Folder;
+
+                if (preset.Quality != null && ComboPreferredQuality.Visibility == Visibility.Visible)
+                {
+                    for (int i = 0; i < ComboPreferredQuality.Items.Count; i++)
+                    {
+                        if (ComboPreferredQuality.Items[i] is ComboBoxItem { Content: string q } && q == preset.Quality)
+                        {
+                            ComboPreferredQuality.SelectedIndex = i;
+                            break;
+                        }
+                    }
+                }
+
+                if (checkDelay.Visibility == Visibility.Visible && checkDelay.IsEnabled)
+                    checkDelay.IsChecked = preset.DelayDownload;
+
+                if (checkLive.Visibility == Visibility.Visible && checkLive.IsEnabled)
+                    checkLive.IsChecked = preset.LiveDownload;
+
+                if (checkChat.Visibility == Visibility.Visible && checkChat.IsEnabled)
+                    checkChat.IsChecked = preset.DownloadChat;
+
+                if (radioJson.Visibility == Visibility.Visible)
+                {
+                    radioJson.IsChecked = preset.ChatFormat == "JSON";
+                    radioTxt.IsChecked = preset.ChatFormat == "TXT";
+                    radioHTML.IsChecked = preset.ChatFormat == "HTML";
+                }
+
+                if (RadioCompressionGzip.Visibility == Visibility.Visible)
+                    RadioCompressionGzip.IsChecked = preset.ChatCompressGzip;
+
+                if (checkEmbed.Visibility == Visibility.Visible)
+                    checkEmbed.IsChecked = preset.EmbedImages;
+
+                if (CheckBttvEmbed.Visibility == Visibility.Visible)
+                    CheckBttvEmbed.IsChecked = preset.EmbedBttv;
+
+                if (CheckFfzEmbed.Visibility == Visibility.Visible)
+                    CheckFfzEmbed.IsChecked = preset.EmbedFfz;
+
+                if (CheckStvEmbed.Visibility == Visibility.Visible)
+                    CheckStvEmbed.IsChecked = preset.EmbedStv;
+
+                if (checkDelayChat.Visibility == Visibility.Visible && checkDelayChat.IsEnabled)
+                    checkDelayChat.IsChecked = preset.DelayChat;
+
+                if (checkRender.Visibility == Visibility.Visible && checkRender.IsEnabled)
+                    checkRender.IsChecked = preset.RenderChat;
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+        }
+
+        private EnqueuePreset GetCurrentPreset()
+        {
+            return new EnqueuePreset
+            {
+                Folder = textFolder.Text,
+                Quality = (ComboPreferredQuality.SelectedItem as ComboBoxItem)?.Content as string,
+                DelayDownload = checkDelay.IsChecked.GetValueOrDefault(),
+                LiveDownload = checkLive.IsChecked.GetValueOrDefault(),
+                DownloadChat = checkChat.IsChecked.GetValueOrDefault(),
+                ChatFormat = radioTxt.IsChecked == true ? "TXT" : radioHTML.IsChecked == true ? "HTML" : "JSON",
+                ChatCompressGzip = RadioCompressionGzip.IsChecked.GetValueOrDefault(),
+                EmbedImages = checkEmbed.IsChecked.GetValueOrDefault(),
+                EmbedBttv = CheckBttvEmbed.IsChecked.GetValueOrDefault(),
+                EmbedFfz = CheckFfzEmbed.IsChecked.GetValueOrDefault(),
+                EmbedStv = CheckStvEmbed.IsChecked.GetValueOrDefault(),
+                DelayChat = checkDelayChat.IsChecked.GetValueOrDefault(),
+                RenderChat = checkRender.IsChecked.GetValueOrDefault(),
+            };
+        }
+
+        private void BtnSavePreset_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new WindowInputText("Save Preset", "Enter a name for this preset:", (comboPresets.SelectedItem as EnqueuePreset)?.Name ?? "")
+            {
+                Owner = this
+            };
+
+            if (dialog.ShowDialog() != true || string.IsNullOrWhiteSpace(dialog.InputValue))
+                return;
+
+            var preset = GetCurrentPreset();
+            preset.Name = dialog.InputValue;
+            EnqueuePresetService.AddOrUpdate(preset);
+
+            LoadPresets();
+
+            // Re-select the saved preset
+            var presets = EnqueuePresetService.Load();
+            var savedIndex = presets.FindIndex(p => p.Name == preset.Name);
+            if (savedIndex >= 0)
+            {
+                _applyingPreset = true;
+                comboPresets.SelectedIndex = savedIndex;
+                _applyingPreset = false;
+            }
+        }
+
+        private void BtnDeletePreset_Click(object sender, RoutedEventArgs e)
+        {
+            if (comboPresets.SelectedItem is not EnqueuePreset preset)
+                return;
+
+            var result = MessageBox.Show(this, $"Delete preset '{preset.Name}'?", "Delete Preset", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (result != MessageBoxResult.Yes)
+                return;
+
+            EnqueuePresetService.Delete(preset.Name);
+            LoadPresets();
         }
     }
 }

--- a/TwitchDownloaderWPF/WindowSettings.xaml
+++ b/TwitchDownloaderWPF/WindowSettings.xaml
@@ -48,6 +48,10 @@
                 <CheckBox x:Name="CheckReduceMotion" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckReduceMotion_OnCheckedChanged" Unchecked="CheckReduceMotion_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
+                <TextBlock Margin="3,4,3,3" Text="Notify on task complete" Foreground="{DynamicResource AppText}" />
+                <CheckBox x:Name="CheckNotifyOnTaskComplete" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,2,0,0" Checked="CheckNotifyOnTaskComplete_OnCheckedChanged" Unchecked="CheckNotifyOnTaskComplete_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,3,3,4" Text="{lex:Loc SettingsTimeFormat}" Foreground="{DynamicResource AppText}" />
                 <RadioButton x:Name="RadioTimeFormatUtc" Content="{lex:Loc TimestampUtc}" Checked="RadioTimeFormat_OnCheckedChanged" Unchecked="RadioTimeFormat_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                 <RadioButton x:Name="RadioTimeFormatLocal" IsChecked="True" Content="{lex:Loc TimestampLocal}" Margin="3,0,0,0" Checked="RadioTimeFormat_OnCheckedChanged" Unchecked="RadioTimeFormat_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
@@ -105,6 +109,10 @@
                 <CheckBox x:Name="CheckThrottleEnabled" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1, 6, 3, 3" Checked="CheckThrottleEnabled_OnCheckedChanged" Unchecked="CheckThrottleEnabled_OnCheckedChanged" BorderBrush="{DynamicResource AppElementBorder}" />
                 <hc:NumericUpDown x:Name="NumMaximumBandwidth" Value="4096" Minimum="1" Maximum="122070" ValueChanged="NumMaximumBandwidth_OnValueChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
                 <TextBlock Margin="3,7,0,0" Text="KiB/s" Foreground="{DynamicResource AppText}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
+                <TextBlock Margin="3,6,3,3" Foreground="{DynamicResource AppText}"><Run Text="{lex:Loc Oauth}"/><Hyperlink NavigateUri="https://www.youtube.com/watch?v=1MBsUoFGuls" RequestNavigate="Hyperlink_RequestNavigate" ToolTipService.ShowDuration="30000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><Run Text="{lex:Loc OauthTooltip}"/></Hyperlink.ToolTip>(?)</Hyperlink>:</TextBlock>
+                <TextBox x:Name="TextOauth" Margin="3" MinWidth="200" MaxWidth="400" TextChanged="TextOauth_OnTextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
             </StackPanel>
             <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
                 <TextBlock Margin="3,6,3,3" Text="{lex:Loc LogLevels}" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/WindowSettings.xaml.cs
+++ b/TwitchDownloaderWPF/WindowSettings.xaml.cs
@@ -67,6 +67,8 @@ namespace TwitchDownloaderWPF
             CheckThrottleEnabled.IsChecked = Settings.Default.DownloadThrottleEnabled;
             RadioTimeFormatUtc.IsChecked = Settings.Default.UTCVideoTime;
             CheckReduceMotion.IsChecked = Settings.Default.ReduceMotion;
+            CheckNotifyOnTaskComplete.IsChecked = Settings.Default.NotifyOnTaskComplete;
+            TextOauth.Text = Settings.Default.OAuth;
 
             if (Directory.Exists("Themes"))
             {
@@ -391,6 +393,22 @@ namespace TwitchDownloaderWPF
                 return;
 
             Settings.Default.ReduceMotion = CheckReduceMotion.IsChecked.GetValueOrDefault();
+        }
+
+        private void CheckNotifyOnTaskComplete_OnCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            if (!IsInitialized)
+                return;
+
+            Settings.Default.NotifyOnTaskComplete = CheckNotifyOnTaskComplete.IsChecked.GetValueOrDefault();
+        }
+
+        private void TextOauth_OnTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (!IsInitialized)
+                return;
+
+            Settings.Default.OAuth = TextOauth.Text;
         }
     }
 }

--- a/TwitchDownloaderWPF/WindowSettingsImport.cs
+++ b/TwitchDownloaderWPF/WindowSettingsImport.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace TwitchDownloaderWPF
+{
+    public sealed class SettingsImportCandidate
+    {
+        public string ConfigPath { get; init; }
+        public string DisplayName { get; init; }
+        public DateTime LastModified { get; init; }
+        public override string ToString() => DisplayName;
+    }
+
+    /// <summary>
+    /// A code-defined (no XAML) one-time dialog that lets the user import an existing
+    /// TwitchDownloader user.config from another install/build identity.
+    /// </summary>
+    public sealed class WindowSettingsImport : Window
+    {
+        private readonly ListBox _list;
+
+        /// <summary>The chosen user.config path, or null if the user chose to start fresh.</summary>
+        public string SelectedConfigPath { get; private set; }
+
+        public WindowSettingsImport(IReadOnlyList<SettingsImportCandidate> candidates)
+        {
+            Title = "Import TwitchDownloader Settings";
+            Width = 720;
+            Height = 360;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            ResizeMode = ResizeMode.NoResize;
+            ShowInTaskbar = false;
+
+            var grid = new Grid { Margin = new Thickness(14) };
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var info = new TextBlock
+            {
+                Text = "Existing TwitchDownloader settings were found from other installs/builds. "
+                     + "Pick one to import into this build (it will be copied in and used from now on), "
+                     + "or start fresh. This prompt only appears once.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+            Grid.SetRow(info, 0);
+            grid.Children.Add(info);
+
+            _list = new ListBox { Margin = new Thickness(0, 0, 0, 10) };
+            foreach (var c in candidates)
+                _list.Items.Add(c);
+            if (_list.Items.Count > 0)
+                _list.SelectedIndex = 0;
+            _list.MouseDoubleClick += (_, _) => Import();
+            Grid.SetRow(_list, 1);
+            grid.Children.Add(_list);
+
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            var importBtn = new Button { Content = "Import Selected", MinWidth = 120, Height = 28, Margin = new Thickness(0, 0, 8, 0), IsDefault = true };
+            importBtn.Click += (_, _) => Import();
+            var freshBtn = new Button { Content = "Start Fresh", MinWidth = 100, Height = 28, IsCancel = true };
+            freshBtn.Click += (_, _) => { SelectedConfigPath = null; DialogResult = true; Close(); };
+            buttons.Children.Add(importBtn);
+            buttons.Children.Add(freshBtn);
+            Grid.SetRow(buttons, 2);
+            grid.Children.Add(buttons);
+
+            Content = grid;
+        }
+
+        private void Import()
+        {
+            if (_list.SelectedItem is not SettingsImportCandidate candidate)
+                return;
+
+            SelectedConfigPath = candidate.ConfigPath;
+            DialogResult = true;
+            Close();
+        }
+    }
+}

--- a/TwitchDownloaderWPF/WindowToast.xaml
+++ b/TwitchDownloaderWPF/WindowToast.xaml
@@ -1,0 +1,38 @@
+<Window x:Class="TwitchDownloaderWPF.WindowToast"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        Width="300"
+        Height="70"
+        Background="Transparent"
+        MouseDown="Window_MouseDown">
+    <Border Background="{DynamicResource AppBackground}"
+            BorderBrush="{DynamicResource AppElementBorder}"
+            BorderThickness="1"
+            CornerRadius="4">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Border x:Name="ColorBar"
+                    Grid.Column="0"
+                    CornerRadius="4,0,0,4"
+                    Background="Green"/>
+            <StackPanel Grid.Column="1" Margin="8,6,8,6" VerticalAlignment="Center">
+                <TextBlock x:Name="TextTitle"
+                           FontWeight="Bold"
+                           TextTrimming="CharacterEllipsis"
+                           Foreground="{DynamicResource AppText}"/>
+                <TextBlock x:Name="TextMessage"
+                           TextTrimming="CharacterEllipsis"
+                           Foreground="{DynamicResource AppText}"
+                           Opacity="0.8"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/TwitchDownloaderWPF/WindowToast.xaml.cs
+++ b/TwitchDownloaderWPF/WindowToast.xaml.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace TwitchDownloaderWPF
+{
+    public partial class WindowToast : Window
+    {
+        private readonly DispatcherTimer _timer;
+        private static int _activeToastCount = 0;
+        private readonly int _toastIndex;
+
+        public WindowToast(string title, string message, bool isError)
+        {
+            InitializeComponent();
+
+            TextTitle.Text = title;
+            TextMessage.Text = message;
+            ColorBar.Background = isError
+                ? new SolidColorBrush(Color.FromRgb(0xE5, 0x39, 0x35))
+                : new SolidColorBrush(Color.FromRgb(0x2E, 0x7D, 0x32));
+
+            _toastIndex = _activeToastCount++;
+
+            PositionWindow();
+
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(4) };
+            _timer.Tick += (s, e) =>
+            {
+                _timer.Stop();
+                _activeToastCount = Math.Max(0, _activeToastCount - 1);
+                Close();
+            };
+            _timer.Start();
+        }
+
+        private void PositionWindow()
+        {
+            const int margin = 16;
+            const int toastHeight = 70;
+            const int toastSpacing = 8;
+
+            double screenWidth = SystemParameters.PrimaryScreenWidth;
+            double screenHeight = SystemParameters.PrimaryScreenHeight;
+
+            Left = screenWidth - Width - margin;
+            Top = screenHeight - (toastHeight + toastSpacing) * (_toastIndex + 1) - margin;
+        }
+
+        private void Window_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            _timer.Stop();
+            _activeToastCount = Math.Max(0, _activeToastCount - 1);
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Chat render page

**Embedded preview panel**
Renders a short clip and plays it back as an animated frame strip (ffmpeg-extracted PNGs at 4 fps) directly on the render page. No WMF/WMP dependency — uses the same ffmpeg that's already required. Includes play/pause, a time scrubber, and a configurable preview duration.

**Render presets**
Save and load full render setting profiles by name. Presets cover all render options (font, size, colors, scales, emote providers, etc.).

**Highlight users**
Comma-separated list of usernames whose messages get a configurable color-tinted background, similar to the existing banned-words and ignore-users fields.

**Username font scale**
Independent scale factor for the username label so it can be sized relative to the message text without affecting anything else.

## Chat download page

**Sync from VOD button**
Copies the currently loaded VOD URL and trim range from the VOD download page into the chat download page in one click.

## Queue / download

**Enqueue presets**
Save and load named download presets in the queue options dialog, covering quality, format, and all download flags.

**Queue multiple VODs from a list**
Paste a newline-separated list of VOD URLs or IDs into the queue dialog and enqueue them all at once.

**Split VOD by chapters**
Queue one download task per chapter of a VOD, each named after the game/category with the correct start and end offsets applied automatically.

**Live stream queuing and monitor**
New Live Stream Monitor page for recording ongoing broadcasts. Queues a `LiveStreamDownloadTask` that records the HLS stream until the broadcast ends or the task is cancelled.

**Delay download option**
"Delay download until broadcast finishes" flag surfaces in the queue options dialog and is carried through to queued tasks.

**Navigate to queue after enqueuing**
The main window switches to the queue tab automatically after tasks are added.

## App startup

**Settings import on first launch**
On the first run with a new build identity (each build has a unique .NET user settings path), scans for `user.config` files from other TwitchDownloader installs on the same machine and offers to import one. Runs once; subsequent launches use the now-populated config directly.