### PR TITLE
More render optimizations

### DIFF
--- a/TwitchDownloaderCLI/Modes/RenderChat.cs
+++ b/TwitchDownloaderCLI/Modes/RenderChat.cs
@@ -5,6 +5,7 @@ using TwitchDownloaderCore;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Interfaces;
 using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.TwitchObjects;
 
 namespace TwitchDownloaderCLI.Modes
 {
@@ -46,7 +47,7 @@ namespace TwitchDownloaderCLI.Modes
                 OutlineSize = inputOptions.OutlineSize,
                 Font = inputOptions.Font,
                 FontSize = inputOptions.FontSize,
-                ChatBadgeMask = inputOptions.BadgeFilterMask,
+                ChatBadgeMask = (ChatBadgeType)inputOptions.BadgeFilterMask,
                 MessageFontStyle = inputOptions.MessageFontStyle.ToLower() switch
                 {
                     "normal" => SKFontStyle.Normal,

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1366,7 +1366,7 @@ namespace TwitchDownloaderCore
             {
                 if (int.TryParse(fragmentString[bitsIndex..], out var bitsAmount) && TryGetCheerEmote(cheermotesList, fragmentString[..bitsIndex], out var currentCheerEmote))
                 {
-                    KeyValuePair<int, TwitchEmote> tierList = currentCheerEmote.getTier(bitsAmount);
+                    var tierList = currentCheerEmote.GetTier(bitsAmount);
                     TwitchEmote cheerEmote = tierList.Value;
                     SKImageInfo cheerEmoteInfo = cheerEmote.Info;
                     if (drawPos.X + cheerEmoteInfo.Width > renderOptions.ChatWidth - renderOptions.SidePadding * 2)
@@ -1783,7 +1783,7 @@ namespace TwitchDownloaderCore
             foreach (var (badgeImage, badgeType) in badgeImages)
             {
                 //Don't render filtered out badges
-                if (((ChatBadgeType)renderOptions.ChatBadgeMask).HasFlag(badgeType))
+                if ((renderOptions.ChatBadgeMask & badgeType) != 0)
                     continue;
 
                 float badgeY = (float)((renderOptions.SectionHeight - badgeImage.Height) / 2.0);

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -83,6 +83,7 @@ namespace TwitchDownloaderCore
         // unchanged frame does not need to be copied and recomposited. See DrawAnimatedEmotes.
         private SKBitmap _animComposedFrame;
         private SKCanvas _animCanvas;
+        private int _animByteSize;
         private int _animComposedForCommentIndex = int.MinValue;
         private readonly List<int> _animLastFrameIndices = [];
 
@@ -487,23 +488,24 @@ namespace TwitchDownloaderCore
             if (_animComposedFrame == null)
             {
                 _animComposedFrame = new SKBitmap(updateFrame.Info);
+                _animByteSize = updateFrame.Info.BytesSize;
                 _animCanvas = new SKCanvas(_animComposedFrame);
             }
 
             // Copy the background pixels straight into the buffer the canvas is bound to. CopyTo(bitmap) always
-            // allocates a new buffer, even if the old buffer is the same since, so a raw memcpy into the existing
+            // allocates a new buffer, even if the old buffer is the same size, so a raw memcpy into the existing
             // buffer is used instead.
             unsafe
             {
-                var byteCount = _animComposedFrame.Info.BytesSize;
-                Buffer.MemoryCopy((void*)updateFrame.GetPixels(), (void*)_animComposedFrame.GetPixels(), byteCount, byteCount);
+                Buffer.MemoryCopy((void*)updateFrame.GetPixels(), (void*)_animComposedFrame.GetPixels(), _animByteSize, _animByteSize);
             }
 
             var frameHeight = renderOptions.ChatHeight;
+            var verticalPadding = renderOptions.VerticalPadding;
             for (var c = comments.Count - 1; c >= 0; c--)
             {
                 var comment = comments[c];
-                frameHeight -= comment.Image.Height + renderOptions.VerticalPadding;
+                frameHeight -= comment.Image.Info.Height + verticalPadding;
                 foreach (var (drawPoint, emote) in comment.Emotes)
                 {
                     if (emote.FrameCount > 1)
@@ -517,9 +519,10 @@ namespace TwitchDownloaderCore
         private static int ComputeAnimFrameIndex(TwitchEmote emote, long currentTickMs)
         {
             var imageFrame = currentTickMs % (emote.TotalDuration * 10);
-            for (var i = 0; i < emote.EmoteFrameDurations.Count; i++)
+            var durations = emote.EmoteFrameDurations;
+            for (var i = 0; i < durations.Count; i++)
             {
-                imageFrame -= emote.EmoteFrameDurations[i] * 10;
+                imageFrame -= durations[i] * 10;
 
                 if (imageFrame <= 0) return i;
             }
@@ -568,7 +571,7 @@ namespace TwitchDownloaderCore
         private int GetNewestCommentIndex(int lastIndex, double currentTimeSeconds)
         {
             var commentSpan = CollectionsMarshal.AsSpan(chatRoot.comments);
-            for (var i = Math.Max(0, lastIndex); i < commentSpan.Length; i++)
+            for (var i = lastIndex + 1; i < commentSpan.Length; i++)
             {
                 if (commentSpan[i].content_offset_seconds > currentTimeSeconds)
                 {
@@ -634,7 +637,7 @@ namespace TwitchDownloaderCore
                 while (commentListIndex >= 0 && frameHeight > -renderOptions.VerticalPadding)
                 {
                     var comment = commentList[commentListIndex];
-                    var commentHeight = comment.Image.Height;
+                    var commentHeight = comment.Image.Info.Height;
                     frameHeight -= commentHeight + renderOptions.VerticalPadding;
 
                     var backgroundColor = GetMessageBackground(comment.CommentIndex, out var backgroundPaint);
@@ -643,7 +646,7 @@ namespace TwitchDownloaderCore
                         frameCanvas.DrawRect(0, frameHeight - renderOptions.VerticalPadding / 2f, frameWidth, commentHeight + renderOptions.VerticalPadding, backgroundPaint);
                     }
 
-                    frameCanvas.DrawBitmap(comment.Image, 0, frameHeight);
+                    frameCanvas.DrawBitmap(comment.Image.Bitmap, 0, frameHeight);
 
                     foreach (var (drawPoint, emote) in comment.Emotes)
                     {
@@ -660,7 +663,7 @@ namespace TwitchDownloaderCore
                 int removeCount = commentList.Count - commentsDrawn;
                 for (int i = 0; i < removeCount; i++)
                 {
-                    commentList[i].Image.Dispose();
+                    ReturnSectionImage(commentList[i].Image);
                 }
                 commentList.RemoveRange(0, removeCount);
             }
@@ -758,54 +761,54 @@ namespace TwitchDownloaderCore
                 DrawNonAccentedMessage(comment, sectionImages, emoteSectionList, false, commentIndex, ref drawPos, ref defaultPos);
             }
 
-            SKBitmap finalBitmap = CombineImages(sectionImages, highlightType, commentIndex);
-            newSection.Image = finalBitmap;
+            var finalImage = CombineImages(sectionImages, highlightType, commentIndex);
+            newSection.Image = finalImage;
             newSection.Emotes = emoteSectionList;
             newSection.CommentIndex = commentIndex;
 
             return newSection;
         }
 
-        private SKBitmap CombineImages(List<SectionImage> sectionImages, HighlightType highlightType, int commentIndex)
+        private SectionImage CombineImages(List<SectionImage> sectionImages, HighlightType highlightType, int commentIndex)
         {
-            var finalBitmap = new SKBitmap(renderOptions.ChatWidth, sectionImages.Sum(x => x.Info.Height));
-            var finalBitmapInfo = finalBitmap.Info;
-            using (SKCanvas finalCanvas = new SKCanvas(finalBitmap))
+            var finalImage = RentSectionImage(renderOptions.ChatWidth, sectionImages.Sum(x => x.Info.Height));
+            var finalBitmapInfo = finalImage.Info;
+            var finalCanvas = finalImage.Canvas;
+
+            if (highlightType is HighlightType.PayingForward or HighlightType.ChannelPointHighlight or HighlightType.WatchStreak or HighlightType.Combo)
             {
-                if (highlightType is HighlightType.PayingForward or HighlightType.ChannelPointHighlight or HighlightType.WatchStreak or HighlightType.Combo)
-                {
-                    var accentColor = highlightType is HighlightType.PayingForward
-                        ? new SKColor(0xFF26262C) // AARRGGBB
-                        : new SKColor(0xFF80808C); // AARRGGBB
+                var accentColor = highlightType is HighlightType.PayingForward
+                    ? new SKColor(0xFF26262C) // AARRGGBB
+                    : new SKColor(0xFF80808C); // AARRGGBB
 
-                    var paint = GetCachedPaint(accentColor);
-                    finalCanvas.DrawRect(renderOptions.SidePadding, 0, renderOptions.AccentStrokeWidth, finalBitmapInfo.Height, paint);
-                }
-                else if (highlightType is not HighlightType.None)
+                var paint = GetCachedPaint(accentColor);
+                finalCanvas.DrawRect(renderOptions.SidePadding, 0, renderOptions.AccentStrokeWidth, finalBitmapInfo.Height, paint);
+            }
+            else if (highlightType is not HighlightType.None)
+            {
+                const int OPAQUE_THRESHOLD = 245;
+                var messageBackground = GetMessageBackground(commentIndex, out _);
+                if (messageBackground.Alpha < OPAQUE_THRESHOLD)
                 {
-                    const int OPAQUE_THRESHOLD = 245;
-                    var messageBackground = GetMessageBackground(commentIndex, out _);
-                    if (messageBackground.Alpha < OPAQUE_THRESHOLD)
-                    {
-                        // Draw the highlight background only if the message background is opaque enough
-                        var backgroundColor = new SKColor(0x1A6B6B6E); // AARRGGBB
-                        var backgroundPaint = GetCachedPaint(backgroundColor);
-                        finalCanvas.DrawRect(renderOptions.SidePadding, 0, finalBitmapInfo.Width - renderOptions.SidePadding * 2, finalBitmapInfo.Height, backgroundPaint);
-                    }
-
-                    var accentPaint = GetCachedPaint(Purple);
-                    finalCanvas.DrawRect(renderOptions.SidePadding, 0, renderOptions.AccentStrokeWidth, finalBitmapInfo.Height, accentPaint);
+                    // Draw the highlight background only if the message background is opaque enough
+                    var backgroundColor = new SKColor(0x1A6B6B6E); // AARRGGBB
+                    var backgroundPaint = GetCachedPaint(backgroundColor);
+                    finalCanvas.DrawRect(renderOptions.SidePadding, 0, finalBitmapInfo.Width - renderOptions.SidePadding * 2, finalBitmapInfo.Height, backgroundPaint);
                 }
 
-                for (int i = 0; i < sectionImages.Count; i++)
-                {
-                    finalCanvas.DrawBitmap(sectionImages[i].Bitmap, 0, i * renderOptions.SectionHeight);
-                    sectionImages[i].Dispose();
-                }
+                var accentPaint = GetCachedPaint(Purple);
+                finalCanvas.DrawRect(renderOptions.SidePadding, 0, renderOptions.AccentStrokeWidth, finalBitmapInfo.Height, accentPaint);
+            }
+
+            for (var i = 0; i < sectionImages.Count; i++)
+            {
+                finalCanvas.DrawBitmap(sectionImages[i].Bitmap, 0, i * renderOptions.SectionHeight);
+                ReturnSectionImage(sectionImages[i]);
             }
             sectionImages.Clear();
-            finalBitmap.SetImmutable();
-            return finalBitmap;
+
+            finalImage.Flush();
+            return finalImage;
         }
 
         private static string GetKeyName(IEnumerable<Codepoint> codepoints)
@@ -849,7 +852,7 @@ namespace TwitchDownloaderCore
 
             foreach (var sectionImage in sectionImages)
             {
-                sectionImage.SetImmutable();
+                sectionImage.Flush();
             }
         }
 
@@ -901,7 +904,7 @@ namespace TwitchDownloaderCore
 
             foreach (var sectionImage in sectionImages)
             {
-                sectionImage.SetImmutable();
+                sectionImage.Flush();
             }
         }
 
@@ -1888,7 +1891,43 @@ namespace TwitchDownloaderCore
         {
             drawPos.X = defaultPos.X;
             drawPos.Y = defaultPos.Y;
-            sectionImages.Add(new SectionImage(renderOptions.ChatWidth, renderOptions.SectionHeight));
+
+            sectionImages.Add(RentSectionImage(renderOptions.ChatWidth, renderOptions.SectionHeight));
+        }
+
+        private SectionImage RentSectionImage(int width, int height)
+        {
+            ref var bucket = ref CollectionsMarshal.GetValueRefOrAddDefault(sectionImageCache, (width, height), out var exists);
+            if (!exists)
+            {
+                bucket = [];
+            }
+
+            if (bucket.Count == 0)
+            {
+                return new SectionImage(width, height);
+            }
+
+            var image = bucket[^1];
+            bucket.RemoveAt(bucket.Count - 1);
+            image.Canvas.Clear();
+            return image;
+        }
+
+        private void ReturnSectionImage(SectionImage sectionImage)
+        {
+            var width = sectionImage.Info.Width;
+            var height = sectionImage.Info.Height;
+
+            ref var bucket = ref CollectionsMarshal.GetValueRefOrAddDefault(sectionImageCache, (width, height), out var exists);
+            if (!exists)
+            {
+                // Don't create a new bucket for an image that wasn't rented from the cache
+                sectionImage.Dispose();
+                return;
+            }
+
+            bucket.Add(sectionImage);
         }
 
         /// <summary>
@@ -2220,6 +2259,9 @@ namespace TwitchDownloaderCore
                         paint?.Dispose();
                     foreach (var (_, paint) in paintCache)
                         paint?.Dispose();
+                    foreach (var (_, bucket) in sectionImageCache)
+                        foreach (var image in bucket)
+                            image.Dispose();
                     fontManager?.Dispose();
                     nameFont?.Dispose();
                     messageFont?.Dispose();

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -67,10 +67,11 @@ namespace TwitchDownloaderCore
         private List<TwitchEmote> emoteList = new List<TwitchEmote>();
         private List<TwitchEmote> emoteThirdList = new List<TwitchEmote>();
         private List<CheerEmote> cheermotesList = new List<CheerEmote>();
-        private Dictionary<string, SKBitmap> emojiCache = new Dictionary<string, SKBitmap>();
-        private Dictionary<string, SKBitmap> avatarCache = new Dictionary<string, SKBitmap>();
-        private Dictionary<int, SKPaint> fallbackFontCache = new Dictionary<int, SKPaint>();
-        private Dictionary<SKColor, SKPaint> paintCache = new Dictionary<SKColor, SKPaint>();
+        private Dictionary<string, SKImage> emojiCache = [];
+        private Dictionary<string, SKImage> avatarCache = [];
+        private Dictionary<int, SKPaint> fallbackFontCache = [];
+        private Dictionary<SKColor, SKPaint> paintCache = [];
+        private Dictionary<(int, int), List<SectionImage>> sectionImageCache = [];
         private bool noFallbackFontFound = false;
         private readonly SKFontManager fontManager = SKFontManager.CreateDefault();
         private SKPaint messageFont;
@@ -1244,7 +1245,7 @@ namespace TwitchDownloaderCore
                 }
 
                 SingleEmoji selectedEmoji = emojiMatches.MaxBy(x => x.SortOrder);
-                SKBitmap emojiImage = emojiCache[GetKeyName(selectedEmoji.Sequence.Codepoints)];
+                var emojiImage = emojiCache[GetKeyName(selectedEmoji.Sequence.Codepoints)];
                 SKImageInfo emojiImageInfo = emojiImage.Info;
 
                 if (drawPos.X + emojiImageInfo.Width > renderOptions.ChatWidth - renderOptions.SidePadding * 2)
@@ -1265,7 +1266,7 @@ namespace TwitchDownloaderCore
                     canvas.DrawRect((int)(emotePoint.X - renderOptions.EmoteSpacing / 2d), 0, emojiImageInfo.Width + renderOptions.EmoteSpacing, renderOptions.SectionHeight, paint);
                 }
 
-                canvas.DrawBitmap(emojiImage, emotePoint.X, emotePoint.Y);
+                canvas.DrawImage(emojiImage, emotePoint.X, emotePoint.Y);
                 nonEmojiStart += elementLength;
 
                 drawPos.X += emojiImageInfo.Width + renderOptions.EmoteSpacing;
@@ -1775,14 +1776,14 @@ namespace TwitchDownloaderCore
             var canvas = sectionImages[^1].Canvas;
 
             var avatarY = (float)((renderOptions.SectionHeight - avatarImage.Height) / 2.0);
-            canvas.DrawBitmap(avatarImage, drawPos.X, avatarY);
+            canvas.DrawImage(avatarImage, drawPos.X, avatarY);
             drawPos.X += avatarImage.Width + renderOptions.WordSpacing;
         }
 
         private void DrawBadges(Comment comment, List<SectionImage> sectionImages, ref Point drawPos)
         {
             var canvas = sectionImages[^1].Canvas;
-            List<(SKBitmap, ChatBadgeType)> badgeImages = ParseCommentBadges(comment);
+            var badgeImages = ParseCommentBadges(comment);
             foreach (var (badgeImage, badgeType) in badgeImages)
             {
                 //Don't render filtered out badges
@@ -1790,14 +1791,14 @@ namespace TwitchDownloaderCore
                     continue;
 
                 float badgeY = (float)((renderOptions.SectionHeight - badgeImage.Height) / 2.0);
-                canvas.DrawBitmap(badgeImage, drawPos.X, badgeY);
+                canvas.DrawImage(badgeImage, drawPos.X, badgeY);
                 drawPos.X += badgeImage.Width + renderOptions.WordSpacing / 2;
             }
         }
 
-        private List<(SKBitmap badgeImage, ChatBadgeType badgeType)> ParseCommentBadges(Comment comment)
+        private List<(SKImage, ChatBadgeType)> ParseCommentBadges(Comment comment)
         {
-            List<(SKBitmap, ChatBadgeType)> returnList = new List<(SKBitmap, ChatBadgeType)>();
+            var returnList = new List<(SKImage, ChatBadgeType)>();
 
             if (comment.message.user_badges == null)
                 return returnList;
@@ -1941,7 +1942,7 @@ namespace TwitchDownloaderCore
             var emoteThirdTask = GetScaledThirdEmotes(cancellationToken);
             var cheerTask = GetScaledBits(cancellationToken);
             var emojiTask = GetScaledEmojis(cancellationToken);
-            var avatarTask = renderOptions.RenderUserAvatars ? GetScaledAvatars(cancellationToken) : Task.FromResult(new Dictionary<string, SKBitmap>());
+            var avatarTask = renderOptions.RenderUserAvatars ? GetScaledAvatars(cancellationToken) : Task.FromResult(new Dictionary<string, SKImage>());
 
             await Task.WhenAll(badgeTask, emoteTask, emoteThirdTask, cheerTask, emojiTask, avatarTask);
 
@@ -2036,32 +2037,28 @@ namespace TwitchDownloaderCore
             return cheerTask;
         }
 
-        private async Task<Dictionary<string, SKBitmap>> GetScaledEmojis(CancellationToken cancellationToken)
+        private async Task<Dictionary<string, SKImage>> GetScaledEmojis(CancellationToken cancellationToken)
         {
             var emojis = await TwitchHelper.GetEmojis(_cacheDir, renderOptions.EmojiVendor, _progress, cancellationToken);
 
             var newHeight = (int)Math.Round(36 * renderOptions.ReferenceScale * renderOptions.EmojiScale);
 
-            // We can't just enumerate the dictionary because of the version checks
-            string[] emojiKeys = emojis.Keys.ToArray();
-            foreach (var emojiKey in emojiKeys)
+            return emojis.Keys.ToDictionary(x => x, x =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                SKBitmap bitmap = emojis[emojiKey];
+                using var bitmap = emojis[x];
                 SKImageInfo oldEmojiInfo = bitmap.Info;
                 SKImageInfo imageInfo = new SKImageInfo((int)(newHeight / (double)oldEmojiInfo.Height * oldEmojiInfo.Width), newHeight);
-                SKBitmap newBitmap = new SKBitmap(imageInfo);
+                using var newBitmap = new SKBitmap(imageInfo);
                 bitmap.ScalePixels(newBitmap, SKFilterQuality.High);
-                bitmap.Dispose();
-                newBitmap.SetImmutable();
-                emojis[emojiKey] = newBitmap;
-            }
 
-            return emojis;
+                newBitmap.SetImmutable();
+                return SKImage.FromBitmap(newBitmap);
+            });
         }
 
-        private async Task<Dictionary<string, SKBitmap>> GetScaledAvatars(CancellationToken cancellationToken)
+        private async Task<Dictionary<string, SKImage>> GetScaledAvatars(CancellationToken cancellationToken)
         {
             var avatars = await TwitchHelper.GetAvatars(chatRoot.comments, DefaultAvatarUrls, _cacheDir, _progress, renderOptions.Offline, cancellationToken);
 
@@ -2071,17 +2068,15 @@ namespace TwitchDownloaderCore
             var radius = newHeight / 2;
             maskPath.AddCircle(radius, radius, radius);
 
-            var avatarKeys = avatars.Keys.ToArray();
-            foreach (var avatar in avatarKeys)
+            return avatars.Keys.ToDictionary(x => x, x =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var oldBitmap = avatars[avatar];
+                using var oldBitmap = avatars[x];
                 var oldImageInfo = oldBitmap.Info;
                 var imageInfo = new SKImageInfo((int)(newHeight / (double)oldImageInfo.Height * oldImageInfo.Width), newHeight);
-                var newBitmap = new SKBitmap(imageInfo);
+                using var newBitmap = new SKBitmap(imageInfo);
                 oldBitmap.ScalePixels(newBitmap, SKFilterQuality.High);
-                oldBitmap.Dispose();
 
                 // Clip avatar to circle
                 using (var canvas = new SKCanvas(newBitmap))
@@ -2091,10 +2086,8 @@ namespace TwitchDownloaderCore
                 }
 
                 newBitmap.SetImmutable();
-                avatars[avatar] = newBitmap;
-            }
-
-            return avatars;
+                return SKImage.FromBitmap(newBitmap);
+            });
         }
 
         private (int startTick, int totalTicks) GetVideoTicks()

