### PR TITLE
New m3u8 API + support vertical VODs

### DIFF
--- a/TwitchDownloaderCLI/Modes/InfoHandler.cs
+++ b/TwitchDownloaderCLI/Modes/InfoHandler.cs
@@ -344,10 +344,19 @@ namespace TwitchDownloaderCLI.Modes
 
             var streams = clipQualities.Qualities
                 .Select(x =>
-                    new M3U8.Stream(
-                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Framerate, x.Item.quality, x.Item.quality, "source"),
+                {
+                    string[] ivsGroups = x.Orientation switch
+                    {
+                        VideoOrientation.Landscape => ["landscape"],
+                        VideoOrientation.Portrait => ["portrait"],
+                        _ => []
+                    };
+
+                    return new M3U8.Stream(
+                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Framerate, x.Item.quality, x.Item.quality, ivsGroups, "source"),
                         $"{x.Item.sourceURL}?sig={clip.playbackAccessToken.signature}&token={HttpUtility.UrlEncode(clip.playbackAccessToken.value)}"
-                    ))
+                    );
+                })
                 .ToArray();
 
             var m3u8 = new M3U8(metadata, streams);

--- a/TwitchDownloaderCLI/Modes/InfoHandler.cs
+++ b/TwitchDownloaderCLI/Modes/InfoHandler.cs
@@ -334,11 +334,11 @@ namespace TwitchDownloaderCLI.Modes
 
             var metadata = new M3U8.Metadata
             {
-                Version = default,
+                Version = null,
                 MediaSequence = 0,
                 StreamTargetDuration = (uint)clip.durationSeconds,
                 TwitchElapsedSeconds = 0,
-                TwitchLiveSequence = default,
+                TwitchLiveSequence = null,
                 TwitchTotalSeconds = clip.durationSeconds,
                 Type = M3U8.Metadata.PlaylistType.Event,
             };
@@ -346,8 +346,7 @@ namespace TwitchDownloaderCLI.Modes
             var streams = clipQualities.Qualities
                 .Select(x =>
                     new M3U8.Stream(
-                        new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, x.Item.quality, x.Name, true, true),
-                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Item.quality, x.Framerate),
+                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Framerate, x.Item.quality, x.Item.quality, "source"),
                         $"{x.Item.sourceURL}?sig={clip.playbackAccessToken.signature}&token={HttpUtility.UrlEncode(clip.playbackAccessToken.value)}"
                     ))
                 .ToArray();

--- a/TwitchDownloaderCLI/Modes/InfoHandler.cs
+++ b/TwitchDownloaderCLI/Modes/InfoHandler.cs
@@ -106,7 +106,6 @@ namespace TwitchDownloaderCLI.Modes
         private static void HandleVodTable(GqlVideoResponse videoInfo, GqlVideoChapterResponse chapters, string playlistString)
         {
             var m3u8 = M3U8.Parse(playlistString);
-            m3u8.SortStreamsByQuality();
             var qualities = VideoQualities.FromM3U8(m3u8);
 
             const string DEFAULT_STRING = "-";

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
@@ -306,6 +306,24 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         }
 
         [Theory]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"chunked\",NAME=\"1080p60\",AUTOSELECT=NO,DEFAULT=NO", M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "1080p60", false, false)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"audio_only\",NAME=\"Audio Only\",AUTOSELECT=NO,DEFAULT=NO", M3U8.Stream.ExtMediaInfo.MediaType.Video, "audio_only", "Audio Only", false, false)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "160p30", "160p", true, true)]
+        public void CorrectlyParsesTwitchM3U8MediaInfo(string mediaInfoString, M3U8.Stream.ExtMediaInfo.MediaType type, string groupId, string name, bool autoSelect, bool @default)
+        {
+            var mediaInfo = M3U8.Stream.ExtMediaInfo.Parse(mediaInfoString);
+
+            Assert.Equal(type, mediaInfo.Type);
+            Assert.Equal(groupId, mediaInfo.GroupId);
+            Assert.Equal(name, mediaInfo.Name);
+            Assert.Equal(autoSelect, mediaInfo.AutoSelect);
+            Assert.Equal(@default, mediaInfo.Default);
+        }
+
+        [Theory]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
             5898203, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, 59.995, "1080p60", "1080p60", "source")]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-VARIANT-SOURCE=\"transcode\"",
@@ -500,6 +518,23 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             Assert.Equivalent(streams[4], m3u8.Streams[4], true);
         }
         */
+
+        [Theory]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"1080p60\",NAME=\"1080p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "1080p60", "1080p60", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true)]
+        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "160p30", "160p", true, true)]
+        public void CorrectlyParsesKickM3U8MediaInfo(string mediaInfoString, M3U8.Stream.ExtMediaInfo.MediaType type, string groupId, string name, bool autoSelect, bool @default)
+        {
+            var mediaInfo = M3U8.Stream.ExtMediaInfo.Parse(mediaInfoString);
+
+            Assert.Equal(type, mediaInfo.Type);
+            Assert.Equal(groupId, mediaInfo.GroupId);
+            Assert.Equal(name, mediaInfo.Name);
+            Assert.Equal(autoSelect, mediaInfo.AutoSelect);
+            Assert.Equal(@default, mediaInfo.Default);
+        }
 
         [Theory]
         [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=9878400,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"1080p60\"", 9878400, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080)]

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
@@ -502,19 +502,18 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         */
 
         [Theory]
-        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=9878400,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"1080p60\"", 9878400, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3330599,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\"", 3330599, new[] { "avc1.4D401F", "mp4a.40.2" }, 1280, 720, "720p60")]
-        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1335600,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\"", 1335600, new[] { "avc1.4D401F", "mp4a.40.2" }, 852, 480, "480p30")]
-        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=630000,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\"", 630000, new[] { "avc1.4D401F", "mp4a.40.2" }, 640, 360, "360p30")]
-        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=230000,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\"", 230000, new[] { "avc1.4D401F", "mp4a.40.2" }, 284, 160, "160p30")]
-        public void CorrectlyParsesKickM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight, string video)
+        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=9878400,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"1080p60\"", 9878400, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080)]
+        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3330599,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\"", 3330599, new[] { "avc1.4D401F", "mp4a.40.2" }, 1280, 720)]
+        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1335600,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\"", 1335600, new[] { "avc1.4D401F", "mp4a.40.2" }, 852, 480)]
+        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=630000,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\"", 630000, new[] { "avc1.4D401F", "mp4a.40.2" }, 640, 360)]
+        [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=230000,CODECS=\"avc1.4D401F,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\"", 230000, new[] { "avc1.4D401F", "mp4a.40.2" }, 284, 160)]
+        public void CorrectlyParsesKickM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight)
         {
             var streamInfo = M3U8.Stream.ExtStreamInfo.Parse(streamInfoString);
 
             Assert.Equal(bandwidth, streamInfo.Bandwidth);
             Assert.Equal(codecs, streamInfo.Codecs);
             Assert.Equal((videoWidth, videoHeight), streamInfo.Resolution);
-            // Assert.Equal(video, streamInfo.Video);
         }
 
         [Theory]

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
@@ -245,44 +245,32 @@ namespace TwitchDownloaderCore.Tests.ModelTests
                 "#EXTM3U" +
                 "\n#EXT-X-SESSION-DATA:DATA-ID=\"com.amazon.ivs.unavailable-media\",VALUE=\"W3siTkFNRSI6IjE0NDBwNjAiLCJCQU5EV0lEVEgiOjc3MzY1NjAsIkNPREVDUyI6ImhldjEuMS4yLkwxNTAuOTAuMC4wLjAuMC4wLG1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIyNTYweDE0NDAiLCJGSUxURVJfUkVBU09OUyI6W10sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6WyJBVVRIWl9OT1RfTE9HR0VEX0lOIl0sIkdST1VQLUlEIjoiY2h1bmtlZCIsIkZSQU1FLVJBVEUiOjYwfSx7Ik5BTUUiOiJBdWRpbyBPbmx5IiwiQkFORFdJRFRIIjoyMDQzMTAsIkNPREVDUyI6Im1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIiLCJGSUxURVJfUkVBU09OUyI6WyJGUl9BVURJT19ESVNBTExPV0VEIl0sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6W10sIkdST1VQLUlEIjoiYXVkaW9fb25seSIsIkZSQU1FLVJBVEUiOjB9XQ==\"" +
                 "\n#EXT-X-TWITCH-INFO:ORIGIN=\"s3\",B=\"false\",REGION=\"NA\",USER-IP=\"255.255.255.255\",SERVING-ID=\"123abc456def789ghi012jkl345mno67\",CLUSTER=\"cloudfront_vod\",USER-COUNTRY=\"US\",MANIFEST-CLUSTER=\"cloudfront_vod\"" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"chunked\",NAME=\"1080p60\",AUTOSELECT=NO,DEFAULT=NO" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"chunked\",FRAME-RATE=59.995" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\",FRAME-RATE=59.995" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"audio_only\",NAME=\"Audio Only\",AUTOSELECT=NO,DEFAULT=NO" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",VIDEO=\"audio_only\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8" +
-                "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8";
 
             var streams = new M3U8.Stream[]
             {
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "1080p60", false, false),
-                    new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), "chunked", 59.995m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), 59.995m, "1080p60", "1080p60", "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), "720p60", 59.995m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), 59.995m, "720p60", "720p60", "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), "480p30", 29.998m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), 29.998m, "480p30", "480p", "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "audio_only", "Audio Only", false, false),
-                    new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), "audio_only", 0m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), 0m, "audio_only", "Audio Only", "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), "360p30", 29.998m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), 29.998m, "360p30", "360p", "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "160p30", "160p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), "160p30", 29.998m),
+                new(new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), 29.998m, "160p30", "160p", "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8")
             };
 
@@ -318,39 +306,29 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         }
 
         [Theory]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"chunked\",NAME=\"1080p60\",AUTOSELECT=NO,DEFAULT=NO", M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "1080p60", false, false)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"audio_only\",NAME=\"Audio Only\",AUTOSELECT=NO,DEFAULT=NO", M3U8.Stream.ExtMediaInfo.MediaType.Video, "audio_only", "Audio Only", false, false)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "160p30", "160p", true, true)]
