### PR TITLE
Add a live monitor page

### DIFF
--- a/TwitchDownloaderCore/LiveStreamDownloader.cs
+++ b/TwitchDownloaderCore/LiveStreamDownloader.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TwitchDownloaderCore.Extensions;
+using TwitchDownloaderCore.Interfaces;
+using TwitchDownloaderCore.Models;
+using TwitchDownloaderCore.Options;
+
+namespace TwitchDownloaderCore
+{
+    /// <summary>
+    /// "Live download": captures a currently-airing broadcast in full.
+    /// <list type="number">
+    /// <item><b>Back-catalog</b> <c>[start -&gt; split]</c>: the hours already aired are
+    /// downloaded immediately with the multi-threaded <see cref="VideoDownloader"/>. This
+    /// range is static, so it is fast and finalizes reliably.</item>
+    /// <item><b>Live tail</b> <c>[split -&gt; end]</c>: recorded concurrently in real time by
+    /// ffmpeg streaming the in-progress VOD from segment index <c>split</c>. ffmpeg only has
+    /// to keep up with real time (the backlog is the back-catalog's job), and it finalizes
+    /// once cleanly when the broadcast ends.</item>
+    /// <item><b>Stitch</b>: the two halves are concatenated with <c>-c copy</c>. The split is
+    /// an exact HLS segment boundary (same source segments, "Safe" trim), so the join is
+    /// bit-exact - no re-encode, no overlap, no gap, no frame matching.</item>
+    /// </list>
+    /// </summary>
+    public sealed class LiveStreamDownloader
+    {
+        private static readonly HttpClient HttpClient = new();
+
+        // Tracks every ffmpeg process currently recording a live tail so they can be
+        // killed if the host application exits without going through normal cancellation.
+        private static readonly HashSet<Process> _activeFfmpegProcesses = new();
+        private static readonly object _activeFfmpegLock = new();
+
+        static LiveStreamDownloader()
+        {
+            AppDomain.CurrentDomain.ProcessExit += static (_, _) =>
+            {
+                lock (_activeFfmpegLock)
+                {
+                    foreach (var p in _activeFfmpegProcesses)
+                    {
+                        try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                    }
+                    _activeFfmpegProcesses.Clear();
+                }
+            };
+        }
+
+        private readonly LiveStreamDownloadOptions _options;
+        private readonly ITaskProgress _progress;
+
+        public LiveStreamDownloader(LiveStreamDownloadOptions options, ITaskProgress progress)
+        {
+            _options = options;
+            _progress = progress;
+        }
+
+        public async Task DownloadAsync(CancellationToken cancellationToken)
+        {
+            _progress.SetStatus("Starting live download...");
+
+            var info = await TwitchHelper.GetVideoInfo(_options.Id);
+            var video = info?.data?.video;
+            if (video is null)
+                throw new Exception($"Could not get video info for {_options.Id}. A live download requires the in-progress VOD (the channel must have VODs/archive enabled).");
+
+            var channel = video.owner?.login ?? video.owner?.displayName ?? _options.Channel ?? _options.Id.ToString();
+            var isLive = string.Equals(video.status, "RECORDING", StringComparison.OrdinalIgnoreCase);
+
+            var (outputFile, extension) = ResolveOutputPath();
+
+            // Clean up any leftover part files from a previous interrupted session
+            // (e.g. the app was closed mid-recording and restarted while the stream is still live).
+            // The ProcessExit handler kills any surviving ffmpeg before we reach this point,
+            // so the files should be unlocked. If somehow a file is still locked, log and continue.
+            var stalePartA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
+            var stalePartB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
+            if (File.Exists(stalePartA) || File.Exists(stalePartB))
+            {
+                _progress.LogInfo("Removing leftover part files from a previous interrupted session.");
+                if (!TryDelete(stalePartA))
+                    _progress.LogWarning($"Could not delete stale part file (still locked?): {stalePartA}");
+                if (!TryDelete(stalePartB))
+                    _progress.LogWarning($"Could not delete stale part file (still locked?): {stalePartB}");
+            }
+
+            // If the broadcast already ended, the in-progress VOD is just a normal finished
+            // VOD - one multi-threaded download, no split, no stitch.
+            if (!isLive)
+            {
+                _progress.LogWarning($"'{channel}' is not live (status: {video.status ?? "unknown"}). Downloading the complete VOD instead.");
+                await new VideoDownloader(BuildOptions(outputFile,
+                    _options.TrimBeginning ? _options.TrimBeginningTime : (TimeSpan?)null,
+                    _options.TrimEnding ? _options.TrimEndingTime : (TimeSpan?)null), _progress).DownloadAsync(cancellationToken);
+                _progress.ReportProgress(100);
+                return;
+            }
+
+            // Resolve the media playlist for the chosen quality and measure where the live
+            // edge currently is (segment count + total duration so far).
+            var tokenResponse = await TwitchHelper.GetVideoToken(_options.Id, _options.Oauth);
+            var vodToken = tokenResponse?.data?.videoPlaybackAccessToken;
+            if (vodToken is null || string.IsNullOrEmpty(vodToken.value))
+                throw new Exception($"Could not retrieve a playback token for video {_options.Id}.");
+
+            var masterString = await TwitchHelper.GetVideoPlaylist(_options.Id, vodToken.value, vodToken.signature);
+            if (masterString.Contains("vod_manifest_restricted") || masterString.Contains("unauthorized_entitlements"))
+                throw new Exception("This VOD requires authorization (sub-only / restricted). Provide a valid OAuth token in Settings.");
+
+            var master = M3U8.Parse(masterString);
+            master.SortStreamsByQuality();
+            var quality = VideoQualities.FromM3U8(master).GetQuality(_options.Quality);
+            var mediaUrl = quality?.Item?.Path;
+            if (string.IsNullOrWhiteSpace(mediaUrl))
+                throw new Exception("Could not find a playable quality for this stream.");
+
+            int splitSegmentIndex;
+            TimeSpan splitTime;
+            TimeSpan lastSegmentDuration;
+            try
+            {
+                var mediaString = await HttpClient.GetStringAsync(mediaUrl, cancellationToken);
+                var media = M3U8.Parse(mediaString);
+                var segments = media.Streams ?? Array.Empty<M3U8.Stream>();
+                splitSegmentIndex = segments.Length;
+                splitTime = TimeSpan.FromSeconds((double)segments.Sum(s => s.PartInfo?.Duration ?? 0m));
+                lastSegmentDuration = segments.Length > 0
+                    ? TimeSpan.FromSeconds((double)(segments[^1].PartInfo?.Duration ?? 10m))
+                    : TimeSpan.Zero;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Could not read the live media playlist to find the split point: {ex.Message}", ex);
+            }
+
+            // Need at least 2 segments so that partA gets at least one and partB gets the last.
+            if (splitSegmentIndex <= 1 || splitTime <= TimeSpan.FromSeconds(1))
+            {
+                // Nothing (or almost nothing) meaningful aired yet - just record everything live with ffmpeg.
+                _progress.LogInfo("Nothing has aired yet; recording the whole broadcast live.");
+                await RecordLiveTail(mediaUrl, 0, outputFile, extension, channel, cancellationToken);
+                _progress.ReportProgress(100);
+                return;
+            }
+
+            // Split strategy: give the LAST already-aired segment exclusively to the live tail (partB).
+            // partA gets everything up to (but not including) that segment.
+            // partB starts from that last segment via -live_start_index.
+            //
+            // Why: some ffmpeg versions clamp -live_start_index to last_seq_no when the requested
+            // index equals the current playlist length. Using N-1 (a definitely-present segment)
+            // avoids this, and keeping it exclusively in partB prevents a ~10 s repeated block at
+            // the join point.
+            var partATrimEnd = splitTime - lastSegmentDuration - TimeSpan.FromMilliseconds(100);
+            var ffmpegStartIndex = splitSegmentIndex - 1;
+
+            var partA = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partA" + extension);
+            var partB = Path.Combine(Path.GetDirectoryName(outputFile) ?? "", Path.GetFileNameWithoutExtension(outputFile) + ".partB" + extension);
+
+            try
+            {
+                _progress.LogInfo($"Live download for '{channel}': {splitTime:hh\\:mm\\:ss} already aired ({splitSegmentIndex} segments). "
+                                  + "Downloading the back-catalog multi-threaded while recording the live tail with ffmpeg in parallel.");
+
+                // Back-catalog uses its own CancellationTokenSource so it can run to
+                // completion even when the user requests an early stop.  The back-catalog
+                // is static content and downloads much faster than real time, so it will
+                // almost always be done before the user ever stops the recording.
+                using var backCatalogCts = new CancellationTokenSource();
+
+                var backCatalogTask = new VideoDownloader(BuildOptions(partA,
+                    _options.TrimBeginning ? _options.TrimBeginningTime : (TimeSpan?)null,
+                    partATrimEnd), _progress)
+                    .DownloadAsync(backCatalogCts.Token);
+
+                // Live tail listens to the user's cancellation token - pressing Cancel
+                // gracefully stops the ffmpeg recording and lets us stitch what we have.
+                var liveTailTask = RecordLiveTail(mediaUrl, ffmpegStartIndex, partB, extension, channel, cancellationToken);
+
+                bool stoppedEarly = false;
+                try
+                {
+                    await Task.WhenAll(backCatalogTask, liveTailTask);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    stoppedEarly = true;
+                    _progress.SetStatus("Recording stopped - waiting for back-catalog to finalize...");
+
+                    // Give the back-catalog up to 60 s to finish cleanly (it is static
+                    // content and almost certainly already done).  If it misses the
+                    // deadline, cancel it and stitch whatever partial output we have.
+                    using var backCatalogTimeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+                    try
+                    {
+                        await backCatalogTask.WaitAsync(backCatalogTimeoutCts.Token);
+                    }
+                    catch
+                    {
+                        backCatalogCts.Cancel();
+                        try { await backCatalogTask; } catch { /* ignored */ }
+                    }
+                }
+
+                _progress.SetStatus(stoppedEarly ? "Saving captured footage..." : "Stitching the two halves (lossless)...");
+                try
+                {
+                    await ConcatLossless(partA, partB, outputFile, CancellationToken.None);
+                }
+                catch (Exception ex) when (stoppedEarly)
+                {
+                    _progress.LogWarning($"Could not save partial recording: {ex.Message}");
+                }
+
+                if (stoppedEarly)
+                {
+                    _progress.SetStatus("Recording stopped and saved.");
+                    throw new OperationCanceledException("Recording stopped by user.", cancellationToken);
+                }
+
+                _progress.SetStatus("Live download complete.");
+                _progress.ReportProgress(100);
+            }
+            finally
+            {
+                TryDelete(partA);
+                TryDelete(partB);
+            }
+        }
+
+        private (string outputFile, string extension) ResolveOutputPath()
+        {
+            var outputFile = _options.Filename;
+            var extension = (Path.GetExtension(outputFile) ?? "").ToLowerInvariant();
+            if (string.IsNullOrEmpty(extension))
+            {
+                extension = ".mp4";
+                outputFile += extension;
+            }
+
+            var directory = Path.GetDirectoryName(outputFile);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+
+                if (outputFile.Length > 250)
+                {
+                    var name = Path.GetFileNameWithoutExtension(outputFile);
+                    var available = 250 - directory.Length - 1 - extension.Length - 6;
+                    if (available > 16)
+                    {
+                        name = name.Substring(0, Math.Min(name.Length, available));
+                        outputFile = Path.Combine(directory, name + extension);
+                        _progress.LogWarning($"Output path was too long; truncated to {outputFile}");
+                    }
+                }
+            }
+
+            return (outputFile, extension);
+        }
+
+        private VideoDownloadOptions BuildOptions(string filename, TimeSpan? trimStart, TimeSpan? trimEnd)
+        {
+            return new VideoDownloadOptions
+            {
+                Id = _options.Id,
+                Quality = _options.Quality,
+                Filename = filename,
+                Oauth = _options.Oauth,
+                FfmpegPath = _options.FfmpegPath,
+                DownloadThreads = _options.DownloadThreads,
+                ThrottleKib = _options.ThrottleKib,
+                TempFolder = _options.TempFolder,
+                TrimMode = VideoTrimMode.Safe,
+                TrimBeginning = trimStart.HasValue,
+                TrimBeginningTime = trimStart ?? TimeSpan.Zero,
+                TrimEnding = trimEnd.HasValue,
+                TrimEndingTime = trimEnd ?? TimeSpan.Zero,
+            };
+        }
+
+        private async Task RecordLiveTail(string mediaUrl, int startSegmentIndex, string outFile, string extension, string channel, CancellationToken cancellationToken)
+        {
+            var format = extension switch
+            {
+                ".mp4" => "mp4",
+                ".mov" => "mov",
+                ".mkv" => "matroska",
+                ".ts" => "mpegts",
+                ".webm" => "webm",
+                ".m4a" => "mp4",
+                _ => "mp4"
+            };
+            var audioBsf = extension is ".mp4" or ".mov" or ".m4a" ? " -bsf:a aac_adtstoasc" : "";
+
+            var arguments =
+                "-hide_banner -loglevel warning "
+                + "-user_agent \"Mozilla/5.0\" "
+                + "-protocol_whitelist file,crypto,data,http,https,tcp,tls "
+                + "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 "
+                + $"-live_start_index {startSegmentIndex} "
+                + $"-i \"{mediaUrl}\" -c copy{audioBsf} -f {format} -progress pipe:1 -y "
+                + $"\"{outFile}\"";
+
+            _progress.LogVerbose($"ffmpeg {arguments}");
+
+            var errorTail = new Queue<string>();
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = _options.FfmpegPath,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is null || !e.Data.StartsWith("out_time=", StringComparison.Ordinal)) return;
+                var value = e.Data.Substring("out_time=".Length).Trim();
+                if (TimeSpan.TryParse(value, out var captured))
+                    _progress.SetStatus($"● LIVE recording '{channel}'  -  {captured:hh\\:mm\\:ss} captured");
+            };
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is null) return;
+                _progress.LogFfmpeg(e.Data);
+                lock (errorTail)
+                {
+                    errorTail.Enqueue(e.Data);
+                    while (errorTail.Count > 20) errorTail.Dequeue();
+                }
+            };
+
+            process.Start();
+            lock (_activeFfmpegLock) { _activeFfmpegProcesses.Add(process); }
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _progress.SetStatus("Stopping live recording...");
+                try { if (!process.HasExited) await process.StandardInput.WriteLineAsync("q"); }
+                catch { /* ignored */ }
+                try
+                {
+                    using var graceCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                    await process.WaitForExitAsync(graceCts.Token);
+                }
+                catch
+                {
+                    try { if (!process.HasExited) process.Kill(true); } catch { /* ignored */ }
+                }
+                throw;
+            }
+            finally
+            {
+                lock (_activeFfmpegLock) { _activeFfmpegProcesses.Remove(process); }
+            }
+
+            if (process.ExitCode != 0)
+            {
+                string tail;
+                lock (errorTail) tail = string.Join(Environment.NewLine, errorTail);
+                throw new Exception($"Live tail recording failed (ffmpeg code {process.ExitCode})."
+                                    + (string.IsNullOrWhiteSpace(tail) ? "" : Environment.NewLine + tail));
+            }
+        }
+
+        private async Task ConcatLossless(string partA, string partB, string outputFile, CancellationToken cancellationToken)
+        {
+            bool aExists = File.Exists(partA);
+            bool bExists = File.Exists(partB);
+
+            if (!aExists && !bExists)
+                throw new Exception("Neither recording portion was produced; no output to save.");
+
+            if (!aExists)
+            {
+                // Back-catalog did not complete in time - save the live tail only.
+                _progress.LogWarning("Back-catalog did not complete; output contains the live-recorded portion only.");
+                File.Copy(partB, outputFile, true);
+                return;
+            }
+
+            if (!bExists)
+            {
+                File.Copy(partA, outputFile, true);
+                return;
+            }
+
+            var listFile = Path.Combine(Path.GetTempPath(), $"tdw_concat_{_options.Id}_{Guid.NewGuid():N}.txt");
+            await File.WriteAllTextAsync(listFile,
+                $"file '{partA.Replace("'", "'\\''")}'\nfile '{partB.Replace("'", "'\\''")}'\n",
+                cancellationToken);
+
+            try
+            {
+                var args = "-hide_banner -loglevel warning -y -f concat -safe 0 "
+                           + $"-i \"{listFile}\" -c copy -fflags +genpts \"{outputFile}\"";
+
+                var errorTail = new Queue<string>();
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = _options.FfmpegPath,
+                        Arguments = args,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                    }
+                };
+                process.ErrorDataReceived += (_, e) =>
+                {
+                    if (e.Data is null) return;
+                    _progress.LogFfmpeg(e.Data);
+                    lock (errorTail)
+                    {
+                        errorTail.Enqueue(e.Data);
+                        while (errorTail.Count > 20) errorTail.Dequeue();
+                    }
+                };
+                process.OutputDataReceived += (_, e) => { if (e.Data != null) _progress.LogFfmpeg(e.Data); };
+
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+                await process.WaitForExitAsync(cancellationToken);
+
+                if (process.ExitCode != 0)
+                {
+                    string tail;
+                    lock (errorTail) tail = string.Join(Environment.NewLine, errorTail);
+                    throw new Exception($"Lossless stitch failed (ffmpeg code {process.ExitCode})."
+                                        + (string.IsNullOrWhiteSpace(tail) ? "" : Environment.NewLine + tail));
+                }
+            }
+            finally
+            {
+                TryDelete(listFile);
+            }
+        }
+
+        private static bool TryDelete(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    File.Delete(path);
+                return true;
+            }
+            catch { return false; }
+        }
+    }
+}

