### PR TITLE
Speed up animated emote rendering

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -437,12 +437,23 @@ namespace TwitchDownloaderCore
             // If we are generating a mask then we need to produce a copy
             if (!renderOptions.GenerateMask)
             {
+                // comment.Emotes holds both static (FrameCount == 1) and animated (FrameCount > 1) emotes,
+                // so we must check FrameCount rather than Count. Otherwise the full-frame copy below runs on
+                // every update frame even when only static emotes are present.
                 bool hasAnimatedEmotes = false;
                 foreach (var comment in comments)
                 {
-                    if (comment.Emotes.Count > 0)
+                    foreach (var (_, emote) in comment.Emotes)
                     {
-                        hasAnimatedEmotes = true;
+                        if (emote.FrameCount > 1)
+                        {
+                            hasAnimatedEmotes = true;
+                            break;
+                        }
+                    }
+
+                    if (hasAnimatedEmotes)
+                    {
                         break;
                     }
                 }

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -485,7 +485,14 @@ namespace TwitchDownloaderCore
                 return (_animComposedFrame, false); // owned by the cache; the caller must not dispose it
             }
 
-            SKBitmap newFrame = updateFrame.Copy();
+            // SKBitmap.Copy() allocates excessively, so a raw memcpy into the new bitmap is used instead.
+            var newFrame = new SKBitmap(updateFrame.Info);
+            unsafe
+            {
+                var byteCount = updateFrame.Info.BytesSize;
+                Buffer.MemoryCopy((void*)updateFrame.GetPixels(), (void*)newFrame.GetPixels(), byteCount, byteCount);
+            }
+
             int frameHeight = renderOptions.ChatHeight;
             using (SKCanvas frameCanvas = new SKCanvas(newFrame))
             {

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -80,7 +80,7 @@ namespace TwitchDownloaderCore
         private SKBitmap _animComposedFrame;
         private SKCanvas _animCanvas;
         private int _animComposedForCommentIndex = int.MinValue;
-        private readonly List<int> _animLastFrameIndices = new();
+        private readonly List<int> _animLastFrameIndices = [];
 
         public ChatRenderer(ChatRenderOptions chatRenderOptions, ITaskProgress progress)
         {
@@ -435,21 +435,20 @@ namespace TwitchDownloaderCore
         private (SKBitmap frame, bool isCopyFrame) GetFrameFromTick(int currentTick, int sectionDefaultYPos, UpdateFrame currentFrame = null)
         {
             currentFrame ??= GenerateUpdateFrame(currentTick, sectionDefaultYPos);
-            var (frame, isCopyFrame) = DrawAnimatedEmotes(currentFrame.Image, currentFrame.Comments, currentFrame.CommentIndex, currentTick);
+            var (frame, isCopyFrame) = DrawAnimatedEmotes(currentFrame, currentTick);
             return (frame, isCopyFrame);
         }
 
-        private (SKBitmap frame, bool isCopyFrame) DrawAnimatedEmotes(SKBitmap updateFrame, List<CommentSection> comments, int commentIndex, int currentTick)
+        private (SKBitmap frame, bool isCopyFrame) DrawAnimatedEmotes(UpdateFrame currentFrame, int currentTick)
         {
-            long currentTickMs = (long)(currentTick / (double)renderOptions.Framerate * 1000);
+            var updateFrame = currentFrame.Image;
+            var comments = currentFrame.Comments;
+            var commentIndex = currentFrame.CommentIndex;
+            var currentTickMs = (long)(currentTick / (double)renderOptions.Framerate * 1000);
 
-            // Mask generation reads the alpha of a freshly copied frame every tick, so it is left on the
-            // original uncached copy path below.
+            // Mask generation modifies the returned frame, so it is left on the original uncached copy path.
             if (!renderOptions.GenerateMask)
             {
-                // comment.Emotes holds both static (FrameCount == 1) and animated (FrameCount > 1) emotes,
-                // so we must check FrameCount rather than Count. Otherwise the full-frame copy below runs on
-                // every update frame even when only static emotes are present.
                 bool hasAnimatedEmotes = false;
                 foreach (var comment in comments)
                 {
@@ -462,11 +461,9 @@ namespace TwitchDownloaderCore
                         }
                     }
 
-                    if (hasAnimatedEmotes)
-                    {
-                        break;
-                    }
+                    if (hasAnimatedEmotes) break;
                 }
+
                 if (!hasAnimatedEmotes)
                 {
                     // If there are no animated emotes to draw then return the original bitmap. Copying is pretty expensive.
@@ -510,8 +507,7 @@ namespace TwitchDownloaderCore
 
         /// <summary>
         /// Composites the current animated-emote frames onto a copy of <paramref name="updateFrame"/> held in
-        /// the persistent <see cref="_animComposedFrame"/> buffer. The bitmap and canvas are allocated on the
-        /// first call and reused afterwards, so the hot path is allocation-free.
+        /// the persistent <see cref="_animComposedFrame"/> buffer.
         /// </summary>
         private void ComposeAnimatedFrame(SKBitmap updateFrame, List<CommentSection> comments, long currentTickMs)
         {
@@ -521,21 +517,21 @@ namespace TwitchDownloaderCore
                 _animCanvas = new SKCanvas(_animComposedFrame);
             }
 
-            // Copy the background pixels straight into the buffer the canvas is bound to. CopyTo(bitmap) swaps
-            // the pixel reference, which would leave _animCanvas pointing at the old buffer, so a raw memcpy
-            // into the existing buffer is used instead.
+            // Copy the background pixels straight into the buffer the canvas is bound to. CopyTo(bitmap) always
+            // allocates a new buffer, even if the old buffer is the same since, so a raw memcpy into the existing
+            // buffer is used instead.
             unsafe
             {
-                int byteCount = _animComposedFrame.Info.BytesSize;
+                var byteCount = _animComposedFrame.Info.BytesSize;
                 Buffer.MemoryCopy((void*)updateFrame.GetPixels(), (void*)_animComposedFrame.GetPixels(), byteCount, byteCount);
             }
 
-            int frameHeight = renderOptions.ChatHeight;
-            for (int c = comments.Count - 1; c >= 0; c--)
+            var frameHeight = renderOptions.ChatHeight;
+            for (var c = comments.Count - 1; c >= 0; c--)
             {
                 var comment = comments[c];
                 frameHeight -= comment.Image.Height + renderOptions.VerticalPadding;
-                foreach ((Point drawPoint, TwitchEmote emote) in comment.Emotes)
+                foreach (var (drawPoint, emote) in comment.Emotes)
                 {
                     if (emote.FrameCount > 1)
                     {
@@ -547,21 +543,22 @@ namespace TwitchDownloaderCore
 
         private static int ComputeAnimFrameIndex(TwitchEmote emote, long currentTickMs)
         {
-            long imageFrame = currentTickMs % (emote.TotalDuration * 10);
-            for (int i = 0; i < emote.EmoteFrameDurations.Count; i++)
+            var imageFrame = currentTickMs % (emote.TotalDuration * 10);
+            for (var i = 0; i < emote.EmoteFrameDurations.Count; i++)
             {
-                if (imageFrame - emote.EmoteFrameDurations[i] * 10 <= 0)
-                    return i;
                 imageFrame -= emote.EmoteFrameDurations[i] * 10;
+
+                if (imageFrame <= 0) return i;
             }
+
             return emote.EmoteFrameDurations.Count - 1;
         }
 
-        /// <summary>Returns true when every animated emote is on the same frame index as when the cache was built.</summary>
+        /// <summary>Returns <see langword="true"/> when every animated emote is on the same frame index as when the cache was built.</summary>
         private bool AnimCacheIsValid(List<CommentSection> comments, long currentTickMs)
         {
-            int i = 0;
-            for (int c = comments.Count - 1; c >= 0; c--)
+            var i = 0;
+            for (var c = comments.Count - 1; c >= 0; c--)
             {
                 foreach (var (_, emote) in comments[c].Emotes)
                 {
@@ -573,18 +570,18 @@ namespace TwitchDownloaderCore
                     }
                 }
             }
+
             return i == _animLastFrameIndices.Count;
         }
 
         private void RecordAnimFrameIndices(List<CommentSection> comments, long currentTickMs)
         {
             _animLastFrameIndices.Clear();
-            for (int c = comments.Count - 1; c >= 0; c--)
+            for (var c = comments.Count - 1; c >= 0; c--)
             {
                 foreach (var (_, emote) in comments[c].Emotes)
                 {
-                    if (emote.FrameCount > 1)
-                        _animLastFrameIndices.Add(ComputeAnimFrameIndex(emote, currentTickMs));
+                    if (emote.FrameCount > 1) _animLastFrameIndices.Add(ComputeAnimFrameIndex(emote, currentTickMs));
                 }
             }
         }

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -75,6 +75,13 @@ namespace TwitchDownloaderCore
         private SKPaint outlinePaint;
         private readonly HighlightIcons highlightIcons;
 
+        // Persistent buffer for the composited animated-emote frame, reused across ticks so that an
+        // unchanged frame does not need to be copied and recomposited. See DrawAnimatedEmotes.
+        private SKBitmap _animComposedFrame;
+        private SKCanvas _animCanvas;
+        private int _animComposedForCommentIndex = int.MinValue;
+        private readonly List<int> _animLastFrameIndices = new();
+
         public ChatRenderer(ChatRenderOptions chatRenderOptions, ITaskProgress progress)
         {
             renderOptions = chatRenderOptions;
@@ -428,13 +435,16 @@ namespace TwitchDownloaderCore
         private (SKBitmap frame, bool isCopyFrame) GetFrameFromTick(int currentTick, int sectionDefaultYPos, UpdateFrame currentFrame = null)
         {
             currentFrame ??= GenerateUpdateFrame(currentTick, sectionDefaultYPos);
-            var (frame, isCopyFrame) = DrawAnimatedEmotes(currentFrame.Image, currentFrame.Comments, currentTick);
+            var (frame, isCopyFrame) = DrawAnimatedEmotes(currentFrame.Image, currentFrame.Comments, currentFrame.CommentIndex, currentTick);
             return (frame, isCopyFrame);
         }
 
-        private (SKBitmap frame, bool isCopyFrame) DrawAnimatedEmotes(SKBitmap updateFrame, List<CommentSection> comments, int currentTick)
+        private (SKBitmap frame, bool isCopyFrame) DrawAnimatedEmotes(SKBitmap updateFrame, List<CommentSection> comments, int commentIndex, int currentTick)
         {
-            // If we are generating a mask then we need to produce a copy
+            long currentTickMs = (long)(currentTick / (double)renderOptions.Framerate * 1000);
+
+            // Mask generation reads the alpha of a freshly copied frame every tick, so it is left on the
+            // original uncached copy path below.
             if (!renderOptions.GenerateMask)
             {
                 // comment.Emotes holds both static (FrameCount == 1) and animated (FrameCount > 1) emotes,
@@ -460,13 +470,26 @@ namespace TwitchDownloaderCore
                 if (!hasAnimatedEmotes)
                 {
                     // If there are no animated emotes to draw then return the original bitmap. Copying is pretty expensive.
+                    InvalidateAnimCache();
                     return (updateFrame, false);
                 }
+
+                // Reuse the previously composited frame when the visible comments and every animated emote's
+                // frame index are unchanged since the last tick. At high frame rates the animation advances
+                // more slowly than the video, so most ticks hit this path and skip the copy + compositing.
+                if (_animComposedFrame != null && commentIndex == _animComposedForCommentIndex && AnimCacheIsValid(comments, currentTickMs))
+                {
+                    return (_animComposedFrame, false);
+                }
+
+                ComposeAnimatedFrame(updateFrame, comments, currentTickMs);
+                _animComposedForCommentIndex = commentIndex;
+                RecordAnimFrameIndices(comments, currentTickMs);
+                return (_animComposedFrame, false); // owned by the cache; the caller must not dispose it
             }
 
             SKBitmap newFrame = updateFrame.Copy();
             int frameHeight = renderOptions.ChatHeight;
-            long currentTickMs = (long)(currentTick / (double)renderOptions.Framerate * 1000);
             using (SKCanvas frameCanvas = new SKCanvas(newFrame))
             {
                 for (int c = comments.Count - 1; c >= 0; c--)
@@ -477,24 +500,99 @@ namespace TwitchDownloaderCore
                     {
                         if (emote.FrameCount > 1)
                         {
-                            int frameIndex = emote.EmoteFrameDurations.Count - 1;
-                            long imageFrame = currentTickMs % (emote.TotalDuration * 10);
-                            for (int i = 0; i < emote.EmoteFrameDurations.Count; i++)
-                            {
-                                if (imageFrame - emote.EmoteFrameDurations[i] * 10 <= 0)
-                                {
-                                    frameIndex = i;
-                                    break;
-                                }
-                                imageFrame -= emote.EmoteFrameDurations[i] * 10;
-                            }
-
-                            frameCanvas.DrawBitmap(emote.EmoteFrames[frameIndex], drawPoint.X, drawPoint.Y + frameHeight);
+                            frameCanvas.DrawBitmap(emote.EmoteFrames[ComputeAnimFrameIndex(emote, currentTickMs)], drawPoint.X, drawPoint.Y + frameHeight);
                         }
                     }
                 }
             }
             return (newFrame, true);
+        }
+
+        /// <summary>
+        /// Composites the current animated-emote frames onto a copy of <paramref name="updateFrame"/> held in
+        /// the persistent <see cref="_animComposedFrame"/> buffer. The bitmap and canvas are allocated on the
+        /// first call and reused afterwards, so the hot path is allocation-free.
+        /// </summary>
+        private void ComposeAnimatedFrame(SKBitmap updateFrame, List<CommentSection> comments, long currentTickMs)
+        {
+            if (_animComposedFrame == null)
+            {
+                _animComposedFrame = new SKBitmap(updateFrame.Info);
+                _animCanvas = new SKCanvas(_animComposedFrame);
+            }
+
+            // Copy the background pixels straight into the buffer the canvas is bound to. CopyTo(bitmap) swaps
+            // the pixel reference, which would leave _animCanvas pointing at the old buffer, so a raw memcpy
+            // into the existing buffer is used instead.
+            unsafe
+            {
+                int byteCount = _animComposedFrame.Info.BytesSize;
+                Buffer.MemoryCopy((void*)updateFrame.GetPixels(), (void*)_animComposedFrame.GetPixels(), byteCount, byteCount);
+            }
+
+            int frameHeight = renderOptions.ChatHeight;
+            for (int c = comments.Count - 1; c >= 0; c--)
+            {
+                var comment = comments[c];
+                frameHeight -= comment.Image.Height + renderOptions.VerticalPadding;
+                foreach ((Point drawPoint, TwitchEmote emote) in comment.Emotes)
+                {
+                    if (emote.FrameCount > 1)
+                    {
+                        _animCanvas.DrawBitmap(emote.EmoteFrames[ComputeAnimFrameIndex(emote, currentTickMs)], drawPoint.X, drawPoint.Y + frameHeight);
+                    }
+                }
+            }
+        }
+
+        private static int ComputeAnimFrameIndex(TwitchEmote emote, long currentTickMs)
+        {
+            long imageFrame = currentTickMs % (emote.TotalDuration * 10);
+            for (int i = 0; i < emote.EmoteFrameDurations.Count; i++)
+            {
+                if (imageFrame - emote.EmoteFrameDurations[i] * 10 <= 0)
+                    return i;
+                imageFrame -= emote.EmoteFrameDurations[i] * 10;
+            }
+            return emote.EmoteFrameDurations.Count - 1;
+        }
+
+        /// <summary>Returns true when every animated emote is on the same frame index as when the cache was built.</summary>
+        private bool AnimCacheIsValid(List<CommentSection> comments, long currentTickMs)
+        {
+            int i = 0;
+            for (int c = comments.Count - 1; c >= 0; c--)
+            {
+                foreach (var (_, emote) in comments[c].Emotes)
+                {
+                    if (emote.FrameCount > 1)
+                    {
+                        if (i >= _animLastFrameIndices.Count) return false;
+                        if (ComputeAnimFrameIndex(emote, currentTickMs) != _animLastFrameIndices[i]) return false;
+                        i++;
+                    }
+                }
+            }
+            return i == _animLastFrameIndices.Count;
+        }
+
+        private void RecordAnimFrameIndices(List<CommentSection> comments, long currentTickMs)
+        {
+            _animLastFrameIndices.Clear();
+            for (int c = comments.Count - 1; c >= 0; c--)
+            {
+                foreach (var (_, emote) in comments[c].Emotes)
+                {
+                    if (emote.FrameCount > 1)
+                        _animLastFrameIndices.Add(ComputeAnimFrameIndex(emote, currentTickMs));
+                }
+            }
+        }
+
+        private void InvalidateAnimCache()
+        {
+            _animComposedForCommentIndex = int.MinValue;
+            _animLastFrameIndices.Clear();
         }
 
         private UpdateFrame GenerateUpdateFrame(int currentTick, int sectionDefaultYPos, UpdateFrame lastUpdate = null)
@@ -2024,6 +2122,8 @@ namespace TwitchDownloaderCore
                     messageFont?.Dispose();
                     outlinePaint?.Dispose();
                     highlightIcons?.Dispose();
+                    _animCanvas?.Dispose();
+                    _animComposedFrame?.Dispose();
 
                     badgeList.Clear();
                     emoteList.Clear();


### PR DESCRIPTION
Two rendering optimizations with no change to output. First, skip the per-frame full-frame copy and re-composite when a section contains only static emotes; the guard tested Emotes.Count, which is true for static emotes too. Second, reuse the composited animated-emote frame across ticks when the visible comments and every animated emote's frame index are unchanged. Mask generation keeps the original per-frame copy.