### PR TITLE
Add a render preview to the chat render page

### DIFF
--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -263,7 +263,11 @@
             <WrapPanel Orientation="Horizontal" Margin="0,8,0,0">
                 <TextBlock Text="{lex:Loc PreviewAt}" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource AppText}"/>
                 <TextBox x:Name="textPreviewPos" Text="0:00:00" Width="70" Margin="0,0,4,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
-                <Button x:Name="btnPreviewRender" Content="{lex:Loc Preview}" MinWidth="60" Click="BtnPreviewRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <RadioButton x:Name="radioPreviewImage" Content="{lex:Loc PreviewImage}" IsChecked="True" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource AppText}" Checked="RadioPreviewMode_Changed"/>
+                <RadioButton x:Name="radioPreviewVideo" Content="{lex:Loc PreviewVideo}" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource AppText}" Checked="RadioPreviewMode_Changed"/>
+                <TextBox x:Name="textPreviewDuration" Text="30" Width="34" Visibility="Collapsed" ToolTip="{lex:Loc PreviewDuration}" Margin="0,0,4,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnPreviewRender" Content="{lex:Loc Preview}" MinWidth="60" Margin="0,0,4,0" Click="BtnPreviewRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <Button x:Name="btnPreviewFullscreen" Content="&#x26F6;" Width="26" ToolTip="{lex:Loc PreviewFullscreen}" Click="BtnPreviewFullscreen_Click" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}"/>
             </WrapPanel>
             <ProgressBar x:Name="progressPreview" Height="4" Margin="0,4,0,0" Visibility="Collapsed" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource ProgressBarForeground}"/>
             <Border BorderBrush="{DynamicResource AppElementBorder}" BorderThickness="1" Margin="0,4,0,0" MinHeight="80" Background="{DynamicResource AppElementBackground}">
@@ -272,6 +276,16 @@
                     <Image x:Name="imgPreview" Stretch="Uniform" Visibility="Collapsed"/>
                 </Grid>
             </Border>
+            <Grid x:Name="panelPreviewPlayback" Visibility="Collapsed" Margin="0,4,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button x:Name="btnPreviewPlayPause" Grid.Column="0" Content="{lex:Loc PreviewPause}" MinWidth="50" Margin="0,0,6,0" Click="BtnPreviewPlayPause_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+                <TextBlock x:Name="textPreviewTime" Grid.Column="1" Text="0:00 / 0:00" VerticalAlignment="Center" Margin="0,0,8,0" Foreground="{DynamicResource AppText}"/>
+                <Slider x:Name="sliderPreview" Grid.Column="2" Minimum="0" Maximum="1" VerticalAlignment="Center" ValueChanged="SliderPreview_ValueChanged"/>
+            </Grid>
         </StackPanel>
 
         <!--STATUS BAR-->

--- a/TwitchDownloaderWPF/PageChatRender.xaml
+++ b/TwitchDownloaderWPF/PageChatRender.xaml
@@ -260,6 +260,18 @@
                 </RichTextBox.Resources>
             </RichTextBox>
             <Button x:Name="BtnClearLog" MinWidth="50" IsEnabled="False" Content="{lex:Loc ClearLog}" Click="BtnClearLog_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <WrapPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <TextBlock Text="{lex:Loc PreviewAt}" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource AppText}"/>
+                <TextBox x:Name="textPreviewPos" Text="0:00:00" Width="70" Margin="0,0,4,0" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+                <Button x:Name="btnPreviewRender" Content="{lex:Loc Preview}" MinWidth="60" Click="BtnPreviewRender_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            </WrapPanel>
+            <ProgressBar x:Name="progressPreview" Height="4" Margin="0,4,0,0" Visibility="Collapsed" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource ProgressBarForeground}"/>
+            <Border BorderBrush="{DynamicResource AppElementBorder}" BorderThickness="1" Margin="0,4,0,0" MinHeight="80" Background="{DynamicResource AppElementBackground}">
+                <Grid>
+                    <TextBlock x:Name="textPreviewStatus" Text="{lex:Loc PreviewHint}" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource AppText}" Opacity="0.6"/>
+                    <Image x:Name="imgPreview" Stretch="Uniform" Visibility="Collapsed"/>
+                </Grid>
+            </Border>
         </StackPanel>
 
         <!--STATUS BAR-->

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -35,6 +35,8 @@ namespace TwitchDownloaderWPF
         public SKFontManager fontManager = SKFontManager.CreateDefault();
         public string[] FileNames = [];
         private CancellationTokenSource _cancellationTokenSource;