--- a/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/LiveStreamDownloadOptions.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace TwitchDownloaderCore.Options
+{
+    public class LiveStreamDownloadOptions
+    {
+        /// <summary>
+        /// The id of the in-progress VOD. Used to resolve the channel login (and is shown in the queue).
+        /// Ignored if <see cref="Channel"/> is set.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// The channel login to record. If empty, it is resolved from <see cref="Id"/>.
+        /// </summary>
+        public string Channel { get; set; }
+
+        public string Quality { get; set; }
+        public string Filename { get; set; }
+        public string Oauth { get; set; }
+        public string FfmpegPath { get; set; }
+        public int DownloadThreads { get; set; } = 4;
+        public int ThrottleKib { get; set; } = -1;
+        public string TempFolder { get; set; }
+
+        public bool TrimBeginning { get; set; }
+        public TimeSpan TrimBeginningTime { get; set; }
+        public bool TrimEnding { get; set; }
+        public TimeSpan TrimEndingTime { get; set; }
+    }
+}

--- a/TwitchDownloaderWPF/MainWindow.xaml
+++ b/TwitchDownloaderWPF/MainWindow.xaml
@@ -24,6 +24,7 @@
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="5"/>
         </Grid.ColumnDefinitions>
         <Button x:Name="btnVodDownload" Margin="4" Grid.Row="1" Grid.Column="1" MinWidth="122" Height="52" Click="btnVodDownload_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
