### PR TITLE
Recover hidden VODs from channels with past broadcasts disabled

### DIFF
--- a/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/VideoDownloadOptions.cs
@@ -20,5 +20,18 @@ namespace TwitchDownloaderCore.Options
         public Func<FileInfo, FileInfo> FileCollisionCallback { get; set; } = info => info;
         public VideoTrimMode TrimMode { get; set; }
         public bool DelayDownload { get; set; }
+
+        /// <summary>
+        /// When set, the downloader ignores <see cref="Id"/> and instead reconstructs the broadcast's
+        /// public DVR playlist from <see cref="ChannelLogin"/>, <see cref="StreamId"/>, and
+        /// <see cref="StreamStartTime"/>. This is an unofficial method for grabbing broadcasts from
+        /// channels that have "Store past broadcasts" disabled - see <see cref="TwitchHelper.RecoverHiddenVodPlaylistUrl"/>.
+        /// It is best-effort: it only works while the broadcast's segments still exist on the CDN
+        /// (typically the broadcast must be live or to have ended within the last day or two).
+        /// </summary>
+        public bool RecoverHiddenVod { get; set; }
+        public string ChannelLogin { get; set; }
+        public string StreamId { get; set; }
+        public DateTimeOffset StreamStartTime { get; set; }
     }
 }

--- a/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegMetadata.cs
@@ -21,6 +21,20 @@ namespace TwitchDownloaderCore.Tools
             await SerializeChapters(sw, videoMomentEdges, startOffset, videoLength);
         }
 