--- a/TwitchDownloaderCore/Options/ChatRenderOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatRenderOptions.cs
@@ -1,6 +1,7 @@
 ﻿using SkiaSharp;
 using TwitchDownloaderCore.Chat;
 using TwitchDownloaderCore.Extensions;
+using TwitchDownloaderCore.TwitchObjects;
 
 namespace TwitchDownloaderCore.Options
 {
@@ -67,7 +68,7 @@ namespace TwitchDownloaderCore.Options
         public double EmoteSpacingScale { get; set; } = 1.0;
         public double AccentStrokeScale { get; set; } = 1.0;
         public double AccentIndentScale { get; set; } = 1.0;
-        public int ChatBadgeMask { get; set; } = 0;
+        public ChatBadgeType ChatBadgeMask { get; set; } = 0;
         public int StartOverride { get; set; } = -1;
         public int EndOverride { get; set; } = -1;
         public int SidePadding => (int)(6 * ReferenceScale * SidePaddingScale);

--- a/TwitchDownloaderCore/TwitchObjects/ChatBadge.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatBadge.cs
@@ -33,14 +33,16 @@ namespace TwitchDownloaderCore.TwitchObjects
     {
         public bool Disposed { get; private set; } = false;
         public string Name;
-        public readonly Dictionary<string, SKBitmap> Versions;
+        private readonly Dictionary<string, SKBitmap> _versionBitmaps;
+        private Dictionary<string, SKImage> _versions;
+        public Dictionary<string, SKImage> Versions => _versions ??= _versionBitmaps.ToDictionary(x => x.Key, x => SKImage.FromBitmap(x.Value));
         public readonly Dictionary<string, ChatBadgeData> VersionsData;
         public readonly ChatBadgeType Type;
 
         public ChatBadge(string name, Dictionary<string, ChatBadgeData> versions)
         {
             Name = name;
-            Versions = new Dictionary<string, SKBitmap>();
+            _versionBitmaps = new Dictionary<string, SKBitmap>();
             VersionsData = versions;
 
             foreach (var (versionName, versionData) in versions)
@@ -63,7 +65,7 @@ namespace TwitchDownloaderCore.TwitchObjects
                 }
 
                 badgeImage.SetImmutable();
-                Versions.Add(versionName, badgeImage);
+                _versionBitmaps.Add(versionName, badgeImage);
             }
 
             Type = name switch
@@ -82,7 +84,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         /// <inheritdoc cref="TwitchEmote.SnapResize(int,int,int)"/>
         public void SnapResize(int height, int upSnapThreshold, int downSnapThreshold)
         {
-            foreach (var (versionName, bitmap) in Versions)
+            foreach (var (versionName, bitmap) in _versionBitmaps)
             {
                 var bitmapInfo = bitmap.Info;
 
@@ -93,8 +95,14 @@ namespace TwitchDownloaderCore.TwitchObjects
                 bitmap.ScalePixels(newBitmap, SKFilterQuality.High);
                 bitmap.Dispose();
                 newBitmap.SetImmutable();
-                Versions[versionName] = newBitmap;
+                _versionBitmaps[versionName] = newBitmap;
             }
+
+            foreach (var (_, image) in _versions ?? [])
+            {
+                image?.Dispose();
+            }
+            _versions = null;
         }
 
         public void Scale(double newScale) => SnapScale(newScale, 0, 0);
@@ -106,7 +114,7 @@ namespace TwitchDownloaderCore.TwitchObjects
                 return;
             }
 
