### PR TITLE
Handle third-party emote provider outages

### DIFF
--- a/TwitchDownloaderCore/Chat/ChatHtml.cs
+++ b/TwitchDownloaderCore/Chat/ChatHtml.cs
@@ -12,10 +12,10 @@ namespace TwitchDownloaderCore.Chat
         /// <summary>
         /// Serializes a chat Html file.
         /// </summary>
-        public static async Task SerializeAsync(Stream outputStream, string filePath, ChatRoot chatRoot, ITaskLogger logger, bool embedData = true, CancellationToken cancellationToken = default)
+        public static async Task SerializeAsync(Stream outputStream, string filePath, ChatRoot chatRoot, string cacheDir, ITaskLogger logger, bool embedData = true, CancellationToken cancellationToken = default)
         {
             Dictionary<string, EmbedEmoteData> thirdEmoteData = new();
-            await BuildThirdPartyDictionary(chatRoot, embedData, thirdEmoteData, logger, cancellationToken);
+            await BuildThirdPartyDictionary(chatRoot, embedData, thirdEmoteData, cacheDir, logger, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -72,9 +72,9 @@ namespace TwitchDownloaderCore.Chat
             }
         }
 
-        private static async Task BuildThirdPartyDictionary(ChatRoot chatRoot, bool embedData, Dictionary<string, EmbedEmoteData> thirdEmoteData, ITaskLogger logger, CancellationToken cancellationToken)
+        private static async Task BuildThirdPartyDictionary(ChatRoot chatRoot, bool embedData, Dictionary<string, EmbedEmoteData> thirdEmoteData, string cacheDir, ITaskLogger logger, CancellationToken cancellationToken)
         {
-            EmoteResponse emotes = await TwitchHelper.GetThirdPartyEmotesMetadata(chatRoot.streamer.id, true, true, true, true, logger, cancellationToken);
+            EmoteResponse emotes = await TwitchHelper.GetThirdPartyEmotesMetadata(chatRoot.streamer.id, true, true, true, true, cacheDir, logger, cancellationToken);
             List<EmoteResponseItem> itemList = [];
             itemList.AddRange(emotes.BTTV);
             itemList.AddRange(emotes.FFZ);

--- a/TwitchDownloaderCore/Chat/ChatHtml.cs
+++ b/TwitchDownloaderCore/Chat/ChatHtml.cs
@@ -74,7 +74,7 @@ namespace TwitchDownloaderCore.Chat
 
         private static async Task BuildThirdPartyDictionary(ChatRoot chatRoot, bool embedData, Dictionary<string, EmbedEmoteData> thirdEmoteData, string cacheDir, ITaskLogger logger, CancellationToken cancellationToken)
         {
-            EmoteResponse emotes = await TwitchHelper.GetThirdPartyEmotesMetadata(chatRoot.streamer.id, true, true, true, true, cacheDir, logger, cancellationToken);
+            EmoteResponse emotes = await TwitchHelper.GetThirdPartyEmotesMetadata(chatRoot.streamer.id, true, true, true, true, cacheDir, false, logger, cancellationToken);
             List<EmoteResponseItem> itemList = [];
             itemList.AddRange(emotes.BTTV);
             itemList.AddRange(emotes.FFZ);

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -335,7 +335,7 @@ namespace TwitchDownloaderCore
                         await ChatJson.SerializeAsync(outputStream, chatRoot, cancellationToken);
                         break;
                     case ChatFormat.Html:
-                        await ChatHtml.SerializeAsync(outputStream, outputFileInfo.FullName, chatRoot, _progress, downloadOptions.EmbedData, cancellationToken);
+                        await ChatHtml.SerializeAsync(outputStream, outputFileInfo.FullName, chatRoot, _cacheDir, _progress, downloadOptions.EmbedData, cancellationToken);
                         break;
                     case ChatFormat.Text:
                         await ChatText.SerializeAsync(outputStream, chatRoot, downloadOptions.TimeFormat);

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -100,7 +100,7 @@ namespace TwitchDownloaderCore
                         await ChatJson.SerializeAsync(outputStream, chatRoot, cancellationToken);
                         break;
                     case ChatFormat.Html:
-                        await ChatHtml.SerializeAsync(outputStream, outputFileInfo.FullName, chatRoot, _progress, chatRoot.embeddedData != null && (chatRoot.embeddedData.firstParty?.Count > 0 || chatRoot.embeddedData.twitchBadges?.Count > 0), cancellationToken);
+                        await ChatHtml.SerializeAsync(outputStream, outputFileInfo.FullName, chatRoot, _cacheDir, _progress, chatRoot.embeddedData != null && (chatRoot.embeddedData.firstParty?.Count > 0 || chatRoot.embeddedData.twitchBadges?.Count > 0), cancellationToken);
                         break; // If there is embedded data, it's almost guaranteed to be first party emotes or badges.
                     case ChatFormat.Text:
                         await ChatText.SerializeAsync(outputStream, chatRoot, _updateOptions.TextTimestampFormat);

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -6,7 +6,9 @@ using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Extensions;
@@ -464,11 +466,21 @@ namespace TwitchDownloaderCore
 
             EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, logger, cancellationToken);
 
+            // For each provider: persist fresh metadata to disk so future sessions can fall back to it
+            // when the API is unavailable. If the API call already failed (null), try loading the cached list.
+            var metadataCacheAge = TimeSpan.FromHours(24);
+            if (bttv)
+                emoteDataResponse.BTTV = await RefreshOrLoadProviderMetadata(bttvFolder, emoteDataResponse.BTTV, "BetterTTV", metadataCacheAge, logger, cancellationToken);
+            if (ffz)
+                emoteDataResponse.FFZ = await RefreshOrLoadProviderMetadata(ffzFolder, emoteDataResponse.FFZ, "FFZ", metadataCacheAge, logger, cancellationToken);
+            if (stv)
+                emoteDataResponse.STV = await RefreshOrLoadProviderMetadata(stvFolder, emoteDataResponse.STV, "7TV", metadataCacheAge, logger, cancellationToken);
+
             if (bttv)
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, "BetterTTV", logger, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -480,7 +492,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, "FFZ", logger, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -492,7 +504,20 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", logger, cancellationToken);
+
+                    // When metadata failed (STV is null), FetchEmoteImages returned early without touching
+                    // the cache. Report whether previously cached images exist so the user knows what to expect.
+                    if (emoteDataResponse.STV is null)
+                    {
+                        // Both the API and the metadata cache failed. Report image cache status for context.
+                        stvFolder.Refresh();
+                        var cachedCount = stvFolder.Exists ? stvFolder.GetFiles("*_2.*").Length : 0;
+                        if (cachedCount > 0)
+                            logger.LogWarning($"7TV API and metadata cache were both unavailable. {cachedCount} cached 7TV emote image(s) exist but cannot be matched - new 7TV emotes will not appear, embedded ones may still be present.");
+                        else
+                            logger.LogInfo("7TV API and metadata cache were both unavailable and no cached 7TV emotes were found - only embedded 7TV emotes will appear.");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -502,9 +527,12 @@ namespace TwitchDownloaderCore
 
             return emotes.Values.ToList();
 
-            static async Task FetchEmoteImages([AllowNull] IEnumerable<Comment> comments, IEnumerable<EmoteResponseItem> emoteResponse, Dictionary<string, TwitchEmote> emotes,
-                DirectoryInfo cacheFolder, ITaskLogger logger, CancellationToken cancellationToken)
+            static async Task FetchEmoteImages([AllowNull] IEnumerable<Comment> comments, [AllowNull] IEnumerable<EmoteResponseItem> emoteResponse, Dictionary<string, TwitchEmote> emotes,
+                DirectoryInfo cacheFolder, string providerName, ITaskLogger logger, CancellationToken cancellationToken)
             {
+                if (emoteResponse is null)
+                    return;
+
                 if (!cacheFolder.Exists)
                     cacheFolder = CreateDirectory(cacheFolder.FullName);
 
@@ -522,9 +550,12 @@ namespace TwitchDownloaderCore
                         select emote;
                 }
 
+                int fromCache = 0, downloaded = 0;
                 foreach (var emote in emoteResponseQuery)
                 {
                     var emoteUrl = emote.ImageUrl.Replace("[scale]", "2");
+                    var expectedCachePath = Path.Combine(cacheFolder.FullName, $"{emote.Id}_2.{emote.ImageType}");
+                    bool wasInCache = File.Exists(expectedCachePath);
 
                     try
                     {
@@ -541,12 +572,71 @@ namespace TwitchDownloaderCore
                             // Should never occur, but just in case
                             newEmote.Dispose();
                         }
+                        else if (wasInCache)
+                        {
+                            fromCache++;
+                        }
+                        else
+                        {
+                            downloaded++;
+                        }
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                     {
                         logger.LogWarning($"Got {(int)ex.StatusCode}: {ex.StatusCode} when fetching {emote.Code} ({emoteUrl}).");
                     }
                 }
+
+                var total = fromCache + downloaded;
+                if (total > 0)
+                    logger.LogInfo($"Loaded {total} {providerName} emote(s) - {fromCache} from cache, {downloaded} newly downloaded.");
+                else
+                    logger.LogVerbose($"No {providerName} emotes found in this chat.");
+            }
+
+            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(
+                DirectoryInfo folder, List<EmoteResponseItem> freshData, string providerName,
+                TimeSpan maxAge, ITaskLogger logger, CancellationToken ct)
+            {
+                var cacheFile = new FileInfo(Path.Combine(folder.FullName, "metadata.json"));
+
+                if (freshData is not null)
+                {
+                    // Persist fresh metadata so future sessions can fall back to it.
+                    try
+                    {
+                        if (!folder.Exists)
+                            CreateDirectory(folder.FullName);
+                        await File.WriteAllBytesAsync(cacheFile.FullName, JsonSerializer.SerializeToUtf8Bytes(freshData), ct);
+                    }
+                    catch { /* best-effort - never block rendering on a metadata write failure */ }
+                    return freshData;
+                }
+
+                // API failed - try falling back to a previously cached emote list.
+                try
+                {
+                    if (!cacheFile.Exists)
+                        return null;
+
+                    if (DateTime.UtcNow - cacheFile.LastWriteTimeUtc > maxAge)
+                        return null;
+
+                    var bytes = await File.ReadAllBytesAsync(cacheFile.FullName, ct);
+                    var cached = JsonSerializer.Deserialize<List<EmoteResponseItem>>(bytes);
+                    if (cached is { Count: > 0 })
+                    {
+                        var ageHours = (DateTime.UtcNow - cacheFile.LastWriteTimeUtc).TotalHours;
+                        logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Count} emotes).");
+                        return cached;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogVerbose($"Failed to load cached {providerName} emote metadata: {ex.Message}");
+                }
+
+                return null;
             }
 
             static void LogProviderException(Exception ex, string providerName, ITaskLogger logger)

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -215,7 +215,7 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlClipSearchResponse>();
         }
 