-        public void CorrectlyParsesTwitchM3U8MediaInfo(string mediaInfoString, M3U8.Stream.ExtMediaInfo.MediaType type, string groupId, string name, bool autoSelect, bool @default)
-        {
-            var mediaInfo = M3U8.Stream.ExtMediaInfo.Parse(mediaInfoString);
-
-            Assert.Equal(type, mediaInfo.Type);
-            Assert.Equal(groupId, mediaInfo.GroupId);
-            Assert.Equal(name, mediaInfo.Name);
-            Assert.Equal(autoSelect, mediaInfo.AutoSelect);
-            Assert.Equal(@default, mediaInfo.Default);
-        }
-
-        [Theory]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"chunked\",FRAME-RATE=59.995", 5898203, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, "chunked", 59.995)]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\",FRAME-RATE=59.995", 3443956, new[] { "avc1.4D0020", "mp4a.40.2" }, 1280, 720, "720p60", 59.995)]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\",FRAME-RATE=29.998", 1454397, new[] { "avc1.4D001F", "mp4a.40.2" }, 852, 480, "480p30", 29.998)]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",VIDEO=\"audio_only\"", 220328, new[] { "mp4a.40.2" }, 0, 0, "audio_only", 0)]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\",FRAME-RATE=29.998", 708016, new[] { "avc1.4D001E", "mp4a.40.2" }, 640, 360, "360p30", 29.998)]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\",FRAME-RATE=29.998", 288409, new[] { "avc1.4D000C", "mp4a.40.2" }, 284, 160, "160p30", 29.998)]
-        public void CorrectlyParsesTwitchM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight, string video, decimal framerate)
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+            5898203, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, 59.995, "1080p60", "1080p60", "source")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-VARIANT-SOURCE=\"transcode\"",
+            3443956, new[] { "avc1.4D0020", "mp4a.40.2" }, 1280, 720, 59.995, "720p60", "720p60", "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-VARIANT-SOURCE=\"transcode\"",
+            1454397, new[] { "avc1.4D001F", "mp4a.40.2" }, 852, 480, 29.998, "480p30", "480p", "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-VARIANT-SOURCE=\"source\"",
+            220328, new[] { "mp4a.40.2" }, 0, 0, 0, "audio_only", "Audio Only", "source")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-VARIANT-SOURCE=\"transcode\"",
+            708016, new[] { "avc1.4D001E", "mp4a.40.2" }, 640, 360, 29.998, "360p30", "360p", "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-VARIANT-SOURCE=\"transcode\"",
+            288409, new[] { "avc1.4D000C", "mp4a.40.2" }, 284, 160, 29.998, "160p30", "160p", "transcode")]
+        public void CorrectlyParsesTwitchM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight, decimal framerate, string stableVariantId, string ivsName, string ivsVariantSource)
         {
             var streamInfo = M3U8.Stream.ExtStreamInfo.Parse(streamInfoString);
 
             Assert.Equal(bandwidth, streamInfo.Bandwidth);
             Assert.Equal(codecs, streamInfo.Codecs);
             Assert.Equal((videoWidth, videoHeight), streamInfo.Resolution);
-            Assert.Equal(video, streamInfo.Video);
             Assert.Equal(framerate, streamInfo.Framerate);
+            Assert.Equal(stableVariantId, streamInfo.StableVariantId);
+            Assert.Equal(ivsName, streamInfo.IvsName);
+            Assert.Equal(ivsVariantSource, streamInfo.IvsVariantSource);
         }
 
         [Theory]
@@ -450,6 +428,7 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             }
         }
 
+        /* Kick M3U8 doesn't look like this anymore, nor does it use the new IVS API like Twitch. Ignore for now.
         [Theory]
         [InlineData(false, "en-US")]
         [InlineData(true, "en-US")]
@@ -520,23 +499,7 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             Assert.Equivalent(streams[3], m3u8.Streams[3], true);
             Assert.Equivalent(streams[4], m3u8.Streams[4], true);
         }
-
-        [Theory]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"1080p60\",NAME=\"1080p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "1080p60", "1080p60", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true)]
-        [InlineData("#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES", M3U8.Stream.ExtMediaInfo.MediaType.Video, "160p30", "160p", true, true)]
-        public void CorrectlyParsesKickM3U8MediaInfo(string mediaInfoString, M3U8.Stream.ExtMediaInfo.MediaType type, string groupId, string name, bool autoSelect, bool @default)
-        {
-            var mediaInfo = M3U8.Stream.ExtMediaInfo.Parse(mediaInfoString);
-
-            Assert.Equal(type, mediaInfo.Type);
-            Assert.Equal(groupId, mediaInfo.GroupId);
-            Assert.Equal(name, mediaInfo.Name);
-            Assert.Equal(autoSelect, mediaInfo.AutoSelect);
-            Assert.Equal(@default, mediaInfo.Default);
-        }
+        */
 
         [Theory]
         [InlineData("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=9878400,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"1080p60\"", 9878400, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, "1080p60")]
@@ -551,7 +514,7 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             Assert.Equal(bandwidth, streamInfo.Bandwidth);
             Assert.Equal(codecs, streamInfo.Codecs);
             Assert.Equal((videoWidth, videoHeight), streamInfo.Resolution);
-            Assert.Equal(video, streamInfo.Video);
+            // Assert.Equal(video, streamInfo.Video);
         }
 
         [Theory]

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
@@ -245,32 +245,32 @@ namespace TwitchDownloaderCore.Tests.ModelTests
                 "#EXTM3U" +
                 "\n#EXT-X-SESSION-DATA:DATA-ID=\"com.amazon.ivs.unavailable-media\",VALUE=\"W3siTkFNRSI6IjE0NDBwNjAiLCJCQU5EV0lEVEgiOjc3MzY1NjAsIkNPREVDUyI6ImhldjEuMS4yLkwxNTAuOTAuMC4wLjAuMC4wLG1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIyNTYweDE0NDAiLCJGSUxURVJfUkVBU09OUyI6W10sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6WyJBVVRIWl9OT1RfTE9HR0VEX0lOIl0sIkdST1VQLUlEIjoiY2h1bmtlZCIsIkZSQU1FLVJBVEUiOjYwfSx7Ik5BTUUiOiJBdWRpbyBPbmx5IiwiQkFORFdJRFRIIjoyMDQzMTAsIkNPREVDUyI6Im1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIiLCJGSUxURVJfUkVBU09OUyI6WyJGUl9BVURJT19ESVNBTExPV0VEIl0sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6W10sIkdST1VQLUlEIjoiYXVkaW9fb25seSIsIkZSQU1FLVJBVEUiOjB9XQ==\"" +
                 "\n#EXT-X-TWITCH-INFO:ORIGIN=\"s3\",B=\"false\",REGION=\"NA\",USER-IP=\"255.255.255.255\",SERVING-ID=\"123abc456def789ghi012jkl345mno67\",CLUSTER=\"cloudfront_vod\",USER-COUNTRY=\"US\",MANIFEST-CLUSTER=\"cloudfront_vod\"" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-VARIANT-SOURCE=\"transcode\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-VARIANT-SOURCE=\"transcode\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-VARIANT-SOURCE=\"source\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-GROUPS=\"landscape,portrait\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-VARIANT-SOURCE=\"transcode\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-VARIANT-SOURCE=\"transcode\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8";
 
             var streams = new M3U8.Stream[]
             {
-                new(new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), 59.995m, "1080p60", "1080p60", "source"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), 59.995m, "1080p60", "1080p60", ["landscape"], "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), 59.995m, "720p60", "720p60", "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), 59.995m, "720p60", "720p60", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), 29.998m, "480p30", "480p", "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), 29.998m, "480p30", "480p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), 0m, "audio_only", "Audio Only", "source"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), 0m, "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), 29.998m, "360p30", "360p", "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), 29.998m, "360p30", "360p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), 29.998m, "160p30", "160p", "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), 29.998m, "160p30", "160p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8")
             };
 
@@ -297,12 +297,10 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             );
 
             Assert.Equal(streams.Length, m3u8.Streams.Length);
-            Assert.Equivalent(streams[0], m3u8.Streams[0], true);
-            Assert.Equivalent(streams[1], m3u8.Streams[1], true);
-            Assert.Equivalent(streams[2], m3u8.Streams[2], true);
-            Assert.Equivalent(streams[3], m3u8.Streams[3], true);
-            Assert.Equivalent(streams[4], m3u8.Streams[4], true);
-            Assert.Equivalent(streams[5], m3u8.Streams[5], true);
+            for (var i = 0; i < streams.Length; i++)
+            {
+                Assert.Equivalent(streams[i], m3u8.Streams[i], true);
+            }
         }
 
         [Theory]
@@ -324,19 +322,19 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         }
 
         [Theory]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
-            5898203, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, 59.995, "1080p60", "1080p60", "source")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-VARIANT-SOURCE=\"transcode\"",
-            3443956, new[] { "avc1.4D0020", "mp4a.40.2" }, 1280, 720, 59.995, "720p60", "720p60", "transcode")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-VARIANT-SOURCE=\"transcode\"",
-            1454397, new[] { "avc1.4D001F", "mp4a.40.2" }, 852, 480, 29.998, "480p30", "480p", "transcode")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-VARIANT-SOURCE=\"source\"",
-            220328, new[] { "mp4a.40.2" }, 0, 0, 0, "audio_only", "Audio Only", "source")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-VARIANT-SOURCE=\"transcode\"",
-            708016, new[] { "avc1.4D001E", "mp4a.40.2" }, 640, 360, 29.998, "360p30", "360p", "transcode")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-VARIANT-SOURCE=\"transcode\"",
-            288409, new[] { "avc1.4D000C", "mp4a.40.2" }, 284, 160, 29.998, "160p30", "160p", "transcode")]
-        public void CorrectlyParsesTwitchM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight, decimal framerate, string stableVariantId, string ivsName, string ivsVariantSource)
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
+            5898203, new[] { "avc1.64002A", "mp4a.40.2" }, 1920, 1080, 59.995, "1080p60", "1080p60", new[] { "landscape" }, "source")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"",
+            3443956, new[] { "avc1.4D0020", "mp4a.40.2" }, 1280, 720, 59.995, "720p60", "720p60", new[] { "landscape" }, "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"",
+            1454397, new[] { "avc1.4D001F", "mp4a.40.2" }, 852, 480, 29.998, "480p30", "480p", new[] { "landscape" }, "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-GROUPS=\"landscape,portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            220328, new[] { "mp4a.40.2" }, 0, 0, 0, "audio_only", "Audio Only", new[] { "landscape", "portrait" }, "source")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"",
+            708016, new[] { "avc1.4D001E", "mp4a.40.2" }, 640, 360, 29.998, "360p30", "360p", new[] { "landscape" }, "transcode")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"",
+            288409, new[] { "avc1.4D000C", "mp4a.40.2" }, 284, 160, 29.998, "160p30", "160p", new[] { "landscape" }, "transcode")]
+        public void CorrectlyParsesTwitchM3U8StreamInfo(string streamInfoString, int bandwidth, string[] codecs, uint videoWidth, uint videoHeight, decimal framerate, string stableVariantId, string ivsName, string[] ivsGroups, string ivsVariantSource)
         {
             var streamInfo = M3U8.Stream.ExtStreamInfo.Parse(streamInfoString);
 
@@ -511,11 +509,10 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             CultureInfo.CurrentCulture = oldCulture;
 
             Assert.Equal(streams.Length, m3u8.Streams.Length);
-            Assert.Equivalent(streams[0], m3u8.Streams[0], true);
-            Assert.Equivalent(streams[1], m3u8.Streams[1], true);
-            Assert.Equivalent(streams[2], m3u8.Streams[2], true);
-            Assert.Equivalent(streams[3], m3u8.Streams[3], true);
-            Assert.Equivalent(streams[4], m3u8.Streams[4], true);
+            for (var i = 0; i < streams.Length; i++)
+            {
+                Assert.Equivalent(streams[i], m3u8.Streams[i], true);
+            }
         }
         */
 