-            foreach (var (versionName, bitmap) in Versions)
+            foreach (var (versionName, bitmap) in _versionBitmaps)
             {
                 var bitmapInfo = bitmap.Info;
                 var height = TwitchHelper.SnapResizeHeight((int)(bitmapInfo.Height * newScale), upSnapThreshold, downSnapThreshold, bitmapInfo.Height);
@@ -116,11 +124,15 @@ namespace TwitchDownloaderCore.TwitchObjects
                 bitmap.ScalePixels(newBitmap, SKFilterQuality.High);
                 bitmap.Dispose();
                 newBitmap.SetImmutable();
-                Versions[versionName] = newBitmap;
+                _versionBitmaps[versionName] = newBitmap;
             }
-        }
 
-#region ImplementIDisposable
+            foreach (var (_, image) in _versions ?? [])
+            {
+                image?.Dispose();
+            }
+            _versions = null;
+        }
 
         public void Dispose()
         {
@@ -138,7 +150,12 @@ namespace TwitchDownloaderCore.TwitchObjects
 
                 if (isDisposing)
                 {
-                    foreach (var (_, bitmap) in Versions)
+                    foreach (var (_, image) in _versions ?? [])
+                    {
+                        image?.Dispose();
+                    }
+                    
+                    foreach (var (_, bitmap) in _versionBitmaps)
                     {
                         bitmap?.Dispose();
                     }
@@ -154,7 +171,5 @@ namespace TwitchDownloaderCore.TwitchObjects
                 Disposed = true;
             }
         }