-        public static async Task<EmoteResponse> GetThirdPartyEmotesMetadata(int streamerId, bool getBttv, bool getFfz, bool getStv, bool allowUnlistedEmotes, ITaskLogger logger, CancellationToken cancellationToken = default)
+        public static async Task<EmoteResponse> GetThirdPartyEmotesMetadata(int streamerId, bool getBttv, bool getFfz, bool getStv, bool allowUnlistedEmotes, string cacheFolder, ITaskLogger logger, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -231,6 +231,9 @@ namespace TwitchDownloaderCore
                 {
                     LogProviderException(ex, "BetterTTV", logger);
                 }
+
+                var bttvDir = new DirectoryInfo(Path.Combine(cacheFolder, "bttv"));
+                await RefreshOrLoadProviderMetadata(emoteResponse.BTTV, bttvDir, "BetterTTV", streamerId, logger, cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -245,6 +248,9 @@ namespace TwitchDownloaderCore
                 {
                     LogProviderException(ex, "FFZ", logger);
                 }
+
+                var ffzDir = new DirectoryInfo(Path.Combine(cacheFolder, "ffz"));
+                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, ffzDir, "FFZ", streamerId, logger, cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -259,6 +265,9 @@ namespace TwitchDownloaderCore
                 {
                     LogProviderException(ex, "7TV", logger);
                 }
+
+                var stvDir = new DirectoryInfo(Path.Combine(cacheFolder, "stv"));
+                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, stvDir, "7TV", streamerId, logger, cancellationToken);
             }
 
             return emoteResponse;
