### PR TITLE
Fix progress logging in case of missing parts

### DIFF
--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -377,9 +377,7 @@ namespace TwitchDownloaderCore
                 0x40, 0x01, 0x7F, 0xFC, 0x00, 0xD0, 0x00, 0x07,
             ];
 
-            _progress.ReportProgress(0);
-            var partCount = downloadState.PartCount;
-            var doneCount = 0;
+            var stubCount = 0;
 
             using var headerFs = !string.IsNullOrWhiteSpace(downloadState.HeaderFile)
                 ? File.OpenRead(downloadState.HeaderFile)
@@ -410,15 +408,22 @@ namespace TwitchDownloaderCore
                         headerFs.Seek(0, SeekOrigin.Begin);
                         headerFs.CopyTo(fs);
                     }
+
+                    stubCount++;
                 }
                 catch (Exception ex)
                 {
                     _progress.LogVerbose($"Failed to write stub for part {partName}: {ex.Message}");
                 }
+            }
 
-                doneCount++;
-                var percent = (int)(doneCount / (double)partCount * 100);
-                _progress.ReportProgress(percent);
+            if (stubCount > 0)
+            {
+                _progress.LogInfo($"Failed to redownload {stubCount} parts, using stubs instead");
+            }
+            else
+            {
+                _progress.LogInfo("Successfully redownloaded missing parts");
             }
         }
 

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -226,7 +226,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private async Task DownloadVideoPartsAsync(VideoDownloadState downloadState, CancellationToken cancellationToken, bool reportProgress = true)
+        private async Task DownloadVideoPartsAsync(VideoDownloadState downloadState, CancellationToken cancellationToken)
         {
             var downloadThreads = new VideoDownloadThread[downloadOptions.DownloadThreads];
             for (var i = 0; i < downloadOptions.DownloadThreads; i++)
@@ -234,26 +234,26 @@ namespace TwitchDownloaderCore
                 downloadThreads[i] = new VideoDownloadThread(downloadState, _httpClient, _vodCacheDir, downloadOptions.ThrottleKib, _progress, cancellationToken);
             }
 
-            var partCount = downloadState.PartCount;
-            var downloadExceptions = await WaitForDownloadThreads(downloadThreads, downloadState, partCount, true, cancellationToken, reportProgress);
+            var downloadExceptions = await WaitForDownloadThreads(downloadThreads, downloadState, true, cancellationToken);
 
             LogDownloadThreadExceptions(downloadExceptions);
         }
 