-
-#endregion
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/CheerEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/CheerEmote.cs
@@ -9,7 +9,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public string prefix { get; set; }
         public List<KeyValuePair<int, TwitchEmote>> tierList { get; set; } = new List<KeyValuePair<int, TwitchEmote>>();
 
-        public KeyValuePair<int, TwitchEmote> getTier(int value)
+        public KeyValuePair<int, TwitchEmote> GetTier(int value)
         {
             KeyValuePair<int, TwitchEmote> returnPair = tierList.First();
             foreach (KeyValuePair<int, TwitchEmote> tierPair in tierList)
@@ -47,8 +47,6 @@ namespace TwitchDownloaderCore.TwitchObjects
             }
         }
 
-#region ImplementIDisposable
-
         public void Dispose()
         {
             Dispose(true);
@@ -76,7 +74,5 @@ namespace TwitchDownloaderCore.TwitchObjects
                 Disposed = true;
             }
         }
-
-#endregion
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/CommentSection.cs
+++ b/TwitchDownloaderCore/TwitchObjects/CommentSection.cs
@@ -1,10 +1,8 @@
-﻿using SkiaSharp;
-
-namespace TwitchDownloaderCore.TwitchObjects
+﻿namespace TwitchDownloaderCore.TwitchObjects
 {
     public class CommentSection
     {
-        public SKBitmap Image { get; set; }
+        public SectionImage Image { get; set; }
         public List<(Point drawPoint, TwitchEmote emote)> Emotes { get; set; }
         public int CommentIndex { get; set; }
     }

--- a/TwitchDownloaderCore/TwitchObjects/SectionImage.cs
+++ b/TwitchDownloaderCore/TwitchObjects/SectionImage.cs
@@ -15,10 +15,9 @@ namespace TwitchDownloaderCore.TwitchObjects
             Canvas = new SKCanvas(Bitmap);
         }
 