@@ -427,6 +436,57 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
+        /// <summary>
+        /// Persists fresh metadata to disk so future sessions can fall back to it when the API is temporarily unavailable.
+        /// </summary>
+        private static async Task RefreshOrLoadProviderMetadata(List<EmoteResponseItem> emotes, DirectoryInfo cacheFolder, string providerName, int streamerId, ITaskLogger logger, CancellationToken ct)
+        {
+            var cacheFile = new FileInfo(Path.Combine(cacheFolder.FullName, $"emotes_{streamerId}.json.gz"));
+
+            if (emotes is { Count: > 0 })
+            {
+                // Persist fresh metadata so future sessions can fall back to it.
+                try
+                {
+                    if (!cacheFolder.Exists)
+                        CreateDirectory(cacheFolder.FullName);
+
+                    await using var fs = cacheFile.OpenWrite();
+                    await using var gs = new GZipStream(fs, CompressionLevel.SmallestSize);
+                    await JsonSerializer.SerializeAsync(gs, emotes, JsonSerializerOptions, ct);
+                }
+                catch { /* best-effort - never block rendering on a metadata write failure */ }
+
+                return;
+            }
+
+            // API failed - try falling back to a previously cached emote list.
+            try
+            {
+                if (!cacheFile.Exists)
+                    return;
+
+                var timeSinceLastWrite = DateTime.UtcNow - cacheFile.LastWriteTimeUtc;
+                var maxAge = TimeSpan.FromHours(48);
+                if (timeSinceLastWrite > maxAge)
+                    return;
+
+                await using var fs = cacheFile.OpenRead();
+                await using var gs = new GZipStream(fs, CompressionMode.Decompress);
+                var cached = await JsonSerializer.DeserializeAsync<EmoteResponseItem[]>(gs, JsonSerializerOptions, ct);
+                if (cached is { Length: > 0 })
+                {
+                    var ageHours = timeSinceLastWrite.TotalHours;
+                    logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Length} emotes).");
+                    emotes.AddRange(cached);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"Failed to load cached {providerName} emote metadata: {ex.Message}");
+            }
+        }
+
         public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(List<Comment> comments, int streamerId, string cacheFolder, ITaskLogger logger, EmbeddedData embeddedData = null, bool bttv = true, bool ffz = true, bool stv = true, bool allowUnlistedEmotes = true, bool offline = false, CancellationToken cancellationToken = default)
         {
             // No 3rd party emotes are wanted
@@ -468,17 +528,16 @@ namespace TwitchDownloaderCore
                 return emotes.Values.ToList();
             }
 
