### PR TITLE
Migrate to 7TV `emote-set` API endpoint

### DIFF
--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -374,15 +374,20 @@ namespace TwitchDownloaderCore
             // Channel might not be registered on 7tv
             try
             {
-                var streamerEmoteRequest = new HttpRequestMessage(HttpMethod.Get, new Uri($"https://7tv.io/v3/users/twitch/{streamerId}", UriKind.Absolute));
+                var streamerInfoRequest = new HttpRequestMessage(HttpMethod.Get, new Uri($"https://7tv.io/v3/users/twitch/{streamerId}", UriKind.Absolute));
+                using var streamerInfoResponse = await httpClient.SendAsync(streamerInfoRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                streamerInfoResponse.EnsureSuccessStatusCode();
+
+                var streamerInfoObject = await streamerInfoResponse.Content.ReadFromJsonAsync<STVChannelEmoteResponse>(cancellationToken: cancellationToken);
+                var streamerEmoteRequest = new HttpRequestMessage(HttpMethod.Get, new Uri($"https://7tv.io/v3/emote-sets/{streamerInfoObject.emote_set_id}", UriKind.Absolute));
                 using var streamerEmoteResponse = await httpClient.SendAsync(streamerEmoteRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 streamerEmoteResponse.EnsureSuccessStatusCode();
 
-                var streamerEmoteObject = await streamerEmoteResponse.Content.ReadFromJsonAsync<STVChannelEmoteResponse>(cancellationToken: cancellationToken);
+                var streamerEmoteObject = await streamerEmoteResponse.Content.ReadFromJsonAsync<STVEmoteSet>(cancellationToken: cancellationToken);
                 // Channel might not have emotes setup
-                if (streamerEmoteObject.emote_set?.emotes != null)
+                if (streamerEmoteObject?.emotes != null)
                 {
-                    stvEmotes.AddRange(streamerEmoteObject.emote_set.emotes);
+                    stvEmotes.AddRange(streamerEmoteObject.emotes);
                 }
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound) { }

--- a/TwitchDownloaderCore/TwitchObjects/Api/STVChannelEmoteResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/STVChannelEmoteResponse.cs
@@ -8,8 +8,7 @@
         public string display_name { get; set; }
         public long linked_at { get; set; }
         public int emote_capacity { get; set; }
-        public object emote_set_id { get; set; }
-        public STVEmoteSet emote_set { get; set; }
+        public string emote_set_id { get; set; }
     }
 
     public class STVEditor
@@ -41,8 +40,7 @@
         public string display_name { get; set; }
         public long linked_at { get; set; }
         public int emote_capacity { get; set; }
-        public object emote_set_id { get; set; }
-        public STVEmoteSet emote_set { get; set; }
+        public string emote_set_id { get; set; }
         public STVUser user { get; set; }
     }
 


### PR DESCRIPTION
Emote sets property on `/v3/users/{platform}/{id}` is being deprecated