@@ -44,6 +45,9 @@
         <Button x:Name="btnQueue" Margin="4" Grid.Row="1" Grid.Column="6" MinWidth="122" Height="52" Click="btnQueue_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
             <TextBlock Text="{lex:Loc TaskQueue}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="{Binding ActualWidth, ElementName=btnQueue, Mode=OneWay}" Padding="3,0,3,0" />
         </Button>
-        <Frame Focusable="False" x:Name="Main" Grid.Column="0" Grid.ColumnSpan="8" Grid.Row="2" NavigationUIVisibility="Hidden" Navigated="Main_OnNavigated" Background="{DynamicResource AppBackground}" BorderBrush="{DynamicResource AppBackground}"/>
+        <Button x:Name="btnLiveMonitor" Margin="4" Grid.Row="1" Grid.Column="7" MinWidth="122" Height="52" Click="btnLiveMonitor_Click" FontWeight="Bold" Padding="3,0,3,0" Background="{DynamicResource BigButtonBackground}" Foreground="{DynamicResource BigButtonText}" BorderBrush="{DynamicResource BigButtonBorder}" >
+            <TextBlock Text="{lex:Loc LiveMonitor}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="{Binding ActualWidth, ElementName=btnLiveMonitor, Mode=OneWay}" Padding="3,0,3,0" />
+        </Button>
+        <Frame Focusable="False" x:Name="Main" Grid.Column="0" Grid.ColumnSpan="9" Grid.Row="2" NavigationUIVisibility="Hidden" Navigated="Main_OnNavigated" Background="{DynamicResource AppBackground}" BorderBrush="{DynamicResource AppBackground}"/>
     </Grid>
 </Window>