+        private readonly List<string> _previewTempFiles = new();
+        private CancellationTokenSource _previewCts;
 
         public PageChatRender()
         {
@@ -504,6 +506,111 @@ namespace TwitchDownloaderWPF
         private void Page_Unloaded(object sender, RoutedEventArgs e)
         {
             SaveSettings();
+            _previewCts?.Cancel();
+            CleanUpPreviewTempFiles();
+        }
+
+        private void CleanUpPreviewTempFiles()
+        {
+            foreach (var file in _previewTempFiles)
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { /* best effort */ }
+            }
+            _previewTempFiles.Clear();
+        }
+
+        private async void BtnPreviewRender_Click(object sender, RoutedEventArgs e)
+        {
+            if (FileNames.Length == 0 || string.IsNullOrWhiteSpace(FileNames[0]) || !ValidateInputs())
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewHint;
+                return;
+            }
+
+            if (!TimeSpan.TryParse(textPreviewPos.Text, out var pos))
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewInvalidPosition;
+                textPreviewStatus.Visibility = Visibility.Visible;
+                imgPreview.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            _previewCts?.Cancel();
+            _previewCts = new CancellationTokenSource();
+            var token = _previewCts.Token;
+
+            var tempFile = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.mp4");
+            var tempPng = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.png");
+            _previewTempFiles.Add(tempFile);
+            _previewTempFiles.Add(tempPng);
+
+            // Render a short window around the requested position at 1 fps and grab a single frame.
+            var options = GetOptions(tempFile);
+            options.InputFile = FileNames[0];
+            options.StartOverride = (int)pos.TotalSeconds;
+            options.EndOverride = (int)pos.TotalSeconds + 2;
+            options.GenerateMask = false;
+            options.Framerate = 1;
+
+            progressPreview.Visibility = Visibility.Visible;
+            progressPreview.IsIndeterminate = true;
+            btnPreviewRender.IsEnabled = false;
+            imgPreview.Visibility = Visibility.Collapsed;
+            textPreviewStatus.Text = Translations.Strings.PreviewRendering;
+            textPreviewStatus.Visibility = Visibility.Visible;
+
+            try
+            {
+                var progress = new WpfTaskProgress(
+                    pct => Dispatcher.BeginInvoke(() => { progressPreview.IsIndeterminate = false; progressPreview.Value = pct; }),
+                    _ => { });
+
+                var renderer = new ChatRenderer(options, progress);
+                await renderer.ParseJsonAsync(token);
+                await renderer.RenderVideoAsync(token);
+                token.ThrowIfCancellationRequested();
+
+                var psi = new ProcessStartInfo("ffmpeg", $"-y -i \"{tempFile}\" -vframes 1 \"{tempPng}\"")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using (var ffmpegProcess = Process.Start(psi))
+                {
+                    if (ffmpegProcess != null)
+                        await ffmpegProcess.WaitForExitAsync(token);
+                }
+
+                if (File.Exists(tempPng) && new FileInfo(tempPng).Length > 0)
+                {
+                    var bitmap = new BitmapImage();
+                    bitmap.BeginInit();
+                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                    bitmap.UriSource = new Uri(tempPng);
+                    bitmap.EndInit();
+                    bitmap.Freeze();
+                    imgPreview.Source = bitmap;
+                    imgPreview.Visibility = Visibility.Visible;
+                    textPreviewStatus.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    textPreviewStatus.Text = Translations.Strings.PreviewHint;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewHint;
+            }
+            catch (Exception ex)
+            {
+                textPreviewStatus.Text = ex.Message;
+            }
+            finally
+            {
+                progressPreview.Visibility = Visibility.Collapsed;
+                btnPreviewRender.IsEnabled = true;
+            }
         }
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/PageChatRender.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatRender.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
+using System.Windows.Threading;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Options;
@@ -37,11 +38,20 @@ namespace TwitchDownloaderWPF
         private CancellationTokenSource _cancellationTokenSource;
         private readonly List<string> _previewTempFiles = new();
         private CancellationTokenSource _previewCts;
+        private DispatcherTimer _previewTimer;
+        private List<BitmapImage> _previewFrames = new();
+        private int _previewFrameIndex;
+        private double _previewDuration;
+        private bool _previewPlaying;
+        private bool _previewSuppressSlider;
+        private const int PreviewFrameRate = 4;
 
         public PageChatRender()
         {
             InitializeComponent();
             App.CultureServiceSingleton.CultureChanged += OnCultureChanged;
+            _previewTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1000.0 / PreviewFrameRate) };
+            _previewTimer.Tick += PreviewTimer_Tick;
         }
 
         private void OnCultureChanged(object sender, CultureInfo e)
