### PR TITLE
Fix Open Folder opening This PC instead of the file's folder

### DIFF
--- a/TwitchDownloaderWPF/Services/FileService.cs
+++ b/TwitchDownloaderWPF/Services/FileService.cs
@@ -24,8 +24,7 @@ namespace TwitchDownloaderWPF.Services
             {
                 FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "explorer.exe"),
                 Arguments = args,
-                UseShellExecute = true,
-                WorkingDirectory = directoryInfo.FullName
+                UseShellExecute = false
             });
         }
     }


### PR DESCRIPTION
explorer.exe needs UseShellExecute=false for the /select argument to be honoured; with it set to true the folder did not open to the selected file.