--- a/TwitchDownloaderWPF/MainWindow.xaml.cs
+++ b/TwitchDownloaderWPF/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace TwitchDownloaderWPF
         public static PageChatUpdate pageChatUpdate = new PageChatUpdate();
         public static PageChatRender pageChatRender = new PageChatRender();
         public static PageQueue pageQueue = new PageQueue();
+        public static PageLiveMonitor pageLiveMonitor = new PageLiveMonitor();
 
         public MainWindow()
         {
@@ -61,6 +62,11 @@ namespace TwitchDownloaderWPF
         private void btnQueue_Click(object sender, RoutedEventArgs e)
         {
             Main.Content = pageQueue;
+        }
+
+        private void btnLiveMonitor_Click(object sender, RoutedEventArgs e)
+        {
+            Main.Content = pageLiveMonitor;
         }
 
         private void Window_OnSourceInitialized(object sender, EventArgs e)

--- a/TwitchDownloaderWPF/Models/MonitoredChannel.cs
+++ b/TwitchDownloaderWPF/Models/MonitoredChannel.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+
+namespace TwitchDownloaderWPF.Models
+{
+    public class MonitoredChannel : INotifyPropertyChanged
+    {
+        private string _status;
+
+        public string Login { get; init; }
+
+        public string Status
+        {
+            get => _status;
+            set
+            {
+                if (_status == value)
+                    return;
+                _status = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Status)));
+            }
+        }
+
+        // The stream id currently being recorded, so the same broadcast is not enqueued twice.
+        public string RecordingStreamId { get; set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml
@@ -1,0 +1,48 @@
+<Page x:Class="TwitchDownloaderWPF.PageLiveMonitor"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="clr-namespace:TwitchDownloaderWPF"
+      xmlns:lex="http://wpflocalizeextension.codeplex.com"
+      lex:LocalizeDictionary.DesignCulture=""
+      lex:ResxLocalizationProvider.DefaultAssembly="TwitchDownloaderWPF"
+      lex:ResxLocalizationProvider.DefaultDictionary="Strings"
+      mc:Ignorable="d"
+      d:DesignHeight="400" d:DesignWidth="800"
+      Title="PageLiveMonitor" Loaded="Page_Loaded" Unloaded="Page_Unloaded">
+    <Grid Background="{DynamicResource AppBackground}" Margin="20,10,20,10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="160"/>
+        </Grid.RowDefinitions>
+
+        <WrapPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="{lex:Loc LiveMonitorChannel}" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource AppText}"/>
+            <TextBox x:Name="textChannel" MinWidth="180" Margin="0,0,4,0" KeyDown="TextChannel_KeyDown" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}"/>
+            <Button x:Name="btnAddChannel" Content="{lex:Loc LiveMonitorAdd}" MinWidth="50" Margin="0,0,4,0" Click="BtnAddChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="btnRemoveChannel" Content="{lex:Loc LiveMonitorRemove}" MinWidth="60" Margin="0,0,12,0" Click="BtnRemoveChannel_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+            <Button x:Name="btnToggleMonitor" Content="{lex:Loc LiveMonitorStart}" MinWidth="120" Click="BtnToggleMonitor_Click" Background="{DynamicResource ActionButtonBackground}" Foreground="{DynamicResource ActionButtonText}" BorderBrush="{DynamicResource ActionButtonBorder}"/>
+        </WrapPanel>
+
+        <ListView x:Name="listChannels" Grid.Row="1" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="{lex:Loc LiveMonitorChannelColumn}" Width="220" DisplayMemberBinding="{Binding Login}"/>
+                    <GridViewColumn Header="{lex:Loc LiveMonitorStatusColumn}" Width="360" DisplayMemberBinding="{Binding Status}"/>
+                </GridView>
+            </ListView.View>
+        </ListView>
+
+        <TextBlock Grid.Row="2" Text="{lex:Loc LogHeader}" Margin="0,8,0,2" Foreground="{DynamicResource AppText}"/>
+        <RichTextBox x:Name="textLog" Grid.Row="3" IsReadOnly="True" VerticalScrollBarVisibility="Auto" Background="{DynamicResource AppElementBackground}" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}">
+            <RichTextBox.Resources>
+                <Style TargetType="{x:Type Paragraph}">
+                    <Setter Property="Margin" Value="0"/>
+                </Style>
+            </RichTextBox.Resources>
+        </RichTextBox>
+    </Grid>
+</Page>