@@ -506,6 +516,7 @@ namespace TwitchDownloaderWPF
         private void Page_Unloaded(object sender, RoutedEventArgs e)
         {
             SaveSettings();
+            _previewTimer?.Stop();
             _previewCts?.Cancel();
             CleanUpPreviewTempFiles();
         }
@@ -535,27 +546,41 @@ namespace TwitchDownloaderWPF
                 return;
             }
 
+            var videoMode = radioPreviewVideo.IsChecked == true;
+            var windowSeconds = 2;
+            if (videoMode && (!int.TryParse(textPreviewDuration.Text, out windowSeconds) || windowSeconds < 1))
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewInvalidPosition;
+                textPreviewStatus.Visibility = Visibility.Visible;
+                return;
+            }
+
+            _previewTimer.Stop();
+            _previewPlaying = false;
+            _previewFrames = new();
+            _previewFrameIndex = 0;
             _previewCts?.Cancel();
             _previewCts = new CancellationTokenSource();
             var token = _previewCts.Token;
 
             var tempFile = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.mp4");
-            var tempPng = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.png");
             _previewTempFiles.Add(tempFile);
-            _previewTempFiles.Add(tempPng);
 
-            // Render a short window around the requested position at 1 fps and grab a single frame.
+            // Render a short window around the requested position. Image mode grabs a single frame at
+            // 1 fps; video mode keeps the configured framerate and samples it back at PreviewFrameRate.
             var options = GetOptions(tempFile);
             options.InputFile = FileNames[0];
             options.StartOverride = (int)pos.TotalSeconds;
-            options.EndOverride = (int)pos.TotalSeconds + 2;
+            options.EndOverride = (int)pos.TotalSeconds + windowSeconds;
             options.GenerateMask = false;
-            options.Framerate = 1;
+            if (!videoMode)
+                options.Framerate = 1;
 
             progressPreview.Visibility = Visibility.Visible;
             progressPreview.IsIndeterminate = true;
             btnPreviewRender.IsEnabled = false;
             imgPreview.Visibility = Visibility.Collapsed;
+            panelPreviewPlayback.Visibility = Visibility.Collapsed;
             textPreviewStatus.Text = Translations.Strings.PreviewRendering;
             textPreviewStatus.Visibility = Visibility.Visible;
 
@@ -570,33 +595,10 @@ namespace TwitchDownloaderWPF
                 await renderer.RenderVideoAsync(token);
                 token.ThrowIfCancellationRequested();
 
-                var psi = new ProcessStartInfo("ffmpeg", $"-y -i \"{tempFile}\" -vframes 1 \"{tempPng}\"")
-                {
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                using (var ffmpegProcess = Process.Start(psi))
-                {
-                    if (ffmpegProcess != null)
-                        await ffmpegProcess.WaitForExitAsync(token);
-                }
-
-                if (File.Exists(tempPng) && new FileInfo(tempPng).Length > 0)
-                {
-                    var bitmap = new BitmapImage();
-                    bitmap.BeginInit();
-                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                    bitmap.UriSource = new Uri(tempPng);
-                    bitmap.EndInit();
-                    bitmap.Freeze();
-                    imgPreview.Source = bitmap;
-                    imgPreview.Visibility = Visibility.Visible;
-                    textPreviewStatus.Visibility = Visibility.Collapsed;
-                }
+                if (videoMode)
+                    await LoadVideoPreview(tempFile, windowSeconds, token);
                 else
-                {
-                    textPreviewStatus.Text = Translations.Strings.PreviewHint;
-                }
+                    await LoadImagePreview(tempFile, token);
             }
             catch (OperationCanceledException)
             {
@@ -611,6 +613,177 @@ namespace TwitchDownloaderWPF
                 progressPreview.Visibility = Visibility.Collapsed;
                 btnPreviewRender.IsEnabled = true;
             }