+            EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, cacheFolder, logger, cancellationToken);
+
             DirectoryInfo bttvFolder = new DirectoryInfo(Path.Combine(cacheFolder, "bttv"));
             DirectoryInfo ffzFolder = new DirectoryInfo(Path.Combine(cacheFolder, "ffz"));
             DirectoryInfo stvFolder = new DirectoryInfo(Path.Combine(cacheFolder, "stv"));
-
-            EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, logger, cancellationToken);
 
             if (bttv)
             {
                 try
                 {
-                    emoteDataResponse.BTTV = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.BTTV, bttvFolder, "BetterTTV", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, "BetterTTV", logger, cancellationToken);
                 }
                 catch (Exception ex)
@@ -491,7 +550,6 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    emoteDataResponse.FFZ = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.FFZ, ffzFolder, "FFZ", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, "FFZ", logger, cancellationToken);
                 }
                 catch (Exception ex)
@@ -504,7 +562,6 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    emoteDataResponse.STV = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.STV, stvFolder, "7TV", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", logger, cancellationToken);
                 }
                 catch (Exception ex)
@@ -535,7 +592,7 @@ namespace TwitchDownloaderCore
                         select emote;
                 }
 
-                int fromCache = 0, fromDownload = 0, fromEmbed = emotes.Count;
+                int fromCache = 0, fromDownload = 0;
                 foreach (var emote in emoteResponseQuery)
                 {
                     var emoteUrl = emote.ImageUrl.Replace("[scale]", "2");
@@ -574,62 +631,8 @@ namespace TwitchDownloaderCore
 
                 if (emotes.Count > 0)
                 {
-                    logger.LogInfo($"Loaded {emotes.Count} {providerName} emote(s) - {fromEmbed} embedded, {fromCache} cached, {fromDownload} newly downloaded.");
+                    logger.LogInfo($"Loaded {emotes.Count} {providerName} emotes from cache/download - {fromCache} cached, {fromDownload} newly downloaded.");
                 }
-            }
-
-            // Persist fresh metadata to disk so future sessions can fall back to it when the API is unavailable.
-            // If the API call already failed (null), try loading the cached list.
-            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(int streamerId, List<EmoteResponseItem> emoteResponse, DirectoryInfo cacheFolder, string providerName,
-                ITaskLogger logger, CancellationToken ct)
-            {
-                var cacheFile = new FileInfo(Path.Combine(cacheFolder.FullName, $"emotes_{streamerId}.json.gz"));
-
-                if (emoteResponse is { Count: > 0 })
-                {
-                    // Persist fresh metadata so future sessions can fall back to it.
-                    try
-                    {
-                        if (!cacheFolder.Exists)
-                            CreateDirectory(cacheFolder.FullName);
-
-                        await using var fs = cacheFile.OpenWrite();
-                        await using var gs = new GZipStream(fs, CompressionLevel.SmallestSize);
-                        await JsonSerializer.SerializeAsync(gs, emoteResponse, JsonSerializerOptions, ct);
-                    }
-                    catch { /* best-effort - never block rendering on a metadata write failure */ }
-
-                    return emoteResponse;
-                }
-
-                // API failed - try falling back to a previously cached emote list.
-                try
-                {
-                    if (!cacheFile.Exists)
-                        return emoteResponse;
-
-                    var timeSinceLastWrite = DateTime.UtcNow - cacheFile.LastWriteTimeUtc;
-                    var maxAge = TimeSpan.FromHours(48);
-                    if (timeSinceLastWrite > maxAge)
-                        return emoteResponse;
-
-                    await using var fs = cacheFile.OpenRead();
-                    await using var gs = new GZipStream(fs, CompressionMode.Decompress);
-                    var cached = await JsonSerializer.DeserializeAsync<List<EmoteResponseItem>>(gs, JsonSerializerOptions, ct);
-                    if (cached is { Count: > 0 })
-                    {
-                        var ageHours = timeSinceLastWrite.TotalHours;
-                        logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Count} emotes).");
-
-                        return cached;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError($"Failed to load cached {providerName} emote metadata: {ex.Message}");
-                }
-
-                return emoteResponse;
             }
 
             static void LogProviderException(Exception ex, string providerName, ITaskLogger logger)

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -506,19 +506,6 @@ namespace TwitchDownloaderCore
                 {
                     emoteDataResponse.STV = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.STV, stvFolder, "7TV", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", logger, cancellationToken);
-
-                    // When metadata failed (STV is null), FetchEmoteImages returned early without touching
-                    // the cache. Report whether previously cached images exist so the user knows what to expect.
-                    if (emoteDataResponse.STV is null)
-                    {
-                        // Both the API and the metadata cache failed. Report image cache status for context.
-                        stvFolder.Refresh();
-                        var cachedCount = stvFolder.Exists ? stvFolder.GetFiles("*_2.*").Length : 0;
-                        if (cachedCount > 0)
-                            logger.LogWarning($"7TV API and metadata cache were both unavailable. {cachedCount} cached 7TV emote image(s) exist but cannot be matched - new 7TV emotes will not appear, embedded ones may still be present.");
-                        else
-                            logger.LogInfo("7TV API and metadata cache were both unavailable and no cached 7TV emotes were found - only embedded 7TV emotes will appear.");
-                    }
                 }
                 catch (Exception ex)
                 {
@@ -528,12 +515,9 @@ namespace TwitchDownloaderCore
 
             return emotes.Values.ToList();
 
-            static async Task FetchEmoteImages([AllowNull] IEnumerable<Comment> comments, [AllowNull] IEnumerable<EmoteResponseItem> emoteResponse, Dictionary<string, TwitchEmote> emotes,
+            static async Task FetchEmoteImages([AllowNull] IEnumerable<Comment> comments, IEnumerable<EmoteResponseItem> emoteResponse, Dictionary<string, TwitchEmote> emotes,
                 DirectoryInfo cacheFolder, string providerName, ITaskLogger logger, CancellationToken cancellationToken)
             {
-                if (emoteResponse is null)
-                    return;
-
                 if (!cacheFolder.Exists)
                     cacheFolder = CreateDirectory(cacheFolder.FullName);
 
@@ -596,12 +580,12 @@ namespace TwitchDownloaderCore
 
             // Persist fresh metadata to disk so future sessions can fall back to it when the API is unavailable.
             // If the API call already failed (null), try loading the cached list.
-            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(int streamerId, List<EmoteResponseItem> freshData, DirectoryInfo cacheFolder, string providerName,
+            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(int streamerId, List<EmoteResponseItem> emoteResponse, DirectoryInfo cacheFolder, string providerName,
                 ITaskLogger logger, CancellationToken ct)
             {
                 var cacheFile = new FileInfo(Path.Combine(cacheFolder.FullName, $"emotes_{streamerId}.json.gz"));
 
-                if (freshData is not null)
+                if (emoteResponse is { Count: > 0 })
                 {
                     // Persist fresh metadata so future sessions can fall back to it.
                     try
@@ -611,23 +595,23 @@ namespace TwitchDownloaderCore
 
                         await using var fs = cacheFile.OpenWrite();
                         await using var gs = new GZipStream(fs, CompressionLevel.SmallestSize);
-                        await JsonSerializer.SerializeAsync(gs, freshData, JsonSerializerOptions, ct);
+                        await JsonSerializer.SerializeAsync(gs, emoteResponse, JsonSerializerOptions, ct);
                     }
                     catch { /* best-effort - never block rendering on a metadata write failure */ }
 
-                    return freshData;
+                    return emoteResponse;
                 }
 
                 // API failed - try falling back to a previously cached emote list.
                 try
                 {
                     if (!cacheFile.Exists)
-                        return null;
+                        return emoteResponse;
 
                     var timeSinceLastWrite = DateTime.UtcNow - cacheFile.LastWriteTimeUtc;
                     var maxAge = TimeSpan.FromHours(48);
                     if (timeSinceLastWrite > maxAge)
-                        return null;
+                        return emoteResponse;
 
                     await using var fs = cacheFile.OpenRead();
                     await using var gs = new GZipStream(fs, CompressionMode.Decompress);
@@ -645,7 +629,7 @@ namespace TwitchDownloaderCore
                     logger.LogError($"Failed to load cached {providerName} emote metadata: {ex.Message}");
                 }
 
-                return null;
+                return emoteResponse;
             }
 
             static void LogProviderException(Exception ex, string providerName, ITaskLogger logger)

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -6,9 +6,10 @@ using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
-using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Extensions;
@@ -25,6 +26,13 @@ namespace TwitchDownloaderCore
         private static readonly HttpClient httpClient = new()
         {
             Timeout = TimeSpan.FromSeconds(60)
+        };
+
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            AllowTrailingCommas = true
         };
 
         private static readonly string[] BttvZeroWidth = ["SoSnowy", "IceCold", "SantaHat", "TopHat", "ReinDeer", "CandyCane", "cvMask", "cvHazmat"];
@@ -466,20 +474,11 @@ namespace TwitchDownloaderCore
 
             EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, logger, cancellationToken);
 
-            // For each provider: persist fresh metadata to disk so future sessions can fall back to it
-            // when the API is unavailable. If the API call already failed (null), try loading the cached list.
-            var metadataCacheAge = TimeSpan.FromHours(24);
-            if (bttv)
-                emoteDataResponse.BTTV = await RefreshOrLoadProviderMetadata(bttvFolder, emoteDataResponse.BTTV, "BetterTTV", metadataCacheAge, logger, cancellationToken);
-            if (ffz)
-                emoteDataResponse.FFZ = await RefreshOrLoadProviderMetadata(ffzFolder, emoteDataResponse.FFZ, "FFZ", metadataCacheAge, logger, cancellationToken);
-            if (stv)
-                emoteDataResponse.STV = await RefreshOrLoadProviderMetadata(stvFolder, emoteDataResponse.STV, "7TV", metadataCacheAge, logger, cancellationToken);
-
             if (bttv)
             {
                 try
                 {
+                    emoteDataResponse.BTTV = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.BTTV, bttvFolder, "BetterTTV", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, "BetterTTV", logger, cancellationToken);
                 }
                 catch (Exception ex)
@@ -492,6 +491,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
+                    emoteDataResponse.FFZ = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.FFZ, ffzFolder, "FFZ", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, "FFZ", logger, cancellationToken);
                 }
                 catch (Exception ex)