--- a/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
+++ b/TwitchDownloaderWPF/PageLiveMonitor.xaml.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Threading;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Services;
+using TwitchDownloaderCore.TwitchObjects.Gql;
+using TwitchDownloaderWPF.Models;
+using TwitchDownloaderWPF.Properties;
+using TwitchDownloaderWPF.Services;
+
+namespace TwitchDownloaderWPF
+{
+    public partial class PageLiveMonitor : Page
+    {
+        private readonly ObservableCollection<MonitoredChannel> _channels = new();
+        private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromSeconds(60) };
+        private bool _monitoring;
+        private bool _polling;
+
+        public PageLiveMonitor()
+        {
+            InitializeComponent();
+            listChannels.ItemsSource = _channels;
+            _timer.Tick += async (_, _) => await PollAsync();
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_channels.Count > 0)
+                return;
+
+            var saved = (Settings.Default.LiveMonitorChannels ?? "").Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            foreach (var login in saved)
+                _channels.Add(new MonitoredChannel { Login = login, Status = "Idle" });
+        }
+
+        private void Page_Unloaded(object sender, RoutedEventArgs e) => SaveChannels();
+
+        private void SaveChannels()
+        {
+            Settings.Default.LiveMonitorChannels = string.Join(",", _channels.Select(c => c.Login));
+            Settings.Default.Save();
+        }
+
+        private void TextChannel_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+                AddChannel();
+        }
+
+        private void BtnAddChannel_Click(object sender, RoutedEventArgs e) => AddChannel();
+
+        private void AddChannel()
+        {
+            var login = textChannel.Text.Trim().TrimEnd('/');
+            var slash = login.LastIndexOf('/');
+            if (slash >= 0)
+                login = login[(slash + 1)..];
+            login = login.ToLowerInvariant();
+
+            if (string.IsNullOrWhiteSpace(login) || _channels.Any(c => c.Login == login))
+                return;
+
+            _channels.Add(new MonitoredChannel { Login = login, Status = "Idle" });
+            textChannel.Clear();
+            SaveChannels();
+        }
+
+        private void BtnRemoveChannel_Click(object sender, RoutedEventArgs e)
+        {
+            if (listChannels.SelectedItem is MonitoredChannel channel)
+            {
+                _channels.Remove(channel);
+                SaveChannels();
+            }
+        }
+
+        private void BtnToggleMonitor_Click(object sender, RoutedEventArgs e)
+        {
+            _monitoring = !_monitoring;
+            if (_monitoring)
+            {
+                btnToggleMonitor.Content = Translations.Strings.LiveMonitorStop;
+                _timer.Start();
+                AppendLog("Monitoring started.");
+                _ = PollAsync();
+            }
+            else
+            {
+                _timer.Stop();
+                btnToggleMonitor.Content = Translations.Strings.LiveMonitorStart;
+                AppendLog("Monitoring stopped.");
+                foreach (var channel in _channels)
+                    channel.Status = "Idle";
+            }
+        }
+
+        private async Task PollAsync()
+        {
+            if (_polling)
+                return;
+
+            _polling = true;
+            try
+            {
+                foreach (var channel in _channels.ToList())
+                {
+                    try
+                    {
+                        var videos = await TwitchHelper.GetGqlVideos(channel.Login, "", 1, "ARCHIVE");
+                        var node = videos?.data?.user?.videos?.edges?.FirstOrDefault()?.node;
+                        if (node is null || !long.TryParse(node.id, out var vodId))
+                        {
+                            channel.Status = "Offline";
+                            channel.RecordingStreamId = null;
+                            continue;
+                        }
+
+                        var info = await TwitchHelper.GetVideoInfo(vodId);
+                        var isLive = info?.data?.video?.status == "RECORDING";
+                        if (!isLive)
+                        {
+                            channel.Status = "Offline";
+                            channel.RecordingStreamId = null;
+                            continue;
+                        }
+
+                        // Live. Queue a recording once per broadcast (keyed on the recording VOD id).
+                        if (channel.RecordingStreamId != node.id)
+                        {
+                            channel.RecordingStreamId = node.id;
+                            EnqueueRecording(channel.Login, vodId, node);
+                            AppendLog($"{channel.Login} is live; queued a recording ({node.title}).");
+                        }
+                        channel.Status = "Recording";
+                    }
+                    catch (Exception ex)
+                    {
+                        channel.Status = "Error";
+                        AppendLog($"{channel.Login}: {ex.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                _polling = false;
+            }
+        }
+
+        private void EnqueueRecording(string login, long vodId, VideoNode node)
+        {
+            var length = TimeSpan.FromSeconds(node.lengthSeconds);
+            var filename = Path.Combine(Settings.Default.QueueFolder,
+                FilenameService.GetFilename(Settings.Default.TemplateVod, node.title, node.id, node.createdAt, login, "",
+                    TimeSpan.Zero, length, length, node.viewCount, node.game?.displayName ?? "") + ".mp4");
+
+            var options = new LiveStreamDownloadOptions
+            {
+                Id = vodId,
+                Channel = login,
+                Quality = "chunked",
+                Filename = filename,
+                Oauth = Settings.Default.OAuth,
+                FfmpegPath = "ffmpeg",
+                TempFolder = Settings.Default.TempPath,
+                DownloadThreads = Settings.Default.VodDownloadThreads,
+            };
+
+            var task = new TwitchTasks.LiveStreamDownloadTask
+            {
+                DownloadOptions = options,
+                Info = { Title = node.title }
+            };
+            PageQueue.taskList.Add(task);
+        }
+
+        private void AppendLog(string message)
+        {
+            textLog.Document.Blocks.Add(new Paragraph(new Run($"[{DateTime.Now:HH:mm:ss}] {message}")));
+            textLog.ScrollToEnd();
+        }
+    }
+}

--- a/TwitchDownloaderWPF/Properties/Settings.Designer.cs
+++ b/TwitchDownloaderWPF/Properties/Settings.Designer.cs
@@ -1028,5 +1028,17 @@ namespace TwitchDownloaderWPF.Properties {
                 this["AvatarScale"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LiveMonitorChannels {
+            get {
+                return ((string)(this["LiveMonitorChannels"]));
+            }
+            set {
+                this["LiveMonitorChannels"] = value;
+            }
+        }
     }
 }

--- a/TwitchDownloaderWPF/Properties/Settings.settings
+++ b/TwitchDownloaderWPF/Properties/Settings.settings
@@ -254,6 +254,9 @@
     <Setting Name="AvatarScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
+    <Setting Name="LiveMonitorChannels" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/TwitchDownloaderWPF/Translations/Strings.Designer.cs
+++ b/TwitchDownloaderWPF/Translations/Strings.Designer.cs
@@ -284,7 +284,55 @@ namespace TwitchDownloaderWPF.Translations {
                 return ResourceManager.GetString("Browse", resourceCulture);
             }
         }