@@ -605,22 +602,22 @@ namespace TwitchDownloaderCore.Tests.ModelTests
                 "\n#EXT-X-SESSION-DATA:DATA-ID=\"com.amazon.ivs.unavailable-media\",VALUE=\"W3siTkFNRSI6IjE0NDBwNjAiLCJCQU5EV0lEVEgiOjc3MzY1NjAsIkNPREVDUyI6ImhldjEuMS4yLkwxNTAuOTAuMC4wLjAuMC4wLG1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIyNTYweDE0NDAiLCJGSUxURVJfUkVBU09OUyI6W10sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6WyJBVVRIWl9OT1RfTE9HR0VEX0lOIl0sIkdST1VQLUlEIjoiY2h1bmtlZCIsIkZSQU1FLVJBVEUiOjYwfSx7Ik5BTUUiOiJBdWRpbyBPbmx5IiwiQkFORFdJRFRIIjoyMDQzMTAsIkNPREVDUyI6Im1wNGEuNDAuMiIsIlJFU09MVVRJT04iOiIiLCJGSUxURVJfUkVBU09OUyI6WyJGUl9BVURJT19ESVNBTExPV0VEIl0sIkFVVEhPUklaQVRJT05fUkVBU09OUyI6W10sIkdST1VQLUlEIjoiYXVkaW9fb25seSIsIkZSQU1FLVJBVEUiOjB9XQ==\"" +
                 "\n#EXT-X-TWITCH-INFO:ORIGIN=\"s3\",B=\"false\",REGION=\"NA\",USER-IP=\"255.255.255.255\",SERVING-ID=\"123abc456def789ghi012jkl345mno67\",CLUSTER=\"cloudfront_vod\",USER-COUNTRY=\"US\",MANIFEST-CLUSTER=\"cloudfront_vod\"" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"chunked\",NAME=\"1080p60\",AUTOSELECT=NO,DEFAULT=NO" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"chunked\",FRAME-RATE=59.995" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=5898203,CODECS=\"avc1.64002A,mp4a.40.2\",RESOLUTION=1920x1080,VIDEO=\"chunked\",FRAME-RATE=59.995,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"720p60\",NAME=\"720p60\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\",FRAME-RATE=59.995" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=3443956,CODECS=\"avc1.4D0020,mp4a.40.2\",RESOLUTION=1280x720,VIDEO=\"720p60\",FRAME-RATE=59.995,STABLE-VARIANT-ID=\"720p60\",IVS-NAME=\"720p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"480p30\",NAME=\"480p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=1454397,CODECS=\"avc1.4D001F,mp4a.40.2\",RESOLUTION=852x480,VIDEO=\"480p30\",FRAME-RATE=29.998,STABLE-VARIANT-ID=\"480p30\",IVS-NAME=\"480p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"audio_only\",NAME=\"Audio Only\",AUTOSELECT=NO,DEFAULT=NO" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",VIDEO=\"audio_only\"" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=220328,CODECS=\"mp4a.40.2\",VIDEO=\"audio_only\",STABLE-VARIANT-ID=\"audio_only\",IVS-NAME=\"Audio Only\",IVS-GROUPS=\"landscape,portrait\",IVS-VARIANT-SOURCE=\"source\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"360p30\",NAME=\"360p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=708016,CODECS=\"avc1.4D001E,mp4a.40.2\",RESOLUTION=640x360,VIDEO=\"360p30\",FRAME-RATE=29.998,STABLE-VARIANT-ID=\"360p30\",IVS-NAME=\"360p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8" +
                 "\n#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID=\"160p30\",NAME=\"160p\",AUTOSELECT=YES,DEFAULT=YES" +
-                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\",FRAME-RATE=29.998" +
+                "\n#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=284x160,VIDEO=\"160p30\",FRAME-RATE=29.998,STABLE-VARIANT-ID=\"160p30\",IVS-NAME=\"160p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"transcode\"" +
                 "\nhttps://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8" +
                 "\n#EXT-X-VERSION:4" +
                 "\n#EXT-X-MEDIA-SEQUENCE:0" +

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
@@ -163,6 +163,8 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8", "1080p")]
         // Portrait
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
@@ -147,6 +147,48 @@ namespace TwitchDownloaderCore.Tests.ModelTests
             Assert.Equal(expectedPath, selectedQuality?.Item.Path);
         }
 
+        [Theory]
+        // Landscape
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        // Portrait
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p-portrait\",IVS-NAME=\"1080p-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        public static void BuildsAccurateName_WhenMissingProperties(string streamInfo, string path, string expectedName)
+        {
+            var m3u8 = new M3U8(new M3U8.Metadata(), [
+                new M3U8.Stream(M3U8.Stream.ExtStreamInfo.Parse(streamInfo), path),
+            ]);
+
+            var qualities = VideoQualities.FromM3U8(m3u8);
+
+            Assert.Equal(expectedName, qualities.First().Name);
+        }
+
         [Fact]
         public static void ReturnsNull_WhenNoStreamsPresent()
         {

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
@@ -29,13 +29,13 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 60, "1080p60", "1080p60", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 60, "1080p60", "1080p60", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 60, "720p60", "720p60", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 60, "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 30, "720p30", "720p", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 30, "720p30", "720p", ["landscape"], "transcode"),
                     "720p30"),
             ]);
 
@@ -76,31 +76,31 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 58.644M, "1080p60", "1080p60", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 58.644M, "1080p60", "1080p60", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 28.814M, "720p30", "720p", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 28.814M, "720p30", "720p", ["landscape"], "transcode"),
                     "720p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), 30.159M, "480p30", "480p", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), 30.159M, "480p30", "480p", ["landscape"], "transcode"),
                     "480p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), 30.159M, "360p30", "360p", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), 30.159M, "360p30", "360p", ["landscape"], "transcode"),
                     "360p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), 30.159M, "144p30", "144p", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), 30.159M, "144p30", "144p", ["landscape"], "transcode"),
                     "144p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), 0, "audio_only", "Audio Only", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), 0, "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
                     "audio_only"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 58.644M, "1080p60-portrait", "1080p", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 58.644M, "1080p60-portrait", "1080p", ["portrait"], "source"),
                     "1080p60-portrait"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", ["portrait"], "source"),
                     "720p60-portrait"),
             ]);
 
@@ -128,16 +128,16 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 0, "1080p60", "1080p", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 0, "1080p60", "1080p", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 0, "1080p60-portrait", "1080p", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 0, "1080p60-portrait", "1080p", ["portrait"], "source"),
                     "1080p60-portrait"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", ["portrait"], "source"),
                     "720p60-portrait"),
             ]);
 
@@ -149,32 +149,36 @@ namespace TwitchDownloaderCore.Tests.ModelTests
 
         [Theory]
         // Landscape
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-NAME=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p\",IVS-NAME=\"1080p\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60\",IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-GROUPS=\"landscape\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60/index-dvr.m3u8", "1080p60")]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8", "1080p")]
         // Portrait
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p-portrait\",IVS-NAME=\"1080p-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p-portrait\",IVS-NAME=\"1080p-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-NAME=\"1080p60-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
-        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,IVS-NAME=\"1080p60-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
+            "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
+        [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-GROUPS=\"portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]
         [InlineData("#EXT-X-STREAM-INF:BANDWIDTH=288409,CODECS=\"avc1.4D000C,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=60.000,STABLE-VARIANT-ID=\"1080p60-portrait\",IVS-VARIANT-SOURCE=\"source\"",
             "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/1080p60-portrait/index-dvr.m3u8", "1080p60-Portrait")]

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
@@ -29,16 +29,13 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "1080p60 (source)", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), "chunked", 60),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 60, "1080p60", "1080p60", "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), "720p60", 60),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 60, "720p60", "720p60", "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p30", "720p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), "720p30", 30),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 30, "720p30", "720p", "transcode"),
                     "720p30"),
             ]);
 
@@ -72,37 +69,39 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         [InlineData("chunked", "1080p60")]
         [InlineData("Best", "1080p60")]
         [InlineData("Worst", "144p30")]
+        [InlineData("Source Portrait", "1080p60-portrait")]
+        [InlineData("Best Portrait", "1080p60-portrait")]
+        [InlineData("Worst Portrait", "720p60-portrait")]
         public static void FindsQuality_FromOldM3U8(string? qualityString, string expectedPath)
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "Source", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), "chunked", 58.644M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 58.644M, "1080p60", "1080p60", "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), "720p60", 58.644M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p30", "720p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), "720p30", 28.814M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 28.814M, "720p30", "720p", "transcode"),
                     "720p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "480p30", "480p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), "480p30", 30.159M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), 30.159M, "480p30", "480p", "transcode"),
                     "480p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "360p30", "360p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), "360p30", 30.159M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), 30.159M, "360p30", "360p", "transcode"),
                     "360p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "144p30", "144p", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), "144p30", 30.159M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), 30.159M, "144p30", "144p", "transcode"),
                     "144p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "audio_only", "Audio Only", false, false),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), "audio_only", 0),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), 0, "audio_only", "Audio Only", "source"),
                     "audio_only"),
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 58.644M, "1080p60-portrait", "1080p", "source"),
+                    "1080p60-portrait"),
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", "source"),
+                    "720p60-portrait"),
             ]);
 
             var qualities = VideoQualities.FromM3U8(m3u8);
@@ -114,7 +113,7 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         [Theory]
         [InlineData("1080", "1080p60")]
         [InlineData("1080p", "1080p60")]
-        [InlineData("1080p60", null)]
+        [InlineData("1080p60", "1080p60")]
         [InlineData("720p60", "720p60")]
         [InlineData("", "1080p60")]
         [InlineData(null, "1080p60")]
@@ -122,17 +121,24 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         [InlineData("chunked", "1080p60")]
         [InlineData("Best", "1080p60")]
         [InlineData("Worst", "720p60")]