+        }
+
+        private async Task LoadImagePreview(string videoFile, CancellationToken token)
+        {
+            var tempPng = Path.Combine(Path.GetTempPath(), $"tdw_preview_{Guid.NewGuid():N}.png");
+            _previewTempFiles.Add(tempPng);
+
+            await RunFfmpeg($"-y -i \"{videoFile}\" -vframes 1 \"{tempPng}\"", token);
+
+            if (File.Exists(tempPng) && new FileInfo(tempPng).Length > 0)
+            {
+                imgPreview.Source = LoadFrozenBitmap(tempPng);
+                imgPreview.Visibility = Visibility.Visible;
+                textPreviewStatus.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewHint;
+            }
+        }
+
+        private async Task LoadVideoPreview(string videoFile, int durationSeconds, CancellationToken token)
+        {
+            var frameDir = Path.Combine(Path.GetTempPath(), $"tdw_prevframes_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(frameDir);
+            _previewTempFiles.Add(frameDir);
+
+            // Sample the rendered clip into individual frames so playback does not depend on a media codec.
+            await RunFfmpeg($"-y -i \"{videoFile}\" -vf fps={PreviewFrameRate} \"{Path.Combine(frameDir, "frame%05d.png")}\"", token);
+
+            var files = Directory.GetFiles(frameDir, "frame*.png");
+            Array.Sort(files, StringComparer.Ordinal);
+            var frames = new List<BitmapImage>(files.Length);
+            foreach (var file in files)
+            {
+                try { frames.Add(LoadFrozenBitmap(file)); }
+                catch { /* skip unreadable frame */ }
+            }
+
+            if (frames.Count == 0)
+            {
+                textPreviewStatus.Text = Translations.Strings.PreviewHint;
+                return;
+            }
+
+            _previewFrames = frames;
+            _previewFrameIndex = 0;
+            _previewDuration = durationSeconds;
+            sliderPreview.Maximum = Math.Max(frames.Count - 1, 1);
+            imgPreview.Visibility = Visibility.Visible;
+            panelPreviewPlayback.Visibility = Visibility.Visible;
+            textPreviewStatus.Visibility = Visibility.Collapsed;
+            ShowFrame(0);
+            StartPlayback();
+        }
+
+        private static async Task RunFfmpeg(string arguments, CancellationToken token)
+        {
+            var psi = new ProcessStartInfo("ffmpeg", arguments)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process != null)
+                await process.WaitForExitAsync(token);
+        }
+
+        private static BitmapImage LoadFrozenBitmap(string path)
+        {
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.UriSource = new Uri(path);
+            bitmap.EndInit();
+            bitmap.Freeze();
+            return bitmap;
+        }
+
+        private void RadioPreviewMode_Changed(object sender, RoutedEventArgs e)
+        {
+            if (textPreviewDuration == null)
+                return;
+
+            var videoMode = radioPreviewVideo.IsChecked == true;
+            textPreviewDuration.Visibility = videoMode ? Visibility.Visible : Visibility.Collapsed;
+            if (!videoMode)
+            {
+                _previewTimer?.Stop();
+                _previewPlaying = false;
+                panelPreviewPlayback.Visibility = Visibility.Collapsed;
+            }
+            else if (_previewFrames.Count > 0)
+            {
+                panelPreviewPlayback.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void BtnPreviewPlayPause_Click(object sender, RoutedEventArgs e)
+        {
+            if (_previewFrames.Count == 0)
+                return;
+
+            if (_previewPlaying)
+                StopPlayback();
+            else
+                StartPlayback();
+        }
+
+        private void StartPlayback()
+        {
+            _previewPlaying = true;
+            btnPreviewPlayPause.Content = Translations.Strings.PreviewPause;
+            _previewTimer.Start();
+        }
+
+        private void StopPlayback()
+        {
+            _previewPlaying = false;
+            btnPreviewPlayPause.Content = Translations.Strings.PreviewPlay;
+            _previewTimer.Stop();
+        }
+
+        private void PreviewTimer_Tick(object sender, EventArgs e)
+        {
+            if (_previewFrames.Count == 0)
+                return;
+
+            _previewFrameIndex = (_previewFrameIndex + 1) % _previewFrames.Count;
+            ShowFrame(_previewFrameIndex);
+        }
+
+        private void SliderPreview_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (_previewSuppressSlider || _previewFrames.Count == 0)
+                return;
+
+            ShowFrame(Math.Clamp((int)e.NewValue, 0, _previewFrames.Count - 1));
+        }
+
+        private void ShowFrame(int index)
+        {
+            _previewFrameIndex = index;
+            imgPreview.Source = _previewFrames[index];
+
+            _previewSuppressSlider = true;
+            sliderPreview.Value = index;
+            _previewSuppressSlider = false;
+
+            var current = TimeSpan.FromSeconds((double)index / PreviewFrameRate);
+            var total = TimeSpan.FromSeconds(_previewDuration);
+            textPreviewTime.Text = $"{FormatPreviewTime(current)} / {FormatPreviewTime(total)}";
+        }
+
+        private static string FormatPreviewTime(TimeSpan t) =>
+            t.TotalHours >= 1 ? $"{(int)t.TotalHours}:{t.Minutes:D2}:{t.Seconds:D2}" : $"{t.Minutes}:{t.Seconds:D2}";
+
+        private void BtnPreviewFullscreen_Click(object sender, RoutedEventArgs e)
+        {
+            if (imgPreview.Source == null)
+                return;
+
+            var window = new System.Windows.Window
+            {
+                Title = Translations.Strings.Preview,
+                WindowState = WindowState.Maximized,
+                Background = System.Windows.Media.Brushes.Black,
+                Content = new Image { Source = imgPreview.Source, Stretch = System.Windows.Media.Stretch.Uniform }
+            };
+            window.KeyDown += (_, ke) => { if (ke.Key == Key.Escape || ke.Key == Key.F11) window.Close(); };
+            window.Show();
         }
 
         private void btnDonate_Click(object sender, RoutedEventArgs e)

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -331,6 +331,60 @@ namespace TwitchDownloaderWPF.Translations {
         }
 
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Image ähnelt.
+        /// </summary>
+        public static string PreviewImage {
+            get {
+                return ResourceManager.GetString("PreviewImage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Video ähnelt.
+        /// </summary>
+        public static string PreviewVideo {
+            get {
+                return ResourceManager.GetString("PreviewVideo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Clip length in seconds (video mode) ähnelt.
+        /// </summary>
+        public static string PreviewDuration {
+            get {
+                return ResourceManager.GetString("PreviewDuration", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die View full size ähnelt.
+        /// </summary>
+        public static string PreviewFullscreen {
+            get {
+                return ResourceManager.GetString("PreviewFullscreen", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Play ähnelt.
+        /// </summary>
+        public static string PreviewPlay {
+            get {
+                return ResourceManager.GetString("PreviewPlay", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Pause ähnelt.
+        /// </summary>
+        public static string PreviewPause {
+            get {
+                return ResourceManager.GetString("PreviewPause", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die BTTV Emotes: ähnelt.
         /// </summary>
         public static string BttvEmotes {

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -284,7 +284,52 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("Browse", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Preview ähnelt.
+        /// </summary>
+        public static string Preview {
+            get {
+                return ResourceManager.GetString("Preview", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Preview at: ähnelt.
+        /// </summary>
+        public static string PreviewAt {
+            get {
+                return ResourceManager.GetString("PreviewAt", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Click Preview to render a frame ähnelt.
+        /// </summary>
+        public static string PreviewHint {
+            get {
+                return ResourceManager.GetString("PreviewHint", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Rendering... ähnelt.
+        /// </summary>
+        public static string PreviewRendering {
+            get {
+                return ResourceManager.GetString("PreviewRendering", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Invalid position. Use H:MM:SS. ähnelt.
+        /// </summary>
+        public static string PreviewInvalidPosition {
+            get {
+                return ResourceManager.GetString("PreviewInvalidPosition", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die BTTV Emotes: ähnelt.
         /// </summary>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -149,6 +149,21 @@
   <data name="Browse" xml:space="preserve">
     <value>Browse</value>
   </data>
+  <data name="Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="PreviewAt" xml:space="preserve">
+    <value>Preview at:</value>
+  </data>
+  <data name="PreviewHint" xml:space="preserve">
+    <value>Click Preview to render a frame</value>
+  </data>
+  <data name="PreviewRendering" xml:space="preserve">
+    <value>Rendering...</value>
+  </data>
+  <data name="PreviewInvalidPosition" xml:space="preserve">
+    <value>Invalid position. Use H:MM:SS.</value>
+  </data>
   <data name="BttvEmotes" xml:space="preserve">
     <value>BTTV Emotes:</value>
   </data>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -164,6 +164,24 @@
   <data name="PreviewInvalidPosition" xml:space="preserve">
     <value>Invalid position. Use H:MM:SS.</value>
   </data>
+  <data name="PreviewImage" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="PreviewVideo" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="PreviewDuration" xml:space="preserve">
+    <value>Clip length in seconds (video mode)</value>
+  </data>
+  <data name="PreviewFullscreen" xml:space="preserve">
+    <value>View full size</value>
+  </data>
+  <data name="PreviewPlay" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="PreviewPause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
   <data name="BttvEmotes" xml:space="preserve">
     <value>BTTV Emotes:</value>
   </data>


### PR DESCRIPTION
Render preview could only show a single frame. This adds a Video mode that renders a short clip and plays it back frame-by-frame, plus a fullscreen button. Frames are sampled with ffmpeg so playback does not depend on a media codec being installed.