+        /// <summary>
+        /// Serializes metadata for a recovered hidden VOD, where no <see cref="VideoInfo"/> is available
+        /// because the broadcast was never published. Only the values we can derive from the live
+        /// stream metadata are written, and there are no chapters.
+        /// </summary>
+        public static async Task SerializeRecoveredAsync(string filePath, string streamId, [AllowNull] string streamer, DateTimeOffset createdAt)
+        {
+            await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
+            await using var sw = new StreamWriter(fs) { NewLine = LINE_FEED };
+
+            var title = string.IsNullOrWhiteSpace(streamer) ? $"Recovered broadcast {streamId}" : $"{streamer} - recovered broadcast {streamId}";
+            await SerializeGlobalMetadata(sw, streamer, streamId, title, createdAt.UtcDateTime, 0);
+        }
+
         public static async Task SerializeAsync(string filePath, string videoId, ShareClipRenderStatusClip clip, IEnumerable<VideoMomentEdge> videoMomentEdges)
         {
             await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using TwitchDownloaderCore.Chat;
@@ -40,6 +41,241 @@ namespace TwitchDownloaderCore
             using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<GqlVideoResponse>();
+        }
+
+        /// <summary>
+        /// Fetches the live/most-recent broadcast metadata (stream id and start time) for a channel login.
+        /// This is the input needed to reconstruct a hidden VOD's public DVR playlist path - see
+        /// <see cref="RecoverHiddenVodPlaylistUrl"/> - for channels that have "Store past broadcasts" disabled.
+        /// </summary>
+        public static async Task<GqlStreamMetadataResponse> GetStreamMetadata(string channelLogin)
+        {
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri("https://gql.twitch.tv/gql"),
+                Method = HttpMethod.Post,
+                Content = new StringContent("{\"query\":\"query{user(login:\\\"" + channelLogin + "\\\"){id,login,displayName,stream{id,createdAt}}}\",\"variables\":{}}", Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<GqlStreamMetadataResponse>();
+        }
+
+        // Public Twitch VOD CDN hosts. Segments for a given broadcast live on exactly one of these,
+        // so the reconstructed path must be probed against each until one responds.
+        private static readonly string[] VodCdnDomains =
+        {
+            "https://d2e2de1etea730.cloudfront.net",
+            "https://dqrpb9wgowsf5.cloudfront.net",
+            "https://ds0h3roq6wcgc.cloudfront.net",
+            "https://d2nvs31859zcd8.cloudfront.net",
+            "https://d2aba1wr3818hz.cloudfront.net",
+            "https://d3c27h4odz752x.cloudfront.net",
+            "https://dgeft87wbj63p.cloudfront.net",
+            "https://d1m7jfoe9zdc1j.cloudfront.net",
+            "https://d3vd9lfkzbru3h.cloudfront.net",
+            "https://d2vjef5jvl6bfs.cloudfront.net",
+            "https://d1ymi26ma8va5x.cloudfront.net",
+            "https://d1mhjrowxxagfy.cloudfront.net",
+            "https://ddacn6pr5v0tl.cloudfront.net",
+            "https://d3aqoihi2n8ty8.cloudfront.net",
+            "https://vod-secure.twitch.tv",
+            "https://vod-metro.twitch.tv",
+            "https://vod-pop-secure.twitch.tv",
+        };
+
+        // Quality renditions to look for, best first. The source rendition ("chunked") is preferred,
+        // but it is not always retained, so transcodes are probed too. "audio_only" is last.
+        private static readonly string[] VodQualityRenditions =
+        {
+            "chunked", "1080p60", "1080p30", "720p60", "720p30", "480p30", "360p30", "160p30", "audio_only",
+        };
+
+        /// <summary>
+        /// Friendly display name for a DVR rendition folder (e.g. <c>chunked</c> → <c>Source</c>).
+        /// </summary>
+        public static string DescribeVodRendition(string rendition) => rendition switch
+        {
+            "chunked" => "Source",
+            "audio_only" => "Audio Only",
+            _ => rendition,
+        };
+
+        /// <summary>
+        /// Resolves the base URL (<c>{host}/{pathSegment}</c>) of the CDN host serving a hidden broadcast,
+        /// then probes which quality renditions are actually available under it. Returns a null base URL
+        /// and empty list if the broadcast cannot be located (e.g. its segments have been purged).
+        /// </summary>
+        public static async Task<(string baseUrl, List<string> qualities)> RecoverHiddenVodQualities(
+            string channelLogin, string streamId, DateTimeOffset startTime, ITaskLogger logger = null, CancellationToken cancellationToken = default)
+        {
+            var baseUrl = await ResolveHiddenVodBaseUrlAsync(channelLogin.ToLowerInvariant(), streamId, startTime, cancellationToken);
+            if (baseUrl is null)
+            {
+                logger?.LogWarning($"Could not locate the broadcast's segments on any known Twitch CDN for '{channelLogin}' (stream {streamId}).");
+                return (null, new List<string>());
+            }
+
+            var qualities = await ProbeAvailableQualitiesAsync(baseUrl, cancellationToken);
+            return (baseUrl, qualities);
+        }
+
+        /// <summary>
+        /// Reconstructs the public DVR playlist (<c>index-dvr.m3u8</c>) URL for a broadcast and returns the
+        /// requested quality rendition if it exists, otherwise the best available one. Returns
+        /// <see langword="null"/> if the broadcast cannot be located.
+        /// </summary>
+        /// <param name="channelLogin">The broadcaster's login (lowercase channel name).</param>
+        /// <param name="streamId">The broadcast/stream id from <see cref="GetStreamMetadata"/>.</param>
+        /// <param name="startTime">The broadcast start time (stream <c>createdAt</c>).</param>
+        /// <param name="preferredQuality">Rendition folder to prefer (e.g. <c>chunked</c>, <c>720p60</c>); null = best available.</param>
+        public static async Task<string> RecoverHiddenVodPlaylistUrl(string channelLogin, string streamId, DateTimeOffset startTime, string preferredQuality = null, ITaskLogger logger = null, CancellationToken cancellationToken = default)
+        {
+            var baseUrl = await ResolveHiddenVodBaseUrlAsync(channelLogin.ToLowerInvariant(), streamId, startTime, cancellationToken);
+            if (baseUrl is null)
+            {
+                logger?.LogWarning($"Could not recover a hidden VOD for '{channelLogin}' (stream {streamId}). The broadcast may be too old - DVR segments are typically purged within a day or two.");
+                return null;
+            }
+
+            // Try the requested rendition first, then fall through the priority list.
+            var ordered = new List<string>();
+            if (!string.IsNullOrWhiteSpace(preferredQuality))
+                ordered.Add(preferredQuality);
+            foreach (var q in VodQualityRenditions)
+                if (!ordered.Contains(q))
+                    ordered.Add(q);
+
+            foreach (var quality in ordered)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var url = $"{baseUrl}/{quality}/index-dvr.m3u8";
+                if (await UrlExistsAsync(url, cancellationToken))
+                {
+                    if (!string.IsNullOrWhiteSpace(preferredQuality) && quality != preferredQuality)
+                        logger?.LogWarning($"Requested quality '{preferredQuality}' was unavailable; recovered '{quality}' instead: {url}");
+                    else
+                        logger?.LogInfo($"Recovered hidden VOD playlist ({quality}) at {url}");
+                    return url;
+                }
+            }
+
+            logger?.LogWarning($"Located the broadcast on the CDN but none of the known quality renditions were available for '{channelLogin}' (stream {streamId}).");
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the CDN host serving a broadcast and returns its base URL (<c>{host}/{pathSegment}</c>),
+        /// probing a small timestamp window for rounding. Source is tried first across all hosts; if it
+        /// is not retained, transcode renditions are tried at the exact timestamp. Returns <see langword="null"/>
+        /// if no host serves the broadcast.
+        /// </summary>
+        private static async Task<string> ResolveHiddenVodBaseUrlAsync(string login, string streamId, DateTimeOffset startTime, CancellationToken cancellationToken)
+        {
+            var startUnix = startTime.ToUnixTimeSeconds();
+
+            // The path hash uses integer unix seconds, but the reported start time can be off by a
+            // second due to sub-second rounding, so probe a tiny window around it (exact first).
+            var candidateTimestamps = new List<long> { startUnix };
+            for (long offset = 1; offset <= 2; offset++)
+            {
+                candidateTimestamps.Add(startUnix - offset);
+                candidateTimestamps.Add(startUnix + offset);
+            }
+
+            foreach (var candidateUnix in candidateTimestamps)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var baseUrl = await FindServingCdnHostAsync(BuildVodPathSegment(login, streamId, candidateUnix), "chunked", cancellationToken);
+                if (baseUrl is not null)
+                    return baseUrl;
+            }
+
+            // Source wasn't found anywhere; the broadcast may only have transcodes retained.
+            var exactSegment = BuildVodPathSegment(login, streamId, startUnix);
+            foreach (var quality in VodQualityRenditions)
+            {
+                if (quality == "chunked") continue;
+                cancellationToken.ThrowIfCancellationRequested();
+                var baseUrl = await FindServingCdnHostAsync(exactSegment, quality, cancellationToken);
+                if (baseUrl is not null)
+                    return baseUrl;
+            }
+
+            return null;
+        }
+
+        /// <summary>Probes all known renditions under <paramref name="baseUrl"/> concurrently and returns those that exist, best first.</summary>
+        private static async Task<List<string>> ProbeAvailableQualitiesAsync(string baseUrl, CancellationToken cancellationToken)
+        {
+            var checks = VodQualityRenditions
+                .Select(async q => await UrlExistsAsync($"{baseUrl}/{q}/index-dvr.m3u8", cancellationToken) ? q : null)
+                .ToArray();
+            var results = await Task.WhenAll(checks);
+            return results.Where(q => q is not null).Select(q => q!).ToList();
+        }
+
+        private static async Task<bool> UrlExistsAsync(string url, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Head, url);
+                using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string BuildVodPathSegment(string login, string streamId, long startUnix)
+        {
+            var baseString = $"{login}_{streamId}_{startUnix}";
+            var hash = Convert.ToHexStringLower(SHA1.HashData(Encoding.UTF8.GetBytes(baseString)))[..20];
+            return $"{hash}_{baseString}";
+        }
+
+        /// <summary>
+        /// Probes every known CDN host concurrently for <c>{host}/{pathSegment}/{quality}/index-dvr.m3u8</c>
+        /// and returns the base URL (<c>{host}/{pathSegment}</c>) of the first host that responds, cancelling
+        /// the remaining probes. Returns <see langword="null"/> if no host serves it.
+        /// </summary>
+        private static async Task<string> FindServingCdnHostAsync(string pathSegment, string quality, CancellationToken cancellationToken)
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var probes = VodCdnDomains.Select(async domain =>
+            {
+                var baseUrl = $"{domain}/{pathSegment}";
+                try
+                {
+                    using var request = new HttpRequestMessage(HttpMethod.Head, $"{baseUrl}/{quality}/index-dvr.m3u8");
+                    using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+                    return response.IsSuccessStatusCode ? baseUrl : null;
+                }
+                catch
+                {
+                    // Host unreachable, rejected the request, or the probe was cancelled by a winner.
+                    return null;
+                }
+            }).ToList();
+
+            while (probes.Count > 0)
+            {
+                var finished = await Task.WhenAny(probes);
+                probes.Remove(finished);
+
+                var baseUrl = await finished;
+                if (baseUrl is not null)
+                {
+                    await cts.CancelAsync(); // stop the remaining in-flight probes
+                    return baseUrl;
+                }
+            }
+
+            return null;
         }
 
         public static async Task<GqlVideoTokenResponse> GetVideoToken(long videoId, string authToken)

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlStreamMetadataResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlStreamMetadataResponse.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace TwitchDownloaderCore.TwitchObjects.Gql
+{
+    public class GqlStreamMetadataResponse
+    {
+        public GqlStreamMetadataData data { get; set; }
+    }
+
+    public class GqlStreamMetadataData
+    {
+        public StreamMetadataUser user { get; set; }
+    }
+
+    public class StreamMetadataUser
+    {
+        public string id { get; set; }
+        public string login { get; set; }
+        public string displayName { get; set; }
+        public StreamMetadataStream stream { get; set; }
+    }
+
+    public class StreamMetadataStream
+    {
+        public string id { get; set; }
+        public DateTimeOffset createdAt { get; set; }
+    }
+}

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -61,25 +61,56 @@ namespace TwitchDownloaderCore
 
             try
             {
-                GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(downloadOptions.Id);
-                if (videoInfoResponse.data.video == null)
+                M3U8 playlist;
+                Uri baseUrl;
+                DateTimeOffset airDate;
+                string[] allQualityPaths;
+                int? storageCheckBandwidth;
+                VideoInfo videoInfo;
+                IEnumerable<VideoMomentEdge> chapterEdges;
+                bool codecsContainAv1;
+
+                if (downloadOptions.RecoverHiddenVod)
                 {
-                    throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
+                    var playlistUrl = await ResolveRecoveredPlaylistUrl(cancellationToken);
+                    baseUrl = new Uri(playlistUrl[..(playlistUrl.LastIndexOf('/') + 1)], UriKind.Absolute);
+                    (playlist, airDate) = await GetVideoPlaylist(playlistUrl, cancellationToken);
+
+                    // A recovered DVR playlist is the source-quality media playlist directly - there is no
+                    // master playlist, published metadata, or chapter data to fetch.
+                    allQualityPaths = new[] { "chunked" };
+                    storageCheckBandwidth = null;
+                    videoInfo = null;
+                    chapterEdges = null;
+                    codecsContainAv1 = false;
                 }
+                else
+                {
+                    GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(downloadOptions.Id);
+                    if (videoInfoResponse.data.video == null)
+                    {
+                        throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
+                    }
 
-                GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(downloadOptions.Id, videoInfoResponse.data.video, _progress);
+                    GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(downloadOptions.Id, videoInfoResponse.data.video, _progress);
 
-                var (allQualityPaths, qualityPlaylist) = await GetQualityPlaylist();
+                    var (qualityPaths, qualityPlaylist) = await GetQualityPlaylist();
 
-                var playlistUrl = qualityPlaylist.Path;
-                var baseUrl = new Uri(playlistUrl[..(playlistUrl.LastIndexOf('/') + 1)], UriKind.Absolute);
+                    var playlistUrl = qualityPlaylist.Path;
+                    baseUrl = new Uri(playlistUrl[..(playlistUrl.LastIndexOf('/') + 1)], UriKind.Absolute);
 
-                var videoInfo = videoInfoResponse.data.video;
-                var (playlist, airDate) = await GetVideoPlaylist(playlistUrl, cancellationToken);
+                    videoInfo = videoInfoResponse.data.video;
+                    chapterEdges = videoChapterResponse.data.video.moments.edges;
+                    (playlist, airDate) = await GetVideoPlaylist(playlistUrl, cancellationToken);
+                    allQualityPaths = qualityPaths;
+                    storageCheckBandwidth = qualityPlaylist.StreamInfo.Bandwidth;
+                    codecsContainAv1 = qualityPlaylist.StreamInfo.Codecs.Any(x => x.StartsWith("av01"));
+                }
 
                 var videoListCrop = GetStreamListTrim(playlist.Streams, out var videoLength, out var startOffset, out var endDuration);
 
-                CheckAvailableStorageSpace(qualityPlaylist.StreamInfo.Bandwidth, videoLength);
+                if (storageCheckBandwidth.HasValue)
+                    CheckAvailableStorageSpace(storageCheckBandwidth.Value, videoLength);
 
                 if (Directory.Exists(_vodCacheDir))
                 {
@@ -88,7 +119,7 @@ namespace TwitchDownloaderCore
 
                 TwitchHelper.CreateDirectory(_vodCacheDir);
 
-                if (qualityPlaylist.StreamInfo.Codecs.Any(x => x.StartsWith("av01")))
+                if (codecsContainAv1)
                 {
                     _progress.LogWarning("AV1 VOD support is still experimental. " +
                                          "If you encounter playback issues, try using an FFmpeg-based application like MPV, Kdenlive, or Blender, or re-encode the video file as H.264/AVC or H.265/HEVC with FFmpeg or Handbrake.");
@@ -108,8 +139,15 @@ namespace TwitchDownloaderCore
                 _progress.SetTemplateStatus("Finalizing Video {0}% [4/4]", 0);
 
                 string metadataPath = Path.Combine(_vodCacheDir, "metadata.txt");
-                await FfmpegMetadata.SerializeAsync(metadataPath, downloadOptions.Id.ToString(), videoInfo, downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero, videoLength,
-                    videoChapterResponse.data.video.moments.edges);
+                if (downloadOptions.RecoverHiddenVod)
+                {
+                    await FfmpegMetadata.SerializeRecoveredAsync(metadataPath, downloadOptions.StreamId, downloadOptions.ChannelLogin, downloadOptions.StreamStartTime);
+                }
+                else
+                {
+                    await FfmpegMetadata.SerializeAsync(metadataPath, downloadOptions.Id.ToString(), videoInfo, downloadOptions.TrimBeginning ? downloadOptions.TrimBeginningTime : TimeSpan.Zero, videoLength,
+                        chapterEdges);
+                }
 
                 var concatListPath = Path.Combine(_vodCacheDir, "concat.txt");
                 var streamIds = GetStreamIds(playlist);
@@ -670,6 +708,54 @@ namespace TwitchDownloaderCore
             videoLength = TimeSpan.FromSeconds((double)((endTime - endOffset) - (startTime + startOffset)));
 
             return new Range(startIndex, endIndex);
+        }
+
+        /// <summary>
+        /// Resolves the DVR playlist URL for a hidden VOD. If the broadcast's stream id and start time
+        /// were not supplied on the options (e.g. captured earlier while live), they are fetched fresh
+        /// from the channel's current stream. Throws if the channel is offline and no metadata was
+        /// provided, or if no CDN is serving the reconstructed playlist.
+        /// </summary>
+        private async Task<string> ResolveRecoveredPlaylistUrl(CancellationToken cancellationToken)
+        {
+            _progress.SetStatus("Recovering Hidden VOD [1/4]");
+
+            var login = downloadOptions.ChannelLogin;
+            var streamId = downloadOptions.StreamId;
+            var startTime = downloadOptions.StreamStartTime;
+
+            if (string.IsNullOrWhiteSpace(login))
+                throw new InvalidOperationException("A channel login is required to recover a hidden VOD.");
+
+            if (string.IsNullOrWhiteSpace(streamId) || startTime == default)
+            {
+                _progress.LogInfo($"Fetching live broadcast metadata for '{login}'...");
+                var metadata = await TwitchHelper.GetStreamMetadata(login);
+                var stream = metadata?.data?.user?.stream;
+                if (stream is null)
+                {
+                    throw new InvalidOperationException(
+                        $"'{login}' is not currently live and no captured broadcast metadata was provided. " +
+                        "Hidden VOD recovery needs the stream id and start time, which are only available while the channel is live.");
+                }
+
+                login = metadata.data.user.login ?? login;
+                streamId = stream.id;
+                startTime = stream.createdAt;
+                downloadOptions.ChannelLogin = login;
+                downloadOptions.StreamId = streamId;
+                downloadOptions.StreamStartTime = startTime;
+            }
+
+            var playlistUrl = await TwitchHelper.RecoverHiddenVodPlaylistUrl(login, streamId, startTime, downloadOptions.Quality, _progress, cancellationToken);
+            if (string.IsNullOrEmpty(playlistUrl))
+            {
+                throw new InvalidOperationException(
+                    "Could not locate the broadcast's segments on any known Twitch CDN. " +
+                    "The broadcast may have ended too long ago (DVR segments are typically purged within a day or two), or the reconstruction method may no longer be valid.");
+            }
+
+            return playlistUrl;
         }
 
         private async Task<(string[] allQualityPaths, M3U8.Stream qualityPlaylist)> GetQualityPlaylist()

--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -59,11 +59,20 @@
             <emoji:TextBlock TextWrapping="Wrap" x:Name="textTitle" Foreground="{DynamicResource AppText}" />
         </StackPanel>
         <!-- MIDDLE -->
-        <WrapPanel Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Margin="0,0,0,10" Orientation="Horizontal" HorizontalAlignment="Center">
-            <TextBlock Margin="3,8,3,3" Text="{lex:Loc VodLinkId}" Foreground="{DynamicResource AppText}" />
-            <TextBox x:Name="textUrl" Margin="3" MinWidth="200" MaxWidth="400" KeyDown="TextUrl_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
-            <Button x:Name="btnGetInfo" Margin="3" MinWidth="50" Content="{lex:Loc GetInfo}" Click="btnGetInfo_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
-        </WrapPanel>
+        <StackPanel Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Margin="0,0,0,10" HorizontalAlignment="Center">
+            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock x:Name="labelUrl" Margin="3,8,3,3" Text="{lex:Loc VodLinkId}" Foreground="{DynamicResource AppText}" />
+                <TextBox x:Name="textUrl" Margin="3" MinWidth="200" MaxWidth="400" KeyDown="TextUrl_OnKeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" />
+                <Button x:Name="btnGetInfo" Margin="3" MinWidth="50" Content="{lex:Loc GetInfo}" Click="btnGetInfo_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </WrapPanel>
+            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
+                <CheckBox x:Name="checkRecoverHidden" VerticalAlignment="Center" Checked="checkRecoverHidden_Changed" Unchecked="checkRecoverHidden_Changed" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+                    <TextBlock Foreground="{DynamicResource AppText}"><Run Text="Recover hidden VOD (channel with past broadcasts off)"/><Hyperlink ToolTipService.ShowDuration="60000" Foreground="{DynamicResource AppHyperlink}"><Hyperlink.ToolTip><TextBlock MaxWidth="420" TextWrapping="Wrap"><Run Text="Reconstructs the broadcast's hidden DVR playlist directly from Twitch's public CDN using the channel's live stream metadata, then lets you pick from whichever quality renditions Twitch retained. This is an unofficial method that Twitch could break at any time. It only works while the channel is live or has very recently ended (DVR segments are usually purged within a day or two). Enter the channel name (not a video URL) and the channel must be live to capture the required stream id and start time."/></TextBlock></Hyperlink.ToolTip>(?)</Hyperlink></TextBlock>
+                </CheckBox>
+            </WrapPanel>
+            <TextBlock x:Name="textRecoverWarning" Visibility="Collapsed" Margin="0,4,0,0" MaxWidth="460" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Foreground="#E0A030"
+                       Text="Hidden VOD recovery is unofficial and best-effort: enter the channel name above (the channel must be live), only the quality renditions Twitch retained are available, and this may stop working if Twitch changes their CDN scheme." />
+        </StackPanel>
         <StackPanel Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Margin="0,20,0,0" Orientation="Horizontal" HorizontalAlignment="Center">
             <StackPanel HorizontalAlignment="Left">
                 <TextBlock Text="{lex:Loc Length}" HorizontalAlignment="Right" Foreground="{DynamicResource AppText}" />

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -77,7 +77,115 @@ namespace TwitchDownloaderWPF
 
         private async void btnGetInfo_Click(object sender, RoutedEventArgs e)
         {
-            await GetVideoInfo();
+            if (checkRecoverHidden.IsChecked == true)
+                await GetHiddenVodInfo();
+            else
+                await GetVideoInfo();
+        }
+
+        // Captured stream metadata for hidden-VOD recovery. Populated by GetHiddenVodInfo while the
+        // channel is live, since this data is unavailable once the stream ends.
+        private string recoverChannelLogin;
+        private string recoverStreamId;
+        private DateTimeOffset recoverStreamStartTime;
+
+        private void checkRecoverHidden_Changed(object sender, RoutedEventArgs e)
+        {
+            var recover = checkRecoverHidden.IsChecked == true;
+            textRecoverWarning.Visibility = recover ? Visibility.Visible : Visibility.Collapsed;
+            labelUrl.Text = recover ? "Channel:" : Translations.Strings.VodLinkId;
+
+            SetEnabled(false);
+            recoverChannelLogin = null;
+            recoverStreamId = null;
+        }
+
+        private async Task GetHiddenVodInfo()
+        {
+            var channel = textUrl.Text.Trim();
+            if (string.IsNullOrWhiteSpace(channel))
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Enter a channel name to recover a hidden VOD from.", Translations.Strings.UnableToGetInfo, MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            // Accept a full URL or a bare login.
+            channel = channel.TrimEnd('/');
+            var lastSlash = channel.LastIndexOf('/');
+            if (lastSlash >= 0)
+                channel = channel[(lastSlash + 1)..];
+            channel = channel.ToLowerInvariant();
+
+            try
+            {
+                var metadata = await TwitchHelper.GetStreamMetadata(channel);
+                var user = metadata?.data?.user;
+                if (user is null)
+                {
+                    throw new InvalidOperationException($"No Twitch channel found for '{channel}'.");
+                }
+                if (user.stream is null)
+                {
+                    throw new InvalidOperationException(
+                        $"'{channel}' is not currently live. Hidden VOD recovery needs the stream id and start time, " +
+                        "which Twitch only exposes while the channel is live.");
+                }
+
+                recoverChannelLogin = user.login ?? channel;
+                recoverStreamId = user.stream.id;
+                recoverStreamStartTime = user.stream.createdAt;
+
+                textStreamer.Text = user.displayName ?? user.login ?? channel;
+                streamerId = user.id;
+                textTitle.Text = $"Hidden broadcast (stream {recoverStreamId})";
+                var startLocal = Settings.Default.UTCVideoTime ? recoverStreamStartTime.UtcDateTime : recoverStreamStartTime.LocalDateTime;
+                textCreatedAt.Text = startLocal.ToString(CultureInfo.CurrentCulture);
+                currentVideoTime = startLocal;
+                currentVideoId = 0;
+
+                _ = ThumbnailService.TryGetThumb(ThumbnailService.THUMBNAIL_MISSING_URL, out var image);
+                imgThumbnail.Source = image;
+
+                comboQuality.Items.Clear();
+                var (_, qualities) = await TwitchHelper.RecoverHiddenVodQualities(recoverChannelLogin, recoverStreamId, recoverStreamStartTime);
+                if (qualities.Count == 0)
+                {
+                    // Couldn't probe the CDN (shouldn't happen while live) - offer source and let the
+                    // downloader fall back if it turns out to be unavailable.
+                    comboQuality.Items.Add(new ComboBoxItem { Content = "Source", Tag = "chunked" });
+                    AppendLog("Could not probe available qualities; defaulting to Source.");
+                }
+                else
+                {
+                    foreach (var q in qualities)
+                        comboQuality.Items.Add(new ComboBoxItem { Content = TwitchHelper.DescribeVodRendition(q), Tag = q });
+                    AppendLog($"Available qualities: {string.Join(", ", qualities.Select(TwitchHelper.DescribeVodRendition))}.");
+                }
+                comboQuality.SelectedIndex = 0;
+
+                // Length is unknown ahead of time for a live/hidden broadcast.
+                vodLength = TimeSpan.Zero;
+                labelLength.Text = "Unknown (live)";
+                numStartHour.Maximum = 48;
+                numEndHour.Maximum = 48;
+                numStartHour.Value = numStartMinute.Value = numStartSecond.Value = 0;
+                numEndHour.Value = numEndMinute.Value = numEndSecond.Value = 0;
+                viewCount = 0;
+                game = Translations.Strings.UnknownGame;
+
+                AppendLog($"Captured live metadata for '{recoverChannelLogin}' (stream {recoverStreamId}, started {recoverStreamStartTime:u}).");
+                SetEnabled(true);
+            }
+            catch (Exception ex)
+            {
+                btnGetInfo.IsEnabled = true;
+                AppendLog(Translations.Strings.ErrorLog + ex.Message);
+                MessageBox.Show(Application.Current.MainWindow!, ex.Message, Translations.Strings.UnableToGetInfo, MessageBoxButton.OK, MessageBoxImage.Error);
+                if (Settings.Default.VerboseErrors)
+                {
+                    MessageBox.Show(Application.Current.MainWindow!, ex.ToString(), Translations.Strings.VerboseErrorOutput, MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
         }
 
         private async Task GetVideoInfo()
@@ -227,11 +335,24 @@ namespace TwitchDownloaderWPF
             else if (RadioTrimExact.IsChecked == true)
                 options.TrimMode = VideoTrimMode.Exact;
 
+            if (checkRecoverHidden.IsChecked == true)
+            {
+                options.RecoverHiddenVod = true;
+                options.ChannelLogin = recoverChannelLogin;
+                options.StreamId = recoverStreamId;
+                options.StreamStartTime = recoverStreamStartTime;
+            }
+
             return options;
         }
 
         private void UpdateVideoSizeEstimates()
         {
+            // Hidden-VOD recovery uses a plain string quality tag ("chunked") and an unknown length,
+            // so there is nothing to estimate.
+            if (checkRecoverHidden.IsChecked == true)
+                return;
+
             int selectedIndex = comboQuality.SelectedIndex;
 
             var trimStart = checkStart.IsChecked == true

--- a/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/VodDownloadTask.cs
@@ -28,7 +28,9 @@ namespace TwitchDownloaderWPF.TwitchTasks
         {
             var progress = new WpfTaskProgress(i => Progress = i, s => DisplayStatus = s);
 
-            if (DownloadOptions.DelayDownload)
+            // Hidden-VOD recovery is keyed on a channel + captured stream metadata, not a published
+            // video id, so the offline-delay poll (which queries a video id) does not apply.
+            if (DownloadOptions.DelayDownload && !DownloadOptions.RecoverHiddenVod)
             {
                 var success = await DelayUntilVideoOffline(DownloadOptions.Id, progress);
                 if (!success)


### PR DESCRIPTION
Reconstructs a live broadcast's DVR playlist from the public Twitch CDN, using a hash of the login, stream id and start time, for channels that have past broadcasts turned off. Adds a toggle on the VOD download page. It is best-effort and source quality only, and the broadcast must be live or to have ended very recently.