+        [InlineData("Source Portrait", "1080p60-portrait")]
+        [InlineData("Best Portrait", "1080p60-portrait")]
+        [InlineData("Worst Portrait", "720p60-portrait")]
         public static void FindsQuality_FromM3U8WithoutFramerate(string? qualityString, string? expectedPath)
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "chunked", "Source", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), "chunked", 0),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 0, "1080p60", "1080p", "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, "720p60", "720p60", true, true),
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), "720p60", 58.644M),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", "transcode"),
                     "720p60"),
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 0, "1080p60-portrait", "1080p", "source"),
+                    "1080p60-portrait"),
+                new M3U8.Stream(
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", "source"),
+                    "720p60-portrait"),
             ]);
 
             var qualities = VideoQualities.FromM3U8(m3u8);

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -76,7 +76,14 @@ namespace TwitchDownloaderCore.Extensions
                stream.StreamInfo.IvsName.Contains("audio", StringComparison.OrdinalIgnoreCase);
 
         public static VideoOrientation Orientation(this M3U8.Stream stream)
-            => stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase) ? VideoOrientation.Portrait : VideoOrientation.Landscape;
+        {
+            if (stream.IsAudioOnly())
+                return VideoOrientation.None;
+
+            return stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase)
+                ? VideoOrientation.Portrait
+                : VideoOrientation.Landscape;
+        }
 
         public static M3U8 WithUnavailableMedia(this M3U8 m3u8)
         {

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -25,6 +25,9 @@ namespace TwitchDownloaderCore.Extensions
         [GeneratedRegex("""\d{3,4}p\d{2,3}""")]
         private static partial Regex ResolutionFramerateRegex { get; }
 
+        [GeneratedRegex("""[\dp]-portrait/""")]
+        private static partial Regex PortraitPathRegex { get; }
+
         /// <returns>
         /// A <see cref="string"/> representing the <paramref name="stream"/>'s <see cref="M3U8.Stream.ExtStreamInfo.Resolution"/>
         /// and <see cref="M3U8.Stream.ExtStreamInfo.Framerate"/> in the format of "{resolution}p{framerate}" or <see langword="null"/>
@@ -42,12 +45,15 @@ namespace TwitchDownloaderCore.Extensions
                 return streamInfo.StableVariantId;
             }
 
-            if (streamInfo.Resolution == default)
+            if (streamInfo.Resolution == default || streamInfo.Framerate == 0)
             {
-                var urlId = stream.Path.GetNthOccurrence('/', ^2).ToString();
-                return appendSource && stream.IsSource()
-                    ? $"{urlId} (Source)"
-                    : urlId;
+                var urlId = stream.Path.GetNthOccurrence('/', ^2);
+                if (ResolutionFramerateRegex.IsMatch(urlId))
+                {
+                    return appendSource && stream.IsSource()
+                        ? $"{urlId} (Source)"
+                        : urlId.ToString();
+                }
             }
 
             var frameHeight = streamInfo.Resolution.Height;
@@ -72,7 +78,8 @@ namespace TwitchDownloaderCore.Extensions
                 stream.StreamInfo.IvsVariantSource.Contains("source", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsAudioOnly(this M3U8.Stream stream)
-            => stream.StreamInfo.StableVariantId.Contains("audio", StringComparison.OrdinalIgnoreCase) ||
+            => stream.Path.Contains("/audio_only/", StringComparison.OrdinalIgnoreCase) ||
+               stream.StreamInfo.StableVariantId.Contains("audio", StringComparison.OrdinalIgnoreCase) ||
                stream.StreamInfo.IvsName.Contains("audio", StringComparison.OrdinalIgnoreCase);
 
         public static VideoOrientation Orientation(this M3U8.Stream stream)
@@ -80,9 +87,12 @@ namespace TwitchDownloaderCore.Extensions
             if (stream.IsAudioOnly())
                 return VideoOrientation.None;
 
-            return stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase)
-                ? VideoOrientation.Portrait
-                : VideoOrientation.Landscape;
+            if (PortraitPathRegex.IsMatch(stream.Path) || stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase))
+                return VideoOrientation.Portrait;
+
+            return stream.StreamInfo.StableVariantId.Length > 0
+                ? VideoOrientation.Landscape
+                : VideoOrientation.None;
         }
 
         public static M3U8 WithUnavailableMedia(this M3U8 m3u8)

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -75,11 +75,15 @@ namespace TwitchDownloaderCore.Extensions
         }
 
         public static bool IsSource(this M3U8.Stream stream)
-            => stream.MediaInfo.Name.Contains("source", StringComparison.OrdinalIgnoreCase) ||
-               stream.MediaInfo.GroupId.Equals("chunked", StringComparison.OrdinalIgnoreCase);
+            => stream.Path.Contains("/chunked/", StringComparison.OrdinalIgnoreCase) ||
+                stream.StreamInfo.IvsVariantSource.Contains("source", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsAudioOnly(this M3U8.Stream stream)
-            => stream.MediaInfo.Name.Contains("audio", StringComparison.OrdinalIgnoreCase);
+            => stream.StreamInfo.StableVariantId.Contains("audio", StringComparison.OrdinalIgnoreCase) ||
+               stream.StreamInfo.IvsName.Contains("audio", StringComparison.OrdinalIgnoreCase);
+
+        public static VideoOrientation Orientation(this M3U8.Stream stream)
+            => stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase) ? VideoOrientation.Portrait : VideoOrientation.Landscape;
 
         public static M3U8 WithUnavailableMedia(this M3U8 m3u8)
         {

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -104,10 +104,9 @@ namespace TwitchDownloaderCore.Extensions
 
             var unavailableStreams = unavailableMedia.Select(x =>
             {
-                var mediaInfo = new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, x.StableVariantId, x.IvsName, true, true);
                 var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.StableVariantId, x.FrameRate);
                 var path = string.Format(pathFormat, x.StableVariantId);
-                return new M3U8.Stream(mediaInfo, streamInfo, path);
+                return new M3U8.Stream(streamInfo, path);
             });
 
             var allStreams = unavailableStreams

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -104,9 +104,9 @@ namespace TwitchDownloaderCore.Extensions
 
             var unavailableStreams = unavailableMedia.Select(x =>
             {
-                var mediaInfo = new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, x.GroupId, x.Name, true, true);
-                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.GroupId, x.FrameRate);
-                var path = string.Format(pathFormat, x.GroupId);
+                var mediaInfo = new M3U8.Stream.ExtMediaInfo(M3U8.Stream.ExtMediaInfo.MediaType.Video, x.StableVariantId, x.IvsName, true, true);
+                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.StableVariantId, x.FrameRate);
+                var path = string.Format(pathFormat, x.StableVariantId);
                 return new M3U8.Stream(mediaInfo, streamInfo, path);
             });
 

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -31,30 +31,23 @@ namespace TwitchDownloaderCore.Extensions
         /// </returns>
         public static string GetResolutionFramerateString(this M3U8.Stream stream, bool appendSource = true)
         {
-            var mediaInfo = stream.MediaInfo;
-            if (stream.IsAudioOnly() || ResolutionFramerateRegex.IsMatch(mediaInfo.Name))
-            {
-                return mediaInfo.Name;
-            }
-
             var streamInfo = stream.StreamInfo;
-            if (ResolutionFramerateRegex.IsMatch(streamInfo.Video))
+            if (stream.IsAudioOnly())
             {
-                var hyphenIndex = streamInfo.Video.IndexOf('-');
-                return hyphenIndex > 0 ? streamInfo.Video[..hyphenIndex] : streamInfo.Video;
+                return streamInfo.IvsName;
             }
 
-            if (ResolutionFramerateRegex.IsMatch(mediaInfo.GroupId))
+            if (ResolutionFramerateRegex.IsMatch(streamInfo.StableVariantId))
             {
-                var hyphenIndex = mediaInfo.GroupId.IndexOf('-');
-                return hyphenIndex > 0 ? mediaInfo.GroupId[..hyphenIndex] : mediaInfo.GroupId;
+                return streamInfo.StableVariantId;
             }
 
             if (streamInfo.Resolution == default)
             {
-                return stream.IsSource()
-                    ? "Source"
-                    : "";
+                var urlId = stream.Path.GetNthOccurrence('/', ^2).ToString();
+                return appendSource && stream.IsSource()
+                    ? $"{urlId} (Source)"
+                    : urlId;
             }
 
             var frameHeight = streamInfo.Resolution.Height;
@@ -108,7 +101,7 @@ namespace TwitchDownloaderCore.Extensions
 
             var unavailableStreams = unavailableMedia.Select(x =>
             {
-                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.StableVariantId, x.FrameRate);
+                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.FrameRate, x.StableVariantId, x.IvsName, x.VariantSource);
                 var path = string.Format(pathFormat, x.StableVariantId);
                 return new M3U8.Stream(streamInfo, path);
             });

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -87,7 +87,12 @@ namespace TwitchDownloaderCore.Extensions
             if (stream.IsAudioOnly())
                 return VideoOrientation.None;
 
-            if (PortraitPathRegex.IsMatch(stream.Path) || stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase))
+            if (stream.StreamInfo.IvsGroups.Contains("landscape", StringComparer.OrdinalIgnoreCase))
+                return VideoOrientation.Landscape;
+
+            if (stream.StreamInfo.IvsGroups.Contains("portrait", StringComparer.OrdinalIgnoreCase)
+                || PortraitPathRegex.IsMatch(stream.Path)
+                || stream.StreamInfo.StableVariantId.Contains("-portrait", StringComparison.OrdinalIgnoreCase))
                 return VideoOrientation.Portrait;
 
             return stream.StreamInfo.StableVariantId.Length > 0
@@ -118,7 +123,7 @@ namespace TwitchDownloaderCore.Extensions
 
             var unavailableStreams = unavailableMedia.Select(x =>
             {
-                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.FrameRate, x.StableVariantId, x.IvsName, x.VariantSource);
+                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.FrameRate, x.StableVariantId, x.IvsName, x.IvsGroups, x.VariantSource);
                 var path = string.Format(pathFormat, x.StableVariantId);
                 return new M3U8.Stream(streamInfo, path);
             });

--- a/TwitchDownloaderCore/Models/ClipVideoQualities.cs
+++ b/TwitchDownloaderCore/Models/ClipVideoQualities.cs
@@ -13,9 +13,9 @@ namespace TwitchDownloaderCore.Models
 
         public override IVideoQuality<ClipQuality> GetQuality(string qualityString)
         {
-            if (TryGetQuality(qualityString, out var quality1))
+            if (TryGetQuality(qualityString, out var foundQuality))
             {
-                return quality1;
+                return foundQuality;
             }
 
             foreach (var quality in Qualities)

--- a/TwitchDownloaderCore/Models/ClipVideoQualities.cs
+++ b/TwitchDownloaderCore/Models/ClipVideoQualities.cs
@@ -42,12 +42,6 @@ namespace TwitchDownloaderCore.Models
                 return true;
             }
 