-        public void SetImmutable()
+        public void Flush()
         {
             Canvas.Flush();
-            Bitmap.SetImmutable();
         }
 
         public void Dispose()

--- a/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
+++ b/TwitchDownloaderCore/TwitchObjects/TwitchEmote.cs
@@ -19,12 +19,7 @@ namespace TwitchDownloaderCore.TwitchObjects
         public EmoteProvider EmoteProvider { get; set; }
         private List<SKBitmap> EmoteBitmaps { get; } = [];
         private SKImage[] _emoteFrames;
-        public SKImage[] EmoteFrames
-        {
-            get { return _emoteFrames ??= EmoteBitmaps.Select(SKImage.FromBitmap).ToArray(); }
-            private set => _emoteFrames = value;
-        }
-
+        public SKImage[] EmoteFrames => _emoteFrames ??= EmoteBitmaps.Select(SKImage.FromBitmap).ToArray();
         public List<int> EmoteFrameDurations { get; private set; } = [];
         public int TotalDuration { get; set; }
         public string Name { get; }


### PR DESCRIPTION
~80% of time is spent on writing to FFmpeg. Further optimization probably means having a dedicated render thread & FFmpeg thread.

Also adding a toggle for `DriveHelper.WaitForDrive` to WPF. (~10%)

And swapping to Avalonia because ~2% is spent on `SetPercent()`.