@@ -504,6 +504,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
+                    emoteDataResponse.STV = await RefreshOrLoadProviderMetadata(streamerId, emoteDataResponse.STV, stvFolder, "7TV", logger, cancellationToken);
                     await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", logger, cancellationToken);
 
                     // When metadata failed (STV is null), FetchEmoteImages returned early without touching
@@ -550,12 +551,12 @@ namespace TwitchDownloaderCore
                         select emote;
                 }
 
-                int fromCache = 0, downloaded = 0;
+                int fromCache = 0, fromDownload = 0, fromEmbed = emotes.Count;
                 foreach (var emote in emoteResponseQuery)
                 {
                     var emoteUrl = emote.ImageUrl.Replace("[scale]", "2");
                     var expectedCachePath = Path.Combine(cacheFolder.FullName, $"{emote.Id}_2.{emote.ImageType}");
-                    bool wasInCache = File.Exists(expectedCachePath);
+                    var wasInCache = File.Exists(expectedCachePath);
 
                     try
                     {
@@ -578,7 +579,7 @@ namespace TwitchDownloaderCore
                         }
                         else
                         {
-                            downloaded++;
+                            fromDownload++;
                         }
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -587,29 +588,33 @@ namespace TwitchDownloaderCore
                     }
                 }
 
-                var total = fromCache + downloaded;
-                if (total > 0)
-                    logger.LogInfo($"Loaded {total} {providerName} emote(s) - {fromCache} from cache, {downloaded} newly downloaded.");
-                else
-                    logger.LogVerbose($"No {providerName} emotes found in this chat.");
+                if (emotes.Count > 0)
+                {
+                    logger.LogInfo($"Loaded {emotes.Count} {providerName} emote(s) - {fromEmbed} embedded, {fromCache} cached, {fromDownload} newly downloaded.");
+                }
             }
 