-            if (qualityString.Contains("portrait", StringComparison.OrdinalIgnoreCase))
-            {
-                quality = BestPortraitQuality();
-                return true;
-            }
-
             if (qualityString.Contains("best", StringComparison.OrdinalIgnoreCase)
                 || qualityString.Contains("source", StringComparison.OrdinalIgnoreCase))
             {

--- a/TwitchDownloaderCore/Models/ClipVideoQuality.cs
+++ b/TwitchDownloaderCore/Models/ClipVideoQuality.cs
@@ -19,13 +19,16 @@ namespace TwitchDownloaderCore.Models
 
         public int BitRate { get; }
 
-        internal ClipVideoQuality(ClipQuality item, string name, Resolution resolution, bool isSource)
+        public VideoOrientation Orientation { get; }
+
+        internal ClipVideoQuality(ClipQuality item, string name, Resolution resolution, bool isSource, VideoOrientation orientation)
         {
             Item = item;
             Name = name;
             Resolution = resolution;
             Framerate = item.frameRate;
             IsSource = isSource;
+            Orientation = orientation;
             Path = item.sourceURL;
             BitRate = item.bitrate;
         }

--- a/TwitchDownloaderCore/Models/Enums.cs
+++ b/TwitchDownloaderCore/Models/Enums.cs
@@ -27,4 +27,10 @@
         Safe,
         Exact
     }
+
+    public enum VideoOrientation
+    {
+        Landscape,
+        Portrait
+    }
 }

--- a/TwitchDownloaderCore/Models/Enums.cs
+++ b/TwitchDownloaderCore/Models/Enums.cs
@@ -30,6 +30,7 @@
 
     public enum VideoOrientation
     {
+        None,
         Landscape,
         Portrait
     }

--- a/TwitchDownloaderCore/Models/Interfaces/IVideoQuality.cs
+++ b/TwitchDownloaderCore/Models/Interfaces/IVideoQuality.cs
@@ -16,6 +16,8 @@ namespace TwitchDownloaderCore.Models.Interfaces
 
         int BitRate { get; }
 
+        VideoOrientation Orientation { get; }
+
         string ToString() => Name;
     }
 }

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -152,11 +152,11 @@ namespace TwitchDownloaderCore.Models
             }
         }
 
-        public partial record Stream(Stream.ExtMediaInfo MediaInfo, Stream.ExtStreamInfo StreamInfo, Stream.ExtPartInfo PartInfo, DateTimeOffset ProgramDateTime, ByteRange ByteRange, string Path)
+        public partial record Stream(Stream.ExtStreamInfo StreamInfo, Stream.ExtPartInfo PartInfo, DateTimeOffset ProgramDateTime, ByteRange ByteRange, string Path)
         {
-            public Stream(ExtMediaInfo mediaInfo, ExtStreamInfo streamInfo, string path) : this(mediaInfo, streamInfo, null, default, default, path) { }
+            public Stream(ExtStreamInfo streamInfo, string path) : this(streamInfo, null, default, default, path) { }
 
-            public Stream(ExtPartInfo partInfo, DateTimeOffset programDateTime, ByteRange byteRange, string path) : this(null, null, partInfo, programDateTime, byteRange, path) { }
+            public Stream(ExtPartInfo partInfo, DateTimeOffset programDateTime, ByteRange byteRange, string path) : this(null, partInfo, programDateTime, byteRange, path) { }
 
             public bool IsPlaylist { get; } = Path.AsSpan().EndsWith(".m3u8") || Path.AsSpan().EndsWith(".m3u");
 
@@ -166,9 +166,6 @@ namespace TwitchDownloaderCore.Models
             public override string ToString()
             {
                 var sb = new StringBuilder();
-
-                if (MediaInfo != null)
-                    sb.AppendLine(MediaInfo.ToString());
 
                 if (StreamInfo != null)
                     sb.AppendLine(StreamInfo.ToString());

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -266,9 +266,9 @@ namespace TwitchDownloaderCore.Models
                     Codecs = codecs ?? [];
                     Resolution = resolution;
                     Framerate = framerate;
-                    StableVariantId = stableVariantId;
-                    IvsName = ivsName;
-                    IvsVariantSource = ivsVariantSource;
+                    StableVariantId = stableVariantId ?? "";
+                    IvsName = ivsName ?? "";
+                    IvsVariantSource = ivsVariantSource ?? "";
                 }
 
                 public int ProgramId { get; internal set; }
@@ -276,9 +276,9 @@ namespace TwitchDownloaderCore.Models
                 public IReadOnlyList<string> Codecs { get; internal set; } = [];
                 public StreamResolution Resolution { get; internal set; }
                 public decimal Framerate { get; internal set; }
-                public string StableVariantId { get; internal set; }
-                public string IvsName { get; internal set; }
-                public string IvsVariantSource { get; internal set; }
+                public string StableVariantId { get; internal set; } = "";
+                public string IvsName { get; internal set; } = "";
+                public string IvsVariantSource { get; internal set; } = "";
 
                 public override string ToString()
                 {

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -259,7 +259,7 @@ namespace TwitchDownloaderCore.Models
 
                 private ExtStreamInfo() { }
 
-                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, decimal framerate, string stableVariantId, string ivsName, string ivsVariantSource)
+                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, decimal framerate, string stableVariantId, string ivsName, string[] ivsGroups, string ivsVariantSource)
                 {
                     ProgramId = programId;
                     Bandwidth = bandwidth;
@@ -268,6 +268,7 @@ namespace TwitchDownloaderCore.Models
                     Framerate = framerate;
                     StableVariantId = stableVariantId ?? "";
                     IvsName = ivsName ?? "";
+                    IvsGroups = ivsGroups ?? [];
                     IvsVariantSource = ivsVariantSource ?? "";
                 }
 
@@ -278,6 +279,7 @@ namespace TwitchDownloaderCore.Models
                 public decimal Framerate { get; internal set; }
                 public string StableVariantId { get; internal set; } = "";
                 public string IvsName { get; internal set; } = "";
+                public IReadOnlyList<string> IvsGroups { get; internal set; } = [];
                 public string IvsVariantSource { get; internal set; } = "";
 
                 public override string ToString()
@@ -305,6 +307,9 @@ namespace TwitchDownloaderCore.Models
 
                     if (!string.IsNullOrWhiteSpace(IvsName))
                         sb.AppendKeyQuoteValue("IVS-NAME=", IvsName, keyValueSeparator);
+
+                    if (IvsGroups is { Count: > 0 })
+                        sb.AppendKeyQuoteValue("IVS-GROUPS=", string.Join(',', IvsGroups), keyValueSeparator);
 
                     if (!string.IsNullOrWhiteSpace(IvsVariantSource))
                         sb.AppendKeyQuoteValue("IVS-VARIANT-SOURCE=", IvsVariantSource, keyValueSeparator);

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -259,32 +259,36 @@ namespace TwitchDownloaderCore.Models
 
                 private ExtStreamInfo() { }
 
-                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, string video, decimal framerate)
+                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, decimal framerate, string stableVariantId, string ivsName, string ivsVariantSource)
                 {
                     ProgramId = programId;
                     Bandwidth = bandwidth;
                     Codecs = codecs ?? [];
                     Resolution = resolution;
-                    Video = video;
                     Framerate = framerate;
+                    StableVariantId = stableVariantId;
+                    IvsName = ivsName;
+                    IvsVariantSource = ivsVariantSource;
                 }
 
                 public int ProgramId { get; internal set; }
                 public int Bandwidth { get; internal set; }
                 public IReadOnlyList<string> Codecs { get; internal set; } = [];
                 public StreamResolution Resolution { get; internal set; }
-                public string Video { get; internal set; }
                 public decimal Framerate { get; internal set; }
+                public string StableVariantId { get; internal set; }
+                public string IvsName { get; internal set; }
+                public string IvsVariantSource { get; internal set; }
 
                 public override string ToString()
                 {
                     var sb = new StringBuilder(STREAM_INFO_KEY);
                     ReadOnlySpan<char> keyValueSeparator = [','];
 
-                    if (ProgramId != default)
+                    if (ProgramId != 0)
                         sb.AppendKeyValue("PROGRAM-ID=", ProgramId, keyValueSeparator);
 
-                    if (Bandwidth != default)
+                    if (Bandwidth != 0)
                         sb.AppendKeyValue("BANDWIDTH=", Bandwidth, keyValueSeparator);
 
                     if (Codecs is { Count: > 0 })
@@ -293,11 +297,17 @@ namespace TwitchDownloaderCore.Models
                     if (Resolution != default)
                         sb.AppendKeyValue("RESOLUTION=", Resolution, keyValueSeparator);
 
-                    if (!string.IsNullOrWhiteSpace(Video))
-                        sb.AppendKeyQuoteValue("VIDEO=", Video, keyValueSeparator);
-
-                    if (Framerate != default)
+                    if (Framerate != 0)
                         sb.AppendKeyValue("FRAME-RATE=", Framerate, default);
+
+                    if (!string.IsNullOrWhiteSpace(StableVariantId))
+                        sb.AppendKeyQuoteValue("STABLE-VARIANT-ID=", StableVariantId, keyValueSeparator);
+
+                    if (!string.IsNullOrWhiteSpace(IvsName))
+                        sb.AppendKeyQuoteValue("IVS-NAME=", IvsName, keyValueSeparator);
+
+                    if (!string.IsNullOrWhiteSpace(IvsVariantSource))
+                        sb.AppendKeyQuoteValue("IVS-VARIANT-SOURCE=", IvsVariantSource, keyValueSeparator);
 
                     return sb.TrimEnd(keyValueSeparator).ToString();
                 }

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -62,7 +62,7 @@ namespace TwitchDownloaderCore.Models
             private Dictionary<string, string> _sessionData;
             public IReadOnlyDictionary<string, string> SessionData
             {
-                get => _sessionData ??= new Dictionary<string, string>();
+                get => _sessionData ??= [];
                 init => _sessionData = new Dictionary<string, string>(value);
             }
 
@@ -108,14 +108,14 @@ namespace TwitchDownloaderCore.Models
                 if (Map is not null)
                     sb.AppendKeyValue(MAP_KEY, Map.ToString(), itemSeparator);
 
-                foreach (var (id, value) in _sessionData)
+                foreach (var (id, value) in SessionData)
                 {
                     sb.Append(SESSION_DATA_KEY);
                     sb.AppendKeyQuoteValue("DATA-ID=\"", id, ",");
                     sb.AppendKeyQuoteValue("VALUE=\"", value, itemSeparator);
                 }
 
-                foreach (var (key, value) in _unparsedValues)
+                foreach (var (key, value) in UnparsedValues)
                 {
                     sb.AppendKeyValue(key, value, itemSeparator);
                 }

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -486,7 +486,10 @@ namespace TwitchDownloaderCore.Models
                         var hyphenIndex = variantId.AsSpan(pIndex).IndexOf('-');
                         if (hyphenIndex == -1) hyphenIndex = variantId.Length - pIndex;
 