-        private async Task<IReadOnlyCollection<Exception>> WaitForDownloadThreads(VideoDownloadThread[] downloadThreads, VideoDownloadState downloadState, int partCount, bool limitThreadRestarts, CancellationToken cancellationToken, bool reportProgress)
+        private async Task<IReadOnlyCollection<Exception>> WaitForDownloadThreads(VideoDownloadThread[] downloadThreads, VideoDownloadState downloadState, bool limitThreadRestarts, CancellationToken cancellationToken)
         {
             var allThreadsExited = false;
-            var previousDoneCount = 0;
+            var totalPartsToDownload = downloadState.PartQueue.Count;
+            var previousMissingCount = 0;
             var restartedThreads = 0;
-            var maxRestartedThreads = limitThreadRestarts ? (int)Math.Ceiling(partCount * 0.95) : int.MaxValue;
+            var maxRestartedThreads = limitThreadRestarts ? (int)Math.Ceiling(totalPartsToDownload * 0.95) : int.MaxValue;
             var downloadExceptions = new Dictionary<int, Exception>();
             do
             {
-                if (downloadState.PartQueue.Count != previousDoneCount)
+                if (downloadState.PartQueue.Count != previousMissingCount)
                 {
-                    previousDoneCount = downloadState.PartQueue.Count;
-                    var percent = (int)((partCount - previousDoneCount) / (double)partCount * 100);
-                    if (reportProgress) { _progress.ReportProgress(percent); }
+                    previousMissingCount = downloadState.PartQueue.Count;
+                    var percent = (int)((totalPartsToDownload - previousMissingCount) / (double)totalPartsToDownload * 100);
+                    _progress.ReportProgress(percent);
                 }
 
                 allThreadsExited = true;
@@ -281,7 +281,7 @@ namespace TwitchDownloaderCore
                 await Task.Delay(100, cancellationToken);
             } while (!allThreadsExited);
 
-            if (reportProgress) { _progress.ReportProgress(100); }
+            _progress.ReportProgress(100);
 
             if (restartedThreads >= maxRestartedThreads)
             {
@@ -346,11 +346,20 @@ namespace TwitchDownloaderCore
                 }
 
                 _progress.LogInfo($"{invalidCount} parts were missing or corrupt and will be redownloaded.");
-                await DownloadVideoPartsAsync(downloadState, cancellationToken, false).ConfigureAwait(false);
+                _progress.SetTemplateStatus("Redownloading Missing Parts {0}%", 0);
+                await DownloadVideoPartsAsync(downloadState, cancellationToken).ConfigureAwait(false);
 
                 try
                 {
-                    await Task.Run(() => EmitPartStubs(downloadState), cancellationToken).ConfigureAwait(false);
+                    var stubCount = await Task.Run(() => EmitPartStubs(downloadState), cancellationToken).ConfigureAwait(false);
+                    if (stubCount > 0)
+                    {
+                        _progress.LogWarning($"Failed to redownload {stubCount} parts, using stubs instead");
+                    }
+                    else
+                    {
+                        _progress.LogInfo("Successfully redownloaded missing parts");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -359,7 +368,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private void EmitPartStubs(VideoDownloadState downloadState)
+        private int EmitPartStubs(VideoDownloadState downloadState)
         {
             byte[] transportStreamStub =
             [
@@ -417,14 +426,7 @@ namespace TwitchDownloaderCore
                 }
             }
 
-            if (stubCount > 0)
-            {
-                _progress.LogInfo($"Failed to redownload {stubCount} parts, using stubs instead");
-            }
-            else
-            {
-                _progress.LogInfo("Successfully redownloaded missing parts");
-            }
+            return stubCount;
         }
 
         private int GetInvalidParts(VideoDownloadState downloadState)

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -226,7 +226,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        private async Task DownloadVideoPartsAsync(VideoDownloadState downloadState, CancellationToken cancellationToken)
+        private async Task DownloadVideoPartsAsync(VideoDownloadState downloadState, CancellationToken cancellationToken, bool reportProgress = true)
         {
             var downloadThreads = new VideoDownloadThread[downloadOptions.DownloadThreads];
             for (var i = 0; i < downloadOptions.DownloadThreads; i++)
@@ -235,12 +235,12 @@ namespace TwitchDownloaderCore
             }
 
             var partCount = downloadState.PartCount;
-            var downloadExceptions = await WaitForDownloadThreads(downloadThreads, downloadState, partCount, true, cancellationToken);
+            var downloadExceptions = await WaitForDownloadThreads(downloadThreads, downloadState, partCount, true, cancellationToken, reportProgress);
 
             LogDownloadThreadExceptions(downloadExceptions);
         }
 
-        private async Task<IReadOnlyCollection<Exception>> WaitForDownloadThreads(VideoDownloadThread[] downloadThreads, VideoDownloadState downloadState, int partCount, bool limitThreadRestarts, CancellationToken cancellationToken)
+        private async Task<IReadOnlyCollection<Exception>> WaitForDownloadThreads(VideoDownloadThread[] downloadThreads, VideoDownloadState downloadState, int partCount, bool limitThreadRestarts, CancellationToken cancellationToken, bool reportProgress)
         {
             var allThreadsExited = false;
             var previousDoneCount = 0;
@@ -253,7 +253,7 @@ namespace TwitchDownloaderCore
                 {
                     previousDoneCount = downloadState.PartQueue.Count;
                     var percent = (int)((partCount - previousDoneCount) / (double)partCount * 100);
-                    _progress.ReportProgress(percent);
+                    if (reportProgress) { _progress.ReportProgress(percent); }
                 }
 
                 allThreadsExited = true;
@@ -281,7 +281,7 @@ namespace TwitchDownloaderCore
                 await Task.Delay(100, cancellationToken);
             } while (!allThreadsExited);
 
-            _progress.ReportProgress(100);
+            if (reportProgress) { _progress.ReportProgress(100); }
 
             if (restartedThreads >= maxRestartedThreads)
             {
@@ -346,7 +346,7 @@ namespace TwitchDownloaderCore
                 }
 
                 _progress.LogInfo($"{invalidCount} parts were missing or corrupt and will be redownloaded.");
-                await DownloadVideoPartsAsync(downloadState, cancellationToken).ConfigureAwait(false);
+                await DownloadVideoPartsAsync(downloadState, cancellationToken, false).ConfigureAwait(false);
 
                 try
                 {


### PR DESCRIPTION
When some parts failed to download a 0% verification progress was reported after the missing parts:
<img width="834" height="101" alt="Screenshot 2026-06-01 at 02 00 19" src="https://github.com/user-attachments/assets/8954c397-c37c-4d5f-ada3-f526da4dcccb" />

Now all progress reports are removed/supressed for the redownload.

Also, stubbing used to happen silently, i made it explicit in the logging whether the parts were redownloaded or stubbed.
<img width="850" height="100" alt="Screenshot 2026-06-01 at 02 00 06" src="https://github.com/user-attachments/assets/4eb613dd-1cf7-4486-84d3-b816046f671e" />