-            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(
-                DirectoryInfo folder, List<EmoteResponseItem> freshData, string providerName,
-                TimeSpan maxAge, ITaskLogger logger, CancellationToken ct)
+            // Persist fresh metadata to disk so future sessions can fall back to it when the API is unavailable.
+            // If the API call already failed (null), try loading the cached list.
+            static async Task<List<EmoteResponseItem>> RefreshOrLoadProviderMetadata(int streamerId, List<EmoteResponseItem> freshData, DirectoryInfo cacheFolder, string providerName,
+                ITaskLogger logger, CancellationToken ct)
             {
-                var cacheFile = new FileInfo(Path.Combine(folder.FullName, "metadata.json"));
+                var cacheFile = new FileInfo(Path.Combine(cacheFolder.FullName, $"emotes_{streamerId}.json.gz"));
 
                 if (freshData is not null)
                 {
                     // Persist fresh metadata so future sessions can fall back to it.
                     try
                     {
-                        if (!folder.Exists)
-                            CreateDirectory(folder.FullName);
-                        await File.WriteAllBytesAsync(cacheFile.FullName, JsonSerializer.SerializeToUtf8Bytes(freshData), ct);
+                        if (!cacheFolder.Exists)
+                            CreateDirectory(cacheFolder.FullName);
+
+                        await using var fs = cacheFile.OpenWrite();
+                        await using var gs = new GZipStream(fs, CompressionLevel.SmallestSize);
+                        await JsonSerializer.SerializeAsync(gs, freshData, JsonSerializerOptions, ct);
                     }
                     catch { /* best-effort - never block rendering on a metadata write failure */ }
+
                     return freshData;
                 }
 
@@ -619,21 +624,25 @@ namespace TwitchDownloaderCore
                     if (!cacheFile.Exists)
                         return null;
 
-                    if (DateTime.UtcNow - cacheFile.LastWriteTimeUtc > maxAge)
+                    var timeSinceLastWrite = DateTime.UtcNow - cacheFile.LastWriteTimeUtc;
+                    var maxAge = TimeSpan.FromHours(48);
+                    if (timeSinceLastWrite > maxAge)
                         return null;
 
-                    var bytes = await File.ReadAllBytesAsync(cacheFile.FullName, ct);
-                    var cached = JsonSerializer.Deserialize<List<EmoteResponseItem>>(bytes);
+                    await using var fs = cacheFile.OpenRead();
+                    await using var gs = new GZipStream(fs, CompressionMode.Decompress);
+                    var cached = await JsonSerializer.DeserializeAsync<List<EmoteResponseItem>>(gs, JsonSerializerOptions, ct);
                     if (cached is { Count: > 0 })
                     {
-                        var ageHours = (DateTime.UtcNow - cacheFile.LastWriteTimeUtc).TotalHours;
+                        var ageHours = timeSinceLastWrite.TotalHours;
                         logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Count} emotes).");