-                        streamInfo.Framerate = int.Parse(variantId.AsSpan(pIndex, hyphenIndex));
+                        if (int.TryParse(variantId.AsSpan(pIndex, hyphenIndex), out var framerate))
+                        {
+                            streamInfo.Framerate = framerate;
+                        }
                     }
 
                     return streamInfo;

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -131,11 +131,7 @@ namespace TwitchDownloaderCore.Models
             ref DateTimeOffset extProgramDateTime, ref ByteRange byteRange, ref Stream.ExtPartInfo extPartInfo)
         {
             const string END_LIST_KEY = "#EXT-X-ENDLIST";
-            if (text.StartsWith(Stream.ExtMediaInfo.MEDIA_INFO_KEY))
-            {
-                extMediaInfo = Stream.ExtMediaInfo.Parse(text);
-            }
-            else if (text.StartsWith(Stream.ExtStreamInfo.STREAM_INFO_KEY))
+            if (text.StartsWith(Stream.ExtStreamInfo.STREAM_INFO_KEY))
             {
                 extStreamInfo = Stream.ExtStreamInfo.Parse(text);
             }
@@ -421,7 +417,7 @@ namespace TwitchDownloaderCore.Models
                     }
                 }
 
-                [GeneratedRegex(@"p\d+$", RegexOptions.RightToLeft)]
+                [GeneratedRegex(@"p\d+(?:-\w+)?$", RegexOptions.RightToLeft)]
                 private static partial Regex FramerateRegex { get; }
 
                 public static ExtStreamInfo Parse(ReadOnlySpan<char> text)
@@ -435,8 +431,10 @@ namespace TwitchDownloaderCore.Models
                     const string KEY_BANDWIDTH = "BANDWIDTH=";
                     const string KEY_CODECS = "CODECS=\"";
                     const string KEY_RESOLUTION = "RESOLUTION=";
-                    const string KEY_VIDEO = "VIDEO=\"";
                     const string KEY_FRAMERATE = "FRAME-RATE=";
+                    const string KEY_STABLE_VARIANT_ID = "STABLE-VARIANT-ID=\"";
+                    const string KEY_IVS_NAME = "IVS-NAME=\"";
+                    const string KEY_IVS_VARIANT_SOURCE = "IVS-VARIANT-SOURCE=\"";
                     do
                     {
                         text = text.TrimStart();
@@ -458,13 +456,21 @@ namespace TwitchDownloaderCore.Models
                         {
                             streamInfo.Resolution = ParsingHelpers.ParseResolution(text, KEY_RESOLUTION);
                         }
-                        else if (text.StartsWith(KEY_VIDEO))
-                        {
-                            streamInfo.Video = ParsingHelpers.ParseStringValue(text, KEY_VIDEO);
-                        }
                         else if (text.StartsWith(KEY_FRAMERATE))
                         {
                             streamInfo.Framerate = ParsingHelpers.ParseDecimalValue(text, KEY_FRAMERATE, false);
+                        }
+                        else if (text.StartsWith(KEY_STABLE_VARIANT_ID))
+                        {
+                            streamInfo.StableVariantId = ParsingHelpers.ParseStringValue(text, KEY_STABLE_VARIANT_ID);
+                        }
+                        else if (text.StartsWith(KEY_IVS_NAME))
+                        {
+                            streamInfo.IvsName = ParsingHelpers.ParseStringValue(text, KEY_IVS_NAME);
+                        }
+                        else if (text.StartsWith(KEY_IVS_VARIANT_SOURCE))
+                        {
+                            streamInfo.IvsVariantSource = ParsingHelpers.ParseStringValue(text, KEY_IVS_VARIANT_SOURCE);
                         }
 
                         var nextIndex = text.UnEscapedIndexOf(',');
@@ -474,11 +480,15 @@ namespace TwitchDownloaderCore.Models
                         text = text[(nextIndex + 1)..];
                     } while (true);
 
-                    // Sometimes Twitch's M3U8 response lacks a Framerate value, among other things. We can just guess the framerate using the Video value.
-                    if (streamInfo.Framerate == 0 && FramerateRegex.IsMatch(streamInfo.Video))
+                    // Sometimes Twitch's M3U8 response lacks a Framerate value, among other things. We can just guess the framerate using the StableVariantId value.
+                    var variantId = streamInfo.StableVariantId;
+                    if (streamInfo.Framerate == 0 && variantId is not null && FramerateRegex.IsMatch(variantId))
                     {
-                        var index = streamInfo.Video.LastIndexOf('p');
-                        streamInfo.Framerate = int.Parse(streamInfo.Video.AsSpan(index + 1));
+                        var pIndex = variantId.LastIndexOf('p') + 1;
+                        var hyphenIndex = variantId.AsSpan(pIndex).IndexOf('-');
+                        if (hyphenIndex == -1) hyphenIndex = variantId.Length - pIndex;
+
+                        streamInfo.Framerate = int.Parse(variantId.AsSpan(pIndex, hyphenIndex));
                     }
 
                     return streamInfo;

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -17,7 +17,6 @@ namespace TwitchDownloaderCore.Models
 
             var streams = new List<Stream>();
 
-            Stream.ExtMediaInfo currentExtMediaInfo = null;
             Stream.ExtStreamInfo currentExtStreamInfo = null;
 
             Metadata.Builder metadataBuilder = new();
