### PR TITLE
Add chat render presets

### DIFF
--- a/TwitchDownloaderWPF/Models/ChatRenderPreset.cs
+++ b/TwitchDownloaderWPF/Models/ChatRenderPreset.cs
@@ -1,0 +1,58 @@
+namespace TwitchDownloaderWPF.Models
+{
+    public class ChatRenderPreset
+    {
+        public string Name { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public string Font { get; set; }
+        public double FontSize { get; set; }
+        public int BackgroundColorA { get; set; }
+        public int BackgroundColorR { get; set; }
+        public int BackgroundColorG { get; set; }
+        public int BackgroundColorB { get; set; }
+        public int AltBackgroundColorA { get; set; }
+        public int AltBackgroundColorR { get; set; }
+        public int AltBackgroundColorG { get; set; }
+        public int AltBackgroundColorB { get; set; }
+        public int MessageColorR { get; set; }
+        public int MessageColorG { get; set; }
+        public int MessageColorB { get; set; }
+        public bool Outline { get; set; }
+        public bool Timestamp { get; set; }
+        public bool Bttv { get; set; } = true;
+        public bool Ffz { get; set; } = true;
+        public bool Stv { get; set; } = true;
+        public bool SubMessages { get; set; }
+        public bool Badges { get; set; }
+        public bool RenderAvatars { get; set; }
+        public bool Offline { get; set; }
+        public bool Dispersion { get; set; }
+        public bool AlternateBackgrounds { get; set; }
+        public bool AdjustUsernameVisibility { get; set; }
+        public double UpdateRate { get; set; }
+        public int Framerate { get; set; }
+        public bool GenerateMask { get; set; }
+        public bool ChatRenderSharpening { get; set; }
+        public double EmoteScale { get; set; }
+        public double BadgeScale { get; set; }
+        public double EmojiScale { get; set; }
+        public double AvatarScale { get; set; }
+        public double VerticalScale { get; set; }
+        public double SidePaddingScale { get; set; }
+        public double SectionHeightScale { get; set; }
+        public double WordSpaceScale { get; set; }
+        public double EmoteSpaceScale { get; set; }
+        public double AccentStrokeScale { get; set; }
+        public double AccentIndentScale { get; set; }
+        public double OutlineScale { get; set; }
+        public string IgnoreUsers { get; set; }
+        public string BannedWords { get; set; }
+        public int EmojiVendor { get; set; }
+        public int ChatBadgeMask { get; set; }
+        public string FfmpegInput { get; set; }
+        public string FfmpegOutput { get; set; }
+        public string VideoContainer { get; set; }
+        public string VideoCodec { get; set; }
+    }
+}

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -230,6 +230,10 @@
             <TextBlock Margin="3,8,3,3" Text="{lex:Loc JsonFile}" Foreground="{DynamicResource AppText}"/>
             <TextBox x:Name="textJson" Margin="3" MinWidth="200" MaxWidth="400" TextChanged="TextJson_TextChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
             <Button x:Name="btnBrowse" Margin="3" MinWidth="50" Content="{lex:Loc Browse}" Click="btnBrowse_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <TextBlock Margin="16,8,3,3" Text="{lex:Loc RenderPreset}" Foreground="{DynamicResource AppText}"/>
+            <ComboBox x:Name="comboRenderPresets" Width="150" Margin="3,4,3,3" DisplayMemberPath="Name" SelectionChanged="ComboRenderPresets_SelectionChanged" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <Button x:Name="btnSaveRenderPreset" Margin="3,4,3,3" MinWidth="50" Content="{lex:Loc Save}" Click="BtnSaveRenderPreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="btnDeleteRenderPreset" Margin="0,4,3,3" MinWidth="50" Content="{lex:Loc Delete}" Click="BtnDeleteRenderPreset_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
         </WrapPanel>
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,10">
             <hc:SplitButton x:Name="SplitBtnRender" Height="40" MinWidth="120" Margin="0,6,0,0" Content="{lex:Loc Render}" Click="SplitBtnRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}" >

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -19,6 +19,7 @@ using TwitchDownloaderCore.TwitchObjects;
 using TwitchDownloaderWPF.Extensions;
 using TwitchDownloaderWPF.Models;
 using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.Services;
 using TwitchDownloaderWPF.Utils;
 using WpfAnimatedGif;
 using MessageBox = System.Windows.MessageBox;
@@ -35,6 +36,7 @@ namespace TwitchDownloaderWPF
         public SKFontManager fontManager = SKFontManager.CreateDefault();
         public string[] FileNames = [];
         private CancellationTokenSource _cancellationTokenSource;
+        private bool _applyingPreset = false;
 
         public PageChatRender()
         {
@@ -527,8 +529,224 @@ namespace TwitchDownloaderWPF
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             LoadSettings();
+            LoadRenderPresets();
             btnDonate.Visibility = Settings.Default.HideDonation ? Visibility.Collapsed : Visibility.Visible;
             statusImage.Visibility = Settings.Default.ReduceMotion ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void LoadRenderPresets()
+        {
+            _applyingPreset = true;
+            try
+            {
+                var presets = ChatRenderPresetService.Load();
+                comboRenderPresets.ItemsSource = presets;
+                comboRenderPresets.SelectedIndex = -1;
+                var lastName = Settings.Default.LastRenderPresetName;
+                if (!string.IsNullOrEmpty(lastName))
+                {
+                    var idx = presets.FindIndex(p => p.Name == lastName);
+                    if (idx >= 0) comboRenderPresets.SelectedIndex = idx;
+                }
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+        }
+
+        private void ComboRenderPresets_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_applyingPreset || !IsInitialized)
+                return;
+            if (comboRenderPresets.SelectedItem is ChatRenderPreset preset)
+            {
+                ApplyRenderPreset(preset);
+                Settings.Default.LastRenderPresetName = preset.Name;
+                Settings.Default.Save();
+            }
+        }
+
+        private void ApplyRenderPreset(ChatRenderPreset preset)
+        {
+            _applyingPreset = true;
+            try
+            {
+                if (preset.Width > 0) textWidth.Text = preset.Width.ToString();
+                if (preset.Height > 0) textHeight.Text = preset.Height.ToString();
+                if (!string.IsNullOrEmpty(preset.Font)) comboFont.SelectedItem = preset.Font;
+                if (preset.FontSize > 0) numFontSize.Value = preset.FontSize;
+                colorBackground.SelectedColor = System.Windows.Media.Color.FromArgb(
+                    (byte)preset.BackgroundColorA, (byte)preset.BackgroundColorR,
+                    (byte)preset.BackgroundColorG, (byte)preset.BackgroundColorB);
+                colorAlternateBackground.SelectedColor = System.Windows.Media.Color.FromArgb(
+                    (byte)preset.AltBackgroundColorA, (byte)preset.AltBackgroundColorR,
+                    (byte)preset.AltBackgroundColorG, (byte)preset.AltBackgroundColorB);
+                colorFont.SelectedColor = System.Windows.Media.Color.FromRgb(
+                    (byte)preset.MessageColorR, (byte)preset.MessageColorG, (byte)preset.MessageColorB);
+                checkOutline.IsChecked = preset.Outline;
+                checkTimestamp.IsChecked = preset.Timestamp;
+                checkBTTV.IsChecked = preset.Bttv;
+                checkFFZ.IsChecked = preset.Ffz;
+                checkSTV.IsChecked = preset.Stv;
+                checkSub.IsChecked = preset.SubMessages;
+                checkBadge.IsChecked = preset.Badges;
+                checkRenderAvatars.IsChecked = preset.RenderAvatars;
+                checkOffline.IsChecked = preset.Offline;
+                checkDispersion.IsChecked = preset.Dispersion;
+                checkAlternateMessageBackgrounds.IsChecked = preset.AlternateBackgrounds;
+                checkAdjustUsernameVisibility.IsChecked = preset.AdjustUsernameVisibility;
+                textUpdateTime.Text = preset.UpdateRate.ToString("0.0#", CultureInfo.CurrentCulture);
+                textFramerate.Text = preset.Framerate.ToString();
+                checkMask.IsChecked = preset.GenerateMask;
+                CheckRenderSharpening.IsChecked = preset.ChatRenderSharpening;
+                textEmoteScale.Text = preset.EmoteScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textBadgeScale.Text = preset.BadgeScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textEmojiScale.Text = preset.EmojiScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAvatarScale.Text = preset.AvatarScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textVerticalScale.Text = preset.VerticalScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textSidePaddingScale.Text = preset.SidePaddingScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textSectionHeightScale.Text = preset.SectionHeightScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textWordSpaceScale.Text = preset.WordSpaceScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textEmoteSpaceScale.Text = preset.EmoteSpaceScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAccentStrokeScale.Text = preset.AccentStrokeScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textAccentIndentScale.Text = preset.AccentIndentScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textOutlineScale.Text = preset.OutlineScale.ToString("0.0#", CultureInfo.CurrentCulture);
+                textIgnoreUsersList.Text = preset.IgnoreUsers ?? "";
+                textBannedWordsList.Text = preset.BannedWords ?? "";
+                RadioEmojiNotoColor.IsChecked = preset.EmojiVendor == (int)EmojiVendor.GoogleNotoColor;
+                RadioEmojiTwemoji.IsChecked = preset.EmojiVendor == (int)EmojiVendor.TwitterTwemoji;
+                RadioEmojiNone.IsChecked = preset.EmojiVendor == (int)EmojiVendor.None;
+                comboBadges.SelectedItems.Clear();
+                var badgeMask = (ChatBadgeType)preset.ChatBadgeMask;
+                foreach (CheckComboBoxItem item in comboBadges.Items)
+                {
+                    if (badgeMask.HasFlag((Enum)item.Tag))
+                        comboBadges.SelectedItems.Add(item);
+                }
+                if (!string.IsNullOrEmpty(preset.VideoContainer))
+                {
+                    foreach (VideoContainer container in comboFormat.Items)
+                    {
+                        if (container.Name == preset.VideoContainer)
+                        {
+                            comboFormat.SelectedItem = container;
+                            comboCodec.Items.Clear();
+                            foreach (Codec codec in container.SupportedCodecs)
+                            {
+                                comboCodec.Items.Add(codec);
+                                if (codec.Name == preset.VideoCodec)
+                                    comboCodec.SelectedItem = codec;
+                            }
+                            break;
+                        }
+                    }
+                }
+                if (!string.IsNullOrEmpty(preset.FfmpegInput)) textFfmpegInput.Text = preset.FfmpegInput;
+                if (!string.IsNullOrEmpty(preset.FfmpegOutput)) textFfmpegOutput.Text = preset.FfmpegOutput;
+            }
+            finally
+            {
+                _applyingPreset = false;
+            }
+        }
+
+        private ChatRenderPreset GetCurrentRenderPreset()
+        {
+            int badgeMask = 0;
+            foreach (var item in comboBadges.SelectedItems)
+                badgeMask += (int)((CheckComboBoxItem)item).Tag;
+            int emojiVendor = RadioEmojiTwemoji.IsChecked == true
+                ? (int)EmojiVendor.TwitterTwemoji
+                : RadioEmojiNone.IsChecked == true
+                    ? (int)EmojiVendor.None
+                    : (int)EmojiVendor.GoogleNotoColor;
+            return new ChatRenderPreset
+            {
+                Width = int.TryParse(textWidth.Text, out var w) ? w : 0,
+                Height = int.TryParse(textHeight.Text, out var h) ? h : 0,
+                Font = comboFont.SelectedItem?.ToString(),
+                FontSize = numFontSize.Value,
+                BackgroundColorA = colorBackground.SelectedColor?.A ?? 255,
+                BackgroundColorR = colorBackground.SelectedColor?.R ?? 17,
+                BackgroundColorG = colorBackground.SelectedColor?.G ?? 17,
+                BackgroundColorB = colorBackground.SelectedColor?.B ?? 17,
+                AltBackgroundColorA = colorAlternateBackground.SelectedColor?.A ?? 255,
+                AltBackgroundColorR = colorAlternateBackground.SelectedColor?.R ?? 25,
+                AltBackgroundColorG = colorAlternateBackground.SelectedColor?.G ?? 25,
+                AltBackgroundColorB = colorAlternateBackground.SelectedColor?.B ?? 25,
+                MessageColorR = colorFont.SelectedColor?.R ?? 255,
+                MessageColorG = colorFont.SelectedColor?.G ?? 255,
+                MessageColorB = colorFont.SelectedColor?.B ?? 255,
+                Outline = checkOutline.IsChecked.GetValueOrDefault(),
+                Timestamp = checkTimestamp.IsChecked.GetValueOrDefault(),
+                Bttv = checkBTTV.IsChecked.GetValueOrDefault(),
+                Ffz = checkFFZ.IsChecked.GetValueOrDefault(),
+                Stv = checkSTV.IsChecked.GetValueOrDefault(),
+                SubMessages = checkSub.IsChecked.GetValueOrDefault(),
+                Badges = checkBadge.IsChecked.GetValueOrDefault(),
+                RenderAvatars = checkRenderAvatars.IsChecked.GetValueOrDefault(),
+                Offline = checkOffline.IsChecked.GetValueOrDefault(),
+                Dispersion = checkDispersion.IsChecked.GetValueOrDefault(),
+                AlternateBackgrounds = checkAlternateMessageBackgrounds.IsChecked.GetValueOrDefault(),
+                AdjustUsernameVisibility = checkAdjustUsernameVisibility.IsChecked.GetValueOrDefault(),
+                UpdateRate = double.TryParse(textUpdateTime.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ur) ? ur : 0.5,
+                Framerate = int.TryParse(textFramerate.Text, out var fr) ? fr : 30,
+                GenerateMask = checkMask.IsChecked.GetValueOrDefault(),
+                ChatRenderSharpening = CheckRenderSharpening.IsChecked.GetValueOrDefault(),
+                EmoteScale = double.TryParse(textEmoteScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var es) ? es : 1.0,
+                BadgeScale = double.TryParse(textBadgeScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var bs) ? bs : 1.0,
+                EmojiScale = double.TryParse(textEmojiScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ejs) ? ejs : 1.0,
+                AvatarScale = double.TryParse(textAvatarScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var avs) ? avs : 1.0,
+                VerticalScale = double.TryParse(textVerticalScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var vs) ? vs : 1.0,
+                SidePaddingScale = double.TryParse(textSidePaddingScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var sps) ? sps : 1.0,
+                SectionHeightScale = double.TryParse(textSectionHeightScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var shs) ? shs : 1.0,
+                WordSpaceScale = double.TryParse(textWordSpaceScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var wss) ? wss : 1.0,
+                EmoteSpaceScale = double.TryParse(textEmoteSpaceScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ess) ? ess : 1.0,
+                AccentStrokeScale = double.TryParse(textAccentStrokeScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ass) ? ass : 1.0,
+                AccentIndentScale = double.TryParse(textAccentIndentScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var ais) ? ais : 1.0,
+                OutlineScale = double.TryParse(textOutlineScale.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var os) ? os : 1.0,
+                IgnoreUsers = textIgnoreUsersList.Text,
+                BannedWords = textBannedWordsList.Text,
+                EmojiVendor = emojiVendor,
+                ChatBadgeMask = badgeMask,
+                FfmpegInput = textFfmpegInput.Text,
+                FfmpegOutput = textFfmpegOutput.Text,
+                VideoContainer = (comboFormat.SelectedItem as VideoContainer)?.Name,
+                VideoCodec = (comboCodec.SelectedItem as Codec)?.Name,
+            };
+        }
+
+        private void BtnSaveRenderPreset_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new WindowInputText("Save Preset", "Enter a name for this preset:", (comboRenderPresets.SelectedItem as ChatRenderPreset)?.Name ?? "")
+            {
+                Owner = Application.Current.MainWindow
+            };
+            if (dialog.ShowDialog() != true || string.IsNullOrWhiteSpace(dialog.InputValue))
+                return;
+            var preset = GetCurrentRenderPreset();
+            preset.Name = dialog.InputValue;
+            ChatRenderPresetService.AddOrUpdate(preset);
+            LoadRenderPresets();
+            var presets = ChatRenderPresetService.Load();
+            var savedIndex = presets.FindIndex(p => p.Name == preset.Name);
+            if (savedIndex >= 0)
+            {
+                _applyingPreset = true;
+                comboRenderPresets.SelectedIndex = savedIndex;
+                _applyingPreset = false;
+            }
+        }
+
+        private void BtnDeleteRenderPreset_Click(object sender, RoutedEventArgs e)
+        {
+            if (comboRenderPresets.SelectedItem is not ChatRenderPreset preset)
+                return;
+            ChatRenderPresetService.Delete(preset.Name);
+            Settings.Default.LastRenderPresetName = "";
+            Settings.Default.Save();
+            LoadRenderPresets();
         }
 
         private void btnResetFfmpeg_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -1028,5 +1028,17 @@ namespace TwitchDownloaderWPF.Properties {
                 this["AvatarScale"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastRenderPresetName {
+            get {
+                return ((string)(this["LastRenderPresetName"]));
+            }
+            set {
+                this["LastRenderPresetName"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -254,6 +254,9 @@
     <Setting Name="AvatarScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
+    <Setting Name="LastRenderPresetName" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Services/ChatRenderPresetService.cs
+++ b/TwitchDownloaderWPF/Services/ChatRenderPresetService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using TwitchDownloaderWPF.Models;
+
+namespace TwitchDownloaderWPF.Services
+{
+    public static class ChatRenderPresetService
+    {
+        private static readonly string _filePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TwitchDownloaderWPF",
+            "ChatRenderPresets.json");
+
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        public static List<ChatRenderPreset> Load()
+        {
+            try
+            {
+                if (!File.Exists(_filePath))
+                    return new List<ChatRenderPreset>();
+
+                var json = File.ReadAllText(_filePath);
+                return JsonSerializer.Deserialize<List<ChatRenderPreset>>(json, _jsonOptions) ?? new List<ChatRenderPreset>();
+            }
+            catch
+            {
+                return new List<ChatRenderPreset>();
+            }
+        }
+
+        public static void Save(List<ChatRenderPreset> presets)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                var json = JsonSerializer.Serialize(presets, _jsonOptions);
+                File.WriteAllText(_filePath, json);
+            }
+            catch { /* Silently ignore save errors */ }
+        }
+
+        public static void AddOrUpdate(ChatRenderPreset preset)
+        {
+            var presets = Load();
+            var existing = presets.FindIndex(p => p.Name == preset.Name);
+            if (existing >= 0)
+                presets[existing] = preset;
+            else
+                presets.Add(preset);
+            Save(presets);
+        }
+
+        public static void Delete(string name)
+        {
+            var presets = Load();
+            presets.RemoveAll(p => p.Name == name);
+            Save(presets);
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -284,7 +284,34 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("Browse", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Preset: ähnelt.
+        /// </summary>
+        public static string RenderPreset {
+            get {
+                return ResourceManager.GetString("RenderPreset", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Save ähnelt.
+        /// </summary>
+        public static string Save {
+            get {
+                return ResourceManager.GetString("Save", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Delete ähnelt.
+        /// </summary>
+        public static string Delete {
+            get {
+                return ResourceManager.GetString("Delete", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die BTTV Emotes: ähnelt.
         /// </summary>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -149,6 +149,15 @@
   <data name="Browse" xml:space="preserve">
     <value>Browse</value>
   </data>
+  <data name="RenderPreset" xml:space="preserve">
+    <value>Preset:</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
   <data name="BttvEmotes" xml:space="preserve">
     <value>BTTV Emotes:</value>
   </data>

--- a/TwitchDownloaderWPF/WindowInputText.xaml
+++ b/TwitchDownloaderWPF/WindowInputText.xaml
@@ -1,0 +1,20 @@
+<Window x:Class="TwitchDownloaderWPF.WindowInputText"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Input"
+        WindowStyle="SingleBorderWindow"
+        ResizeMode="NoResize"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        MinWidth="300"
+        Background="{DynamicResource AppBackground}">
+    <StackPanel Margin="12">
+        <TextBlock x:Name="TextPrompt" Margin="0,0,0,6" Foreground="{DynamicResource AppText}" TextWrapping="Wrap"/>
+        <TextBox x:Name="TextInputBox" MinWidth="260" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" KeyDown="TextInput_KeyDown"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Content="OK" Width="70" Margin="0,0,6,0" IsDefault="True" Click="BtnOk_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button Content="Cancel" Width="70" IsCancel="True" Click="BtnCancel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/TwitchDownloaderWPF/WindowInputText.xaml.cs
+++ b/TwitchDownloaderWPF/WindowInputText.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace TwitchDownloaderWPF
+{
+    public partial class WindowInputText : Window
+    {
+        public string InputValue { get; private set; } = "";
+
+        public WindowInputText(string title, string prompt, string defaultValue = "")
+        {
+            InitializeComponent();
+            Title = title;
+            TextPrompt.Text = prompt;
+            TextInputBox.Text = defaultValue;
+            TextInputBox.SelectAll();
+        }
+
+        protected override void OnContentRendered(System.EventArgs e)
+        {
+            base.OnContentRendered(e);
+            TextInputBox.Focus();
+        }
+
+        private void BtnOk_Click(object sender, RoutedEventArgs e)
+        {
+            InputValue = TextInputBox.Text.Trim();
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void TextInput_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                InputValue = TextInputBox.Text.Trim();
+                DialogResult = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Saves and loads the chat render settings as named presets stored in a json file, with the last used preset reselected on load.

Closes #1441