+
                         return cached;
                     }
                 }
                 catch (Exception ex)
                 {
-                    logger.LogVerbose($"Failed to load cached {providerName} emote metadata: {ex.Message}");
+                    logger.LogError($"Failed to load cached {providerName} emote metadata: {ex.Message}");
                 }
 
                 return null;

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -215,7 +215,8 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlClipSearchResponse>();
         }
 
-        public static async Task<EmoteResponse> GetThirdPartyEmotesMetadata(int streamerId, bool getBttv, bool getFfz, bool getStv, bool allowUnlistedEmotes, string cacheFolder, ITaskLogger logger, CancellationToken cancellationToken = default)
+        public static async Task<EmoteResponse> GetThirdPartyEmotesMetadata(int streamerId, bool getBttv, bool getFfz, bool getStv, bool allowUnlistedEmotes, string cacheFolder, bool offline, ITaskLogger logger,
+            CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -225,7 +226,10 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    emoteResponse.BTTV = await GetBttvEmotesMetadata(streamerId, cancellationToken);
+                    if (!offline)
+                    {
+                        emoteResponse.BTTV = await GetBttvEmotesMetadata(streamerId, cancellationToken);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -233,7 +237,7 @@ namespace TwitchDownloaderCore
                 }
 
                 var bttvDir = new DirectoryInfo(Path.Combine(cacheFolder, "bttv"));
-                await RefreshOrLoadProviderMetadata(emoteResponse.BTTV, bttvDir, "BetterTTV", streamerId, logger, cancellationToken);
+                await RefreshOrLoadProviderMetadata(emoteResponse.BTTV, bttvDir, "BetterTTV", streamerId, offline, logger, cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -242,7 +246,10 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    emoteResponse.FFZ = await GetFfzEmotesMetadata(streamerId, cancellationToken);
+                    if (!offline)
+                    {
+                        emoteResponse.FFZ = await GetFfzEmotesMetadata(streamerId, cancellationToken);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -250,7 +257,7 @@ namespace TwitchDownloaderCore
                 }
 
                 var ffzDir = new DirectoryInfo(Path.Combine(cacheFolder, "ffz"));
-                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, ffzDir, "FFZ", streamerId, logger, cancellationToken);
+                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, ffzDir, "FFZ", streamerId, offline, logger, cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -259,7 +266,10 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    emoteResponse.STV = await GetStvEmotesMetadata(streamerId, allowUnlistedEmotes, logger, cancellationToken);
+                    if (!offline)
+                    {
+                        emoteResponse.STV = await GetStvEmotesMetadata(streamerId, allowUnlistedEmotes, logger, cancellationToken);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -267,7 +277,7 @@ namespace TwitchDownloaderCore
                 }
 
                 var stvDir = new DirectoryInfo(Path.Combine(cacheFolder, "stv"));
-                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, stvDir, "7TV", streamerId, logger, cancellationToken);
+                await RefreshOrLoadProviderMetadata(emoteResponse.FFZ, stvDir, "7TV", streamerId, offline, logger, cancellationToken);
             }
 
             return emoteResponse;