-        
+
+        public static string LiveMonitor {
+            get {
+                return ResourceManager.GetString("LiveMonitor", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorChannel {
+            get {
+                return ResourceManager.GetString("LiveMonitorChannel", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorAdd {
+            get {
+                return ResourceManager.GetString("LiveMonitorAdd", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorRemove {
+            get {
+                return ResourceManager.GetString("LiveMonitorRemove", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorStart {
+            get {
+                return ResourceManager.GetString("LiveMonitorStart", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorStop {
+            get {
+                return ResourceManager.GetString("LiveMonitorStop", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorChannelColumn {
+            get {
+                return ResourceManager.GetString("LiveMonitorChannelColumn", resourceCulture);
+            }
+        }
+
+        public static string LiveMonitorStatusColumn {
+            get {
+                return ResourceManager.GetString("LiveMonitorStatusColumn", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die BTTV Emotes: ähnelt.
         /// </summary>

--- a/TwitchDownloaderWPF/Translations/Strings.resx
+++ b/TwitchDownloaderWPF/Translations/Strings.resx
@@ -149,6 +149,30 @@
   <data name="Browse" xml:space="preserve">
     <value>Browse</value>
   </data>
+  <data name="LiveMonitor" xml:space="preserve">
+    <value>Live Monitor</value>
+  </data>
+  <data name="LiveMonitorChannel" xml:space="preserve">
+    <value>Channel:</value>
+  </data>
+  <data name="LiveMonitorAdd" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="LiveMonitorRemove" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="LiveMonitorStart" xml:space="preserve">
+    <value>Start Monitoring</value>
+  </data>
+  <data name="LiveMonitorStop" xml:space="preserve">
+    <value>Stop Monitoring</value>
+  </data>
+  <data name="LiveMonitorChannelColumn" xml:space="preserve">
+    <value>Channel</value>
+  </data>
+  <data name="LiveMonitorStatusColumn" xml:space="preserve">
+    <value>Status</value>
+  </data>
   <data name="BttvEmotes" xml:space="preserve">
     <value>BTTV Emotes:</value>
   </data>

--- a/TwitchDownloaderWPF/TwitchTasks/LiveStreamDownloadTask.cs
+++ b/TwitchDownloaderWPF/TwitchTasks/LiveStreamDownloadTask.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderWPF.Utils;
+
+namespace TwitchDownloaderWPF.TwitchTasks
+{
+    internal class LiveStreamDownloadTask : TwitchTask
+    {
+        public LiveStreamDownloadOptions DownloadOptions { get; init; }
+        public override string TaskType { get; } = Translations.Strings.VodDownload;
+        public override string OutputFile => DownloadOptions.Filename;
+
+        public override void Reinitialize()
+        {
+            Progress = 0;
+            TokenSource = new CancellationTokenSource();
+            Exception = null;
+            CanReinitialize = false;
+            ChangeStatus(TwitchTaskStatus.Ready);
+        }
+
+        public override bool CanRun()
+        {
+            return Status == TwitchTaskStatus.Ready;
+        }
+
+        public override async Task RunAsync()
+        {
+            var progress = new WpfTaskProgress(i => Progress = i, s => DisplayStatus = s);
+
+            if (TokenSource.IsCancellationRequested)
+            {
+                TokenSource.Dispose();
+                ChangeStatus(TwitchTaskStatus.Canceled);
+                CanReinitialize = true;
+                return;
+            }
+
+            var downloader = new LiveStreamDownloader(DownloadOptions, progress);
+            ChangeStatus(TwitchTaskStatus.Running);
+
+            try
+            {
+                await downloader.DownloadAsync(TokenSource.Token);
+                if (TokenSource.IsCancellationRequested)
+                {
+                    ChangeStatus(TwitchTaskStatus.Canceled);
+                    CanReinitialize = true;
+                }
+                else
+                {
+                    progress.ReportProgress(100);
+                    ChangeStatus(TwitchTaskStatus.Finished);
+                }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException && TokenSource.IsCancellationRequested)
+            {
+                // The recording was stopped by the user - whatever was captured is kept.
+                ChangeStatus(TwitchTaskStatus.Canceled);
+                CanReinitialize = true;
+            }
+            catch (Exception ex)
+            {
+                ChangeStatus(TwitchTaskStatus.Failed);
+                Exception = ex;
+                CanReinitialize = true;
+            }
+            TokenSource.Dispose();
+            GC.Collect(-1, GCCollectionMode.Default, false);
+        }
+    }
+}


### PR DESCRIPTION
Adds a Live Monitor page that watches a list of channels and queues a recording when one goes live. This is an intentionally minimal first cut to keep the diff reviewable, and it can be extended with per-channel options later. Opened as a draft for feedback on the approach.

Related to #1294 and #1187
