### PR TITLE
Add split by chapters to VOD download

### DIFF
--- a/TwitchDownloaderWPF/PageVodDownload.xaml
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml
@@ -105,6 +105,7 @@
                 <hc:SplitButton.DropDownContent>
                     <StackPanel>
                         <MenuItem x:Name="MenuItemEnqueue" Header="{lex:Loc EnqueueDownload}" Click="MenuItemEnqueue_Click"/>
+                        <MenuItem x:Name="MenuItemSplitByChapters" Header="{lex:Loc SplitByChapters}" Click="MenuItemSplitByChapters_Click"/>
                     </StackPanel>
                 </hc:SplitButton.DropDownContent>
             </hc:SplitButton>

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -530,6 +530,103 @@ namespace TwitchDownloaderWPF
             }
         }
 
+        private async void MenuItemSplitByChapters_Click(object sender, RoutedEventArgs e)
+        {
+            if (!SplitBtnDownload.IsDropDownOpen)
+                return;
+
+            if (currentVideoId == 0)
+            {
+                MessageBox.Show(Application.Current.MainWindow!, "Please load a VOD first.", "No VOD Loaded", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                btnGetInfo.IsEnabled = false;
+                SplitBtnDownload.IsEnabled = false;
+
+                var videoInfo = new TwitchDownloaderCore.TwitchObjects.Gql.VideoInfo
+                {
+                    lengthSeconds = (int)vodLength.TotalSeconds,
+                    game = new TwitchDownloaderCore.TwitchObjects.Gql.Game { displayName = game }
+                };
+
+                var progress = new WpfTaskProgress((LogLevel)Settings.Default.LogLevels, SetPercent, SetStatus, AppendLog);
+                var chapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(currentVideoId, videoInfo, progress);
+                var chapters = chapterResponse.data.video.moments.edges;
+
+                if (chapters.Count <= 1)
+                {
+                    MessageBox.Show(Application.Current.MainWindow!, "This VOD has only one chapter, so there is nothing to split.", "Single Chapter", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var msg = $"Enqueue {chapters.Count} separate downloads (one per chapter)?";
+                if (MessageBox.Show(Application.Current.MainWindow!, msg, "Split by Chapters", MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                    return;
+
+                string folder = Settings.Default.QueueFolder;
+                string quality = ((ComboBoxItem)comboQuality.SelectedItem).Tag.ToString();
+                string ext = FilenameService.GuessVodFileExtension(quality);
+                var trimMode = RadioTrimSafe.IsChecked == true ? VideoTrimMode.Safe : VideoTrimMode.Exact;
+
+                for (int i = 0; i < chapters.Count; i++)
+                {
+                    var chapter = chapters[i].node;
+                    var startSec = chapter.positionMilliseconds / 1000;
+                    var endSec = startSec + chapter.durationMilliseconds / 1000;
+                    var chapterStart = TimeSpan.FromSeconds(startSec);
+                    var chapterEnd = TimeSpan.FromSeconds(Math.Min(endSec, (int)vodLength.TotalSeconds));
+                    var gameName = chapter.details?.game?.displayName ?? chapter.description ?? game;
+
+                    var options = new VideoDownloadOptions
+                    {
+                        DownloadThreads = (int)numDownloadThreads.Value,
+                        ThrottleKib = Settings.Default.DownloadThrottleEnabled ? Settings.Default.MaximumBandwidthKib : -1,
+                        Filename = Path.Combine(folder,
+                            FilenameService.GetFilename(Settings.Default.TemplateVod, textTitle.Text, currentVideoId.ToString(),
+                                currentVideoTime, textStreamer.Text, streamerId,
+                                chapterStart, chapterEnd, vodLength, viewCount, gameName) + $"_ch{i + 1:D2}" + ext),
+                        Oauth = TextOauth.Text,
+                        Quality = quality,
+                        Id = currentVideoId,
+                        TrimBeginning = true,
+                        TrimBeginningTime = chapterStart,
+                        TrimEnding = true,
+                        TrimEndingTime = chapterEnd,
+                        FfmpegPath = "ffmpeg",
+                        TempFolder = Settings.Default.TempPath,
+                        TrimMode = trimMode
+                    };
+
+                    var task = new TwitchTasks.VodDownloadTask
+                    {
+                        DownloadOptions = options,
+                        Info =
+                        {
+                            Title = $"{textTitle.Text} - {gameName} (Ch. {i + 1})",
+                            Thumbnail = imgThumbnail.Source
+                        }
+                    };
+                    PageQueue.taskList.Add(task);
+                }
+
+                if (Application.Current.MainWindow is MainWindow mw)
+                    mw.Main.Content = MainWindow.pageQueue;
+            }
+            catch (Exception ex)
+            {
+                AppendLog(Translations.Strings.ErrorLog + ex.Message);
+                MessageBox.Show(Application.Current.MainWindow!, "Failed to fetch chapters: " + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                btnGetInfo.IsEnabled = true;
+                SplitBtnDownload.IsEnabled = true;
+            }
+        }
+
         private void numEndHour_ValueChanged(object sender, HandyControl.Data.FunctionEventArgs<double> e)
         {
             UpdateVideoSizeEstimates();

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -284,7 +284,16 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("Browse", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Split by Chapters ähnelt.
+        /// </summary>
+        public static string SplitByChapters {
+            get {
+                return ResourceManager.GetString("SplitByChapters", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die BTTV Emotes: ähnelt.
         /// </summary>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -149,6 +149,9 @@
   <data name="Browse" xml:space="preserve">
     <value>Browse</value>
   </data>
+  <data name="SplitByChapters" xml:space="preserve">
+    <value>Split by Chapters</value>
+  </data>
   <data name="BttvEmotes" xml:space="preserve">
     <value>BTTV Emotes:</value>
   </data>


### PR DESCRIPTION
Adds a Split by Chapters item to the download button that fetches the VOD's chapters and enqueues one trimmed download per chapter, reusing the existing trim and queue.

Closes #980