@@ -439,7 +449,7 @@ namespace TwitchDownloaderCore
         /// <summary>
         /// Persists fresh metadata to disk so future sessions can fall back to it when the API is temporarily unavailable.
         /// </summary>
-        private static async Task RefreshOrLoadProviderMetadata(List<EmoteResponseItem> emotes, DirectoryInfo cacheFolder, string providerName, int streamerId, ITaskLogger logger, CancellationToken ct)
+        private static async Task RefreshOrLoadProviderMetadata(List<EmoteResponseItem> emotes, DirectoryInfo cacheFolder, string providerName, int streamerId, bool offline, ITaskLogger logger, CancellationToken ct)
         {
             var cacheFile = new FileInfo(Path.Combine(cacheFolder.FullName, $"emotes_{streamerId}.json.gz"));
 
@@ -477,7 +487,10 @@ namespace TwitchDownloaderCore
                 if (cached is { Length: > 0 })
                 {
                     var ageHours = timeSinceLastWrite.TotalHours;
-                    logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Length} emotes).");
+                    if (offline)
+                        logger.LogInfo($"Using cached {providerName} emote list from {ageHours:F1}h ago ({cached.Length} emotes).");
+                    else
+                        logger.LogInfo($"{providerName} API unavailable. Using cached emote list from {ageHours:F1}h ago ({cached.Length} emotes).");
                     emotes.AddRange(cached);
                 }
             }
@@ -522,13 +535,7 @@ namespace TwitchDownloaderCore
                 }
             }
 
-            // Directly return if we are in offline, no need for a network request
-            if (offline)
-            {
-                return emotes.Values.ToList();
-            }
-
-            EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, cacheFolder, logger, cancellationToken);
+            EmoteResponse emoteDataResponse = await GetThirdPartyEmotesMetadata(streamerId, bttv, ffz, stv, allowUnlistedEmotes, cacheFolder, offline, logger, cancellationToken);
 
             DirectoryInfo bttvFolder = new DirectoryInfo(Path.Combine(cacheFolder, "bttv"));
             DirectoryInfo ffzFolder = new DirectoryInfo(Path.Combine(cacheFolder, "ffz"));
@@ -538,7 +545,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, "BetterTTV", logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.BTTV, emotes, bttvFolder, "BetterTTV", offline, logger, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -550,7 +557,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, "FFZ", logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.FFZ, emotes, ffzFolder, "FFZ", offline, logger, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -562,7 +569,7 @@ namespace TwitchDownloaderCore
             {
                 try
                 {
-                    await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", logger, cancellationToken);
+                    await FetchEmoteImages(comments, emoteDataResponse.STV, emotes, stvFolder, "7TV", offline, logger, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -573,7 +580,7 @@ namespace TwitchDownloaderCore
             return emotes.Values.ToList();
 
             static async Task FetchEmoteImages([AllowNull] IEnumerable<Comment> comments, IEnumerable<EmoteResponseItem> emoteResponse, Dictionary<string, TwitchEmote> emotes,
-                DirectoryInfo cacheFolder, string providerName, ITaskLogger logger, CancellationToken cancellationToken)
+                DirectoryInfo cacheFolder, string providerName, bool offline, ITaskLogger logger, CancellationToken cancellationToken)
             {
                 if (!cacheFolder.Exists)
                     cacheFolder = CreateDirectory(cacheFolder.FullName);
@@ -601,7 +608,7 @@ namespace TwitchDownloaderCore
 
                     try
                     {
-                        var (bytes, codec) = await GetImage(cacheFolder, emoteUrl, emote.Id, 2, emote.ImageType, false, logger, cancellationToken);
+                        var (bytes, codec) = await GetImage(cacheFolder, emoteUrl, emote.Id, 2, emote.ImageType, offline, logger, cancellationToken);
                         if (bytes is null)
                         {
                             continue;


### PR DESCRIPTION
Guard against null metadata when BTTV, FFZ, or 7TV are unreachable so a render does not crash, and cache provider metadata so emotes still resolve from disk when the API is down.

Related to #1542 and #1457
