### PR TITLE
[ChatRenderer.cs] Fix emote cache to use Id instead of Name

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -1917,7 +1917,7 @@ namespace TwitchDownloaderCore
             GC.WaitForPendingFinalizers();
 
             _badgeCache.AddRange(badgeTask.Result, x => x.Name, x => x);
-            _emoteCache.AddRange(emoteTask.Result, x => x.Name, x => x);
+            _emoteCache.AddRange(emoteTask.Result, x => x.Id, x => x);
             _emoteThirdCache.AddRange(emoteThirdTask.Result, x => x.Name, x => x);
             _cheermoteCache.AddRange(cheerTask.Result, x => x.prefix, x => x);
             _emojiCache.AddRange(emojiTask.Result);


### PR DESCRIPTION
Crashes specifically with key == null.
Eembedded first-party Twitch emotes are saved without assigning their name. They retain their id, image data, width and height.

```
TwitchDownloaderCLI 1.56.5 Copyright (c) lay295 and contributors
[STATUS] - Fetching Images [1/2]
Unhandled exception. System.AggregateException: One or more errors occurred. (Value cannot be null. (Parameter 'key'))
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at TwitchDownloaderCore.Extensions.DictionaryExtensions.AddRange[TKey,TValue,T](IDictionary`2 dictionary, IEnumerable`1 items, Func`2 keySelector, Func`2 valueSelector)
   at TwitchDownloaderCore.ChatRenderer.FetchScaledImages(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatRenderer.RenderAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, FileInfo maskFileInfo, FileStream maskFs, CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatRenderer.RenderVideoAsync(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatRenderer.RenderVideoAsync(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatRenderer.RenderVideoAsync(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatRenderer.RenderVideoAsync(CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at TwitchDownloaderCLI.Modes.RenderChat.Render(ChatRenderArgs inputOptions)
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at TwitchDownloaderCLI.Program.Main(String[] args)
```