@@ -29,20 +28,20 @@ namespace TwitchDownloaderCore.Models
             {
                 if (string.IsNullOrWhiteSpace(line))
                 {
-                    ClearStreamMetadata(out currentExtMediaInfo, out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
+                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
                     continue;
                 }
 
                 if (line[0] != '#')
                 {
                     var path = Path.Combine(basePath, line);
-                    streams.Add(new Stream(currentExtMediaInfo, currentExtStreamInfo, currentExtPartInfo, currentExtProgramDateTime, currentByteRange, path));
-                    ClearStreamMetadata(out currentExtMediaInfo, out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
+                    streams.Add(new Stream(currentExtStreamInfo, currentExtPartInfo, currentExtProgramDateTime, currentByteRange, path));
+                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
 
                     continue;
                 }
 
-                if (!ParseM3U8Key(line, metadataBuilder, ref currentExtMediaInfo, ref currentExtStreamInfo, ref currentExtProgramDateTime, ref currentByteRange, ref currentExtPartInfo))
+                if (!ParseM3U8Key(line, metadataBuilder, ref currentExtStreamInfo, ref currentExtProgramDateTime, ref currentByteRange, ref currentExtPartInfo))
                 {
                     break;
                 }
@@ -60,7 +59,6 @@ namespace TwitchDownloaderCore.Models
 
             var streams = new List<Stream>();
 
-            Stream.ExtMediaInfo currentExtMediaInfo = null;
             Stream.ExtStreamInfo currentExtStreamInfo = null;
 
             Metadata.Builder metadataBuilder = new();
@@ -90,15 +88,15 @@ namespace TwitchDownloaderCore.Models
 
                 if (workingSlice.IsWhiteSpace())
                 {
-                    ClearStreamMetadata(out currentExtMediaInfo, out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
+                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
                     continue;
                 }
 
                 if (workingSlice[0] != '#')
                 {
                     var path = Path.Combine(basePath, workingSlice.ToString());
-                    streams.Add(new Stream(currentExtMediaInfo, currentExtStreamInfo, currentExtPartInfo, currentExtProgramDateTime, currentByteRange, path));
-                    ClearStreamMetadata(out currentExtMediaInfo, out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
+                    streams.Add(new Stream(currentExtStreamInfo, currentExtPartInfo, currentExtProgramDateTime, currentByteRange, path));
+                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
 
                     if (lineEnd == -1)
                         break;
@@ -106,7 +104,7 @@ namespace TwitchDownloaderCore.Models
                     continue;
                 }
 
-                if (!ParseM3U8Key(workingSlice, metadataBuilder, ref currentExtMediaInfo, ref currentExtStreamInfo, ref currentExtProgramDateTime, ref currentByteRange, ref currentExtPartInfo))
+                if (!ParseM3U8Key(workingSlice, metadataBuilder, ref currentExtStreamInfo, ref currentExtProgramDateTime, ref currentByteRange, ref currentExtPartInfo))
                 {
                     break;
                 }
@@ -120,17 +118,16 @@ namespace TwitchDownloaderCore.Models
             return new M3U8(metadataBuilder.ToMetadata(), streams.ToArray());
         }
 
-        private static void ClearStreamMetadata(out Stream.ExtMediaInfo currentExtMediaInfo, out Stream.ExtStreamInfo currentExtStreamInfo, out DateTimeOffset currentExtProgramDateTime,
+        private static void ClearStreamMetadata(out Stream.ExtStreamInfo currentExtStreamInfo, out DateTimeOffset currentExtProgramDateTime,
             out ByteRange currentByteRange, out Stream.ExtPartInfo currentExtPartInfo)
         {
-            currentExtMediaInfo = null;
             currentExtStreamInfo = null;
             currentExtProgramDateTime = default;
             currentByteRange = default;
             currentExtPartInfo = null;
         }
 
-        private static bool ParseM3U8Key(ReadOnlySpan<char> text, Metadata.Builder metadataBuilder, ref Stream.ExtMediaInfo extMediaInfo, ref Stream.ExtStreamInfo extStreamInfo,
+        private static bool ParseM3U8Key(ReadOnlySpan<char> text, Metadata.Builder metadataBuilder, ref Stream.ExtStreamInfo extStreamInfo,
             ref DateTimeOffset extProgramDateTime, ref ByteRange byteRange, ref Stream.ExtPartInfo extPartInfo)
         {
             const string END_LIST_KEY = "#EXT-X-ENDLIST";

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -28,7 +28,6 @@ namespace TwitchDownloaderCore.Models
             {
                 if (string.IsNullOrWhiteSpace(line))
                 {
-                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
                     continue;
                 }
 
@@ -88,7 +87,6 @@ namespace TwitchDownloaderCore.Models
 
                 if (workingSlice.IsWhiteSpace())
                 {
-                    ClearStreamMetadata(out currentExtStreamInfo, out currentExtProgramDateTime, out currentByteRange, out currentExtPartInfo);
                     continue;
                 }
 

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -432,6 +432,7 @@ namespace TwitchDownloaderCore.Models
                     const string KEY_FRAMERATE = "FRAME-RATE=";
                     const string KEY_STABLE_VARIANT_ID = "STABLE-VARIANT-ID=\"";
                     const string KEY_IVS_NAME = "IVS-NAME=\"";
+                    const string KEY_IVS_GROUPS = "IVS-GROUPS=\"";
                     const string KEY_IVS_VARIANT_SOURCE = "IVS-VARIANT-SOURCE=\"";
                     do
                     {
@@ -465,6 +466,11 @@ namespace TwitchDownloaderCore.Models
                         else if (text.StartsWith(KEY_IVS_NAME))
                         {
                             streamInfo.IvsName = ParsingHelpers.ParseStringValue(text, KEY_IVS_NAME);
+                        }
+                        else if (text.StartsWith(KEY_IVS_GROUPS))
+                        {
+                            var groupsString = ParsingHelpers.ParseStringValue(text, KEY_IVS_GROUPS);
+                            streamInfo.IvsGroups = groupsString.Split(',');
                         }
                         else if (text.StartsWith(KEY_IVS_VARIANT_SOURCE))
                         {

--- a/TwitchDownloaderCore/Models/M3U8VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/M3U8VideoQualities.cs
@@ -77,9 +77,18 @@ namespace TwitchDownloaderCore.Models
                 return null;
             }
 
-            var source = Qualities
+            IVideoQuality<M3U8.Stream> source = null;
+
+            if (Qualities.Where(x => x.Orientation is VideoOrientation.Landscape).All(x => x.Framerate > 0))
+            {
+                source = Qualities
+                    .Where(x => x.Orientation is VideoOrientation.Landscape)
+                    .MaxBy(x => x.Resolution.Pixels * x.Framerate);
+            }
+
+            source ??= Qualities
                 .Where(x => x.Orientation is VideoOrientation.Landscape)
-                .MaxBy(x => x.Resolution.Width * x.Resolution.Height * x.Framerate);
+                .MaxBy(x => x.Resolution.Pixels);
 
             source ??= Qualities
                 .Where(x => x.Orientation is VideoOrientation.Landscape)
@@ -114,13 +123,20 @@ namespace TwitchDownloaderCore.Models
                 return null;
             }
 
-            var worstQuality = Qualities
-                .Where(x => !x.Item.IsAudioOnly())
-                .Where(x => x.Orientation is VideoOrientation.Landscape)
-                .MinBy(x => x.Resolution.Width * x.Resolution.Height * x.Framerate);
+            IVideoQuality<M3U8.Stream> worstQuality = null;
+
+            if (Qualities.Where(x => x.Orientation is VideoOrientation.Landscape).All(x => x.Framerate > 0))
+            {
+                worstQuality = Qualities
+                    .Where(x => x.Orientation is VideoOrientation.Landscape)
+                    .MinBy(x => x.Resolution.Pixels * x.Framerate);
+            }
 
             worstQuality ??= Qualities
-                .Where(x => !x.Item.IsAudioOnly())
+                .Where(x => x.Orientation is VideoOrientation.Landscape)
+                .MinBy(x => x.Resolution.Pixels);
+
+            worstQuality ??= Qualities
                 .Where(x => x.Orientation is VideoOrientation.Landscape)
                 .MinBy(x => x.BitRate);
 

--- a/TwitchDownloaderCore/Models/M3U8VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/M3U8VideoQualities.cs
@@ -12,19 +12,19 @@ namespace TwitchDownloaderCore.Models
 
         public override IVideoQuality<M3U8.Stream> GetQuality(string qualityString)
         {
-            if (TryGetQuality(qualityString, out var quality1))
+            if (TryGetQuality(qualityString, out var foundQuality))
             {
-                return quality1;
+                return foundQuality;
             }
 
             var qualitySpan = qualityString.AsSpan().Trim();
-            foreach (var quality2 in Qualities)
+            foreach (var quality in Qualities)
             {
-                if (qualitySpan.Equals(quality2.Item.StreamInfo.Video, StringComparison.OrdinalIgnoreCase)
-                    || qualitySpan.Equals(quality2.Item.MediaInfo.Name, StringComparison.OrdinalIgnoreCase)
-                    || qualitySpan.Equals(quality2.Item.MediaInfo.GroupId, StringComparison.OrdinalIgnoreCase))
+                if (qualitySpan.Equals(quality.Item.StreamInfo.StableVariantId, StringComparison.OrdinalIgnoreCase)
+                    || qualitySpan.Equals(quality.Item.StreamInfo.IvsName, StringComparison.OrdinalIgnoreCase)
+                    || (quality.Path.Count('/') >= 1 && qualitySpan.Equals(quality.Path.GetNthOccurrence('/', ^2), StringComparison.OrdinalIgnoreCase)))
                 {
-                    return quality2;
+                    return quality;
                 }
             }
 
@@ -33,18 +33,29 @@ namespace TwitchDownloaderCore.Models
 
         protected override bool TryGetKeywordQuality(string qualityString, out IVideoQuality<M3U8.Stream> quality)
         {
-            if (string.IsNullOrWhiteSpace(qualityString)
-                || qualityString.Contains("best", StringComparison.OrdinalIgnoreCase)
-                || qualityString.Contains("source", StringComparison.OrdinalIgnoreCase)
-                || qualityString.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(qualityString))
             {
                 quality = BestQuality();
                 return true;
             }
 
+            if (qualityString.Contains("best", StringComparison.OrdinalIgnoreCase)
+                || qualityString.Contains("source", StringComparison.OrdinalIgnoreCase)
+                || qualityString.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+            {
+                quality = qualityString.Contains("portrait", StringComparison.OrdinalIgnoreCase)
+                    ? BestPortraitQuality()
+                    : BestQuality();
+
+                return true;
+            }
+
             if (qualityString.Contains("worst", StringComparison.OrdinalIgnoreCase))
             {
-                quality = WorstQuality();
+                quality = qualityString.Contains("portrait", StringComparison.OrdinalIgnoreCase)
+                    ? WorstPortraitQuality()
+                    : WorstQuality();
+
                 return true;
             }
 
@@ -66,11 +77,34 @@ namespace TwitchDownloaderCore.Models
                 return null;
             }
 
-            var source = Qualities.FirstOrDefault(x => x.Item.IsSource());
+            var source = Qualities
+                .Where(x => x.Orientation is VideoOrientation.Landscape)
+                .MaxBy(x => x.Resolution.Width * x.Resolution.Height * x.Framerate);
 
-            source ??= Qualities.MaxBy(x => x.Item.StreamInfo.Resolution.Width * x.Item.StreamInfo.Resolution.Height * x.Item.StreamInfo.Framerate);
+            source ??= Qualities
+                .Where(x => x.Orientation is VideoOrientation.Landscape)
+                .MaxBy(x => x.BitRate);
 
             return source;
+        }
+
+        private IVideoQuality<M3U8.Stream> BestPortraitQuality()
+        {
+            if (Qualities is null)
+            {
+                return null;
+            }
+
+            var bestQuality = Qualities
+                .WhereOnlyIf(x => x.Resolution.Width < x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
+                .Where(x => x.Orientation is VideoOrientation.Portrait)
+                .MaxBy(x => x.Resolution.Height);
+
+            bestQuality ??= Qualities
+                .Where(x => x.Orientation is VideoOrientation.Portrait)
+                .MaxBy(x => x.Resolution.Height);
+
+            return bestQuality ?? Qualities.FirstOrDefault();
         }
 
         public override IVideoQuality<M3U8.Stream> WorstQuality()
@@ -81,8 +115,33 @@ namespace TwitchDownloaderCore.Models
             }
 
             var worstQuality = Qualities
-                .Where(x => !x.Item.IsSource() && !x.Item.IsAudioOnly())
-                .MinBy(x => x.Item.StreamInfo.Resolution.Width * x.Item.StreamInfo.Resolution.Height * x.Item.StreamInfo.Framerate);
+                .Where(x => !x.Item.IsAudioOnly())
+                .Where(x => x.Orientation is VideoOrientation.Landscape)
+                .MinBy(x => x.Resolution.Width * x.Resolution.Height * x.Framerate);
+
+            worstQuality ??= Qualities
+                .Where(x => !x.Item.IsAudioOnly())
+                .Where(x => x.Orientation is VideoOrientation.Landscape)
+                .MinBy(x => x.BitRate);
+
+            return worstQuality ?? Qualities.LastOrDefault();
+        }
+
+        private IVideoQuality<M3U8.Stream> WorstPortraitQuality()
+        {
+            if (Qualities is null)
+            {
+                return null;
+            }
+
+            var worstQuality = Qualities
+                .WhereOnlyIf(x => x.Resolution.Width < x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
+                .Where(x => x.Orientation is VideoOrientation.Portrait)
+                .MinBy(x => x.Resolution.Height);
+
+            worstQuality ??= Qualities
+                .Where(x => x.Orientation is VideoOrientation.Portrait)
+                .MinBy(x => x.Resolution.Height);
 
             return worstQuality ?? Qualities.LastOrDefault();
         }

--- a/TwitchDownloaderCore/Models/M3U8VideoQuality.cs
+++ b/TwitchDownloaderCore/Models/M3U8VideoQuality.cs
@@ -19,6 +19,8 @@ namespace TwitchDownloaderCore.Models
 
         public int BitRate { get; }
 
+        public VideoOrientation Orientation { get; }
+
         internal M3U8VideoQuality(M3U8.Stream item, string name)
         {
             Item = item;
@@ -28,6 +30,7 @@ namespace TwitchDownloaderCore.Models
             IsSource = item.IsSource();
             Path = item.Path;
             BitRate = item.StreamInfo.Bandwidth;
+            Orientation = item.Orientation();
         }
 
         public override string ToString() => Name;

--- a/TwitchDownloaderCore/Models/Resolution.cs
+++ b/TwitchDownloaderCore/Models/Resolution.cs
@@ -6,6 +6,8 @@ namespace TwitchDownloaderCore.Models
 
         public bool HasWidth => Width > 0;
 
+        public uint Pixels => Width * Height;
+
         public override string ToString() => $"{Width}x{Height}";
 
         public static implicit operator Resolution((uint width, uint height) tuple) => new(tuple.width, tuple.height);

--- a/TwitchDownloaderCore/Models/VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/VideoQualities.cs
@@ -145,11 +145,12 @@ namespace TwitchDownloaderCore.Models
             {
                 var aspectRatio = asset.aspectRatio;
                 var isPortrait = IsPortrait(asset);
+                var orientation = isPortrait ? VideoOrientation.Portrait : VideoOrientation.Landscape;
 
                 var assetQualities = BuildQualityList(
                     asset.videoQualities,
                     quality => isPortrait ? $"{quality.quality}p{quality.frameRate:F0}-{PORTRAIT_SUFFIX}" : $"{quality.quality}p{quality.frameRate:F0}",
-                    (quality, name) => new ClipVideoQuality(quality, name, BuildClipResolution(quality, aspectRatio), ReferenceEquals(quality, sourceQuality))
+                    (quality, name) => new ClipVideoQuality(quality, name, BuildClipResolution(quality, aspectRatio), ReferenceEquals(quality, sourceQuality), orientation)
                 );
 
                 qualities.AddRange(assetQualities);
@@ -165,14 +166,16 @@ namespace TwitchDownloaderCore.Models
 
             return new ClipVideoQualities(sortedQualities);
 
-            static bool IsLandscape(ShareClipRenderStatusAssets asset)
+            static bool IsLandscape(ShareClipRenderStatusAsset asset)
             {
-                return asset.type == "SOURCE" || asset.portraitMetadata is null || asset.aspectRatio > 1;
+                return asset.portraitMetadata is null || asset.aspectRatio > 1 ||
+                       asset.thumbnailURL.Contains("/landscape/", StringComparison.OrdinalIgnoreCase);
             }
 
-            static bool IsPortrait(ShareClipRenderStatusAssets asset)
+            static bool IsPortrait(ShareClipRenderStatusAsset asset)
             {
-                return asset.type == "RECOMPOSED" || asset.portraitMetadata is not null || asset.aspectRatio is < 1 and not 0;
+                return asset.portraitMetadata is not null || asset.aspectRatio is < 1 and > 0 ||
+                       asset.thumbnailURL.Contains("/portrait/", StringComparison.OrdinalIgnoreCase);
             }
 
             static Resolution BuildClipResolution(ClipQuality clipQuality, decimal aspectRatio)

--- a/TwitchDownloaderCore/Models/VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/VideoQualities.cs
@@ -111,7 +111,7 @@ namespace TwitchDownloaderCore.Models
             // Build quality list
             var qualities = BuildQualityList(
                 m3u8.Streams,
-                stream => stream.GetResolutionFramerateString(false),
+                stream => stream.GetResolutionFramerateString(false).Replace("portrait", "Portrait", StringComparison.OrdinalIgnoreCase),
                 (stream, name) => new M3U8VideoQuality(stream, name)
             );
 

--- a/TwitchDownloaderCore/Models/VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/VideoQualities.cs
@@ -111,11 +111,23 @@ namespace TwitchDownloaderCore.Models
             // Build quality list
             var qualities = BuildQualityList(
                 m3u8.Streams,
-                stream => stream.GetResolutionFramerateString(false).Replace("portrait", "Portrait", StringComparison.OrdinalIgnoreCase),
+                BuildM3U8Name,
                 (stream, name) => new M3U8VideoQuality(stream, name)
             );
 
             return new M3U8VideoQualities(qualities);
+        }
+
+        private static string BuildM3U8Name(M3U8.Stream stream)
+        {
+            var name = stream.GetResolutionFramerateString(false).Replace("portrait", "Portrait", StringComparison.OrdinalIgnoreCase);
+
+            if (stream.Orientation() is VideoOrientation.Portrait && !name.Contains("portrait", StringComparison.OrdinalIgnoreCase))
+            {
+                name = $"{name}-Portrait";
+            }
+
+            return name;
         }
 
         public static IVideoQualities<ClipQuality> FromClip(ShareClipRenderStatusClip clip)

--- a/TwitchDownloaderCore/Tools/M3U8StreamQualityComparer.cs
+++ b/TwitchDownloaderCore/Tools/M3U8StreamQualityComparer.cs
@@ -15,8 +15,14 @@ namespace TwitchDownloaderCore.Tools
 
             if (y?.StreamInfo is null) return 1;
 
-            if (x.IsSource()) return -1;
-            if (y.IsSource()) return 1;
+            // Source refers to if the stream was encoded on the streamer's PC. There can be multiple source qualities now.
+            // if (x.IsSource() && !y.IsSource()) return -1;
+            // if (y.IsSource()) return 1;
+
+            var xOrientation = x.Orientation();
+            var yOrientation = y.Orientation();
+
+            if (xOrientation != yOrientation) return xOrientation is VideoOrientation.Landscape ? -1 : 1;
 
             var xResolution = x.StreamInfo.Resolution;
             var yResolution = y.StreamInfo.Resolution;

--- a/TwitchDownloaderCore/Tools/M3U8StreamQualityComparer.cs
+++ b/TwitchDownloaderCore/Tools/M3U8StreamQualityComparer.cs
@@ -22,7 +22,13 @@ namespace TwitchDownloaderCore.Tools
             var xOrientation = x.Orientation();
             var yOrientation = y.Orientation();
 
-            if (xOrientation != yOrientation) return xOrientation is VideoOrientation.Landscape ? -1 : 1;
+            if (xOrientation != yOrientation)
+            {
+                if (x.IsAudioOnly()) return 1;
+                if (y.IsAudioOnly()) return -1;
+
+                return xOrientation is VideoOrientation.Landscape ? -1 : 1;
+            }
 
             var xResolution = x.StreamInfo.Resolution;
             var yResolution = y.StreamInfo.Resolution;

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -87,7 +87,7 @@ namespace TwitchDownloaderCore
                 {
                     request = new HttpRequestMessage()
                     {
-                        RequestUri = new Uri($"https://twitch-downloader-proxy.twitcharchives.workers.dev/{videoId}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
+                        RequestUri = new Uri($"https://twitch-downloader-proxy.twitcharchives.workers.dev/v2/{videoId}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
                         Method = HttpMethod.Get
                     };
                     response = await httpClient.SendAsync(request);

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -76,7 +76,7 @@ namespace TwitchDownloaderCore
             {
                 request = new HttpRequestMessage()
                 {
-                    RequestUri = new Uri($"https://usher.ttvnw.net/vod/{videoId}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
+                    RequestUri = new Uri($"https://usher.ttvnw.net/vod/v2/{videoId}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
                     Method = HttpMethod.Get
                 };
                 response = await httpClient.SendAsync(request);

--- a/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
@@ -4,8 +4,11 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
 {
     public class UnavailableMedia
     {
-        [JsonPropertyName("NAME")]
-        public string Name { get; set; }
+        [JsonPropertyName("STABLE-VARIANT-ID")]
+        public string StableVariantId { get; set; }
+
+        [JsonPropertyName("IVS_NAME")]
+        public string IvsName { get; set; }
 
         [JsonPropertyName("BANDWIDTH")]
         public int Bandwidth { get; set; }
@@ -22,10 +25,10 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
         [JsonPropertyName("AUTHORIZATION_REASONS")]
         public string[] AuthorizationReasons { get; set; }
 
-        [JsonPropertyName("GROUP-ID")]
-        public string GroupId { get; set; }
-
         [JsonPropertyName("FRAME-RATE")]
         public decimal FrameRate { get; set; }
+
+        [JsonPropertyName("IVS-VARIANT-SOURCE")]
+        public decimal VariantSource { get; set; }
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
@@ -30,5 +30,8 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
 
         [JsonPropertyName("IVS-VARIANT-SOURCE")]
         public string VariantSource { get; set; }
+
+        [JsonPropertyName("IVS-GROUPS")]
+        public string[] IvsGroups { get; set; }
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
@@ -29,6 +29,6 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
         public decimal FrameRate { get; set; }
 
         [JsonPropertyName("IVS-VARIANT-SOURCE")]
-        public decimal VariantSource { get; set; }
+        public string VariantSource { get; set; }
     }
 }

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlShareClipRenderStatusResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlShareClipRenderStatusResponse.cs
@@ -109,7 +109,7 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public string profileImageURL { get; set; }
     }
 
-    public class ShareClipRenderStatusAssets
+    public class ShareClipRenderStatusAsset
     {
         public string id { get; set; }
         public decimal aspectRatio { get; set; }
@@ -132,7 +132,7 @@ namespace TwitchDownloaderCore.TwitchObjects.Gql
         public int viewCount { get; set; }
         public string language { get; set; }
         public bool isFeatured { get; set; }
-        public ShareClipRenderStatusAssets[] assets { get; set; }
+        public ShareClipRenderStatusAsset[] assets { get; set; }
         public ShareClipRenderStatusCurator curator { get; set; }
         public ShareClipRenderStatusGame game { get; set; }
         public ShareClipRenderStatusBroadcast broadcast { get; set; }

--- a/TwitchDownloaderWPF/PageVodDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageVodDownload.xaml.cs
@@ -118,7 +118,6 @@ namespace TwitchDownloaderWPF
                 }
 
                 var videoPlaylist = M3U8.Parse(playlistString);
-                videoPlaylist.SortStreamsByQuality();
                 var qualities = VideoQualities.FromM3U8(videoPlaylist);
 
                 //Add video qualities to combo quality

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml
@@ -38,6 +38,7 @@
                 <TextBlock x:Name="TextPreferredQuality" Text="{lex:Loc PreferredQuality}" HorizontalAlignment="Right" Margin="5,5,0,0" Foreground="{DynamicResource AppTextDisabled}" />
                 <ComboBox SelectedIndex="0" x:Name="ComboPreferredQuality" IsEnabled="False" Margin="5,0,0,0" MinWidth="90" SelectionChanged="ComboPreferredQuality_OnSelectionChanged" Background="{DynamicResource AppElementBackground}" Foreground="{DynamicResource AppText}" BorderBrush="{DynamicResource AppElementBorder}">
                     <ComboBoxItem Content="Source" />
+                    <ComboBoxItem Content="Source Portrait" />
                     <ComboBoxItem Content="1440p" />
                     <ComboBoxItem Content="1080p" />
                     <ComboBoxItem Content="720p" />
@@ -46,6 +47,7 @@
                     <ComboBoxItem Content="160p" />
                     <ComboBoxItem Content="144p" />
                     <ComboBoxItem Content="Worst" />
+                    <ComboBoxItem Content="Worst Portrait" />
                 </ComboBox>
             </StackPanel>
             <CheckBox x:Name="checkDelay" Content="{lex:Loc DelayDownload}" HorizontalAlignment="Left" Margin="25,0,0,0" VerticalAlignment="Top" BorderBrush="{DynamicResource AppElementBorder}" Foreground="{DynamicResource AppText}" IsEnabled="False" />

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -114,12 +114,6 @@ namespace TwitchDownloaderWPF
 
             textFolder.Text = Settings.Default.QueueFolder;
 
-            if (_dataList.Any(x => !x.Id.All(char.IsDigit)))
-            {
-                ComboPreferredQuality.Items.Insert(1, new ComboBoxItem { Content = "Source Portrait" });
-                ComboPreferredQuality.Items.Add(new ComboBoxItem { Content = "Worst Portrait" });
-            }
-
             if (_dataList.Any(x => x.Id.All(char.IsDigit)))
             {
                 ComboPreferredQuality.Items.Add(new ComboBoxItem { Content = "Audio Only" });


### PR DESCRIPTION
Note: Vertical VODs expire 7 days after the broadcast ends. [Source](https://help.twitch.tv/s/article/dual-format-vertical-video?language=en_US#faq-vods-clips)

Related to #1519, #1548 