### PR TITLE
New, more accurate dispersion algorithm

### DIFF
--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -210,7 +210,8 @@ namespace TwitchDownloaderCore
             var commentSpan = CollectionsMarshal.AsSpan(comments);
 
             // ChatRoot.Video.CreatedAt lacks millisecond accuracy
-            var estimatedVideoCreated = DateTime.MaxValue;
+            var minVideoCreated = DateTime.MaxValue;
+            var maxVideoCreated = DateTime.MinValue;
             foreach (var c in commentSpan)
             {
                 if (c.content_offset_seconds % 1 != 0)
@@ -220,15 +221,68 @@ namespace TwitchDownloaderCore
                 }
 
                 var newEstimate = c.created_at - TimeSpan.FromSeconds(c.content_offset_seconds);
-                if (newEstimate < estimatedVideoCreated)
-                {
-                    estimatedVideoCreated = newEstimate;
-                }
+
+                if (newEstimate < minVideoCreated) minVideoCreated = newEstimate;
+                if (newEstimate > maxVideoCreated) maxVideoCreated = newEstimate;
             }
 
-            foreach (var c in commentSpan)
+            if ((maxVideoCreated - minVideoCreated).TotalSeconds < 2)
             {
-                c.content_offset_seconds = (c.created_at - estimatedVideoCreated).TotalSeconds;
+                foreach (var c in commentSpan)
+                {
+                    var newOffset = (c.created_at - minVideoCreated).TotalSeconds;
+                    Debug.Assert(Math.Abs(newOffset - c.content_offset_seconds) < 2);
+                    c.content_offset_seconds = newOffset;
+                }
+            }
+            else
+            {
+                // Comments.CreatedAt is inaccurate. Fall back to jitter approximation
+                JitterCommentOffsets(comments);
+            }
+        }
+
+        /// <summary>
+        /// Disperse the offsets of comments on each whole second across the second. For example:
+        ///   the input a=1.0 b=2.0 c=2.0  d=2.0 e=2.0  f=3.0
+        ///     becomes a=1.0 b=2.0 c=2.25 d=2.5 e=2.75 f=3.0
+        ///
+        /// The only drawback to this method is there will never be multiple comments drawn on the same tick
+        /// like in a real chat. The overall improved chat flow is still worth it regardless. */
+        /// </summary>
+        private static void JitterCommentOffsets(List<Comment> comments)
+        {
+            var jitterRnd = new Random(comments.Count);
+
+            for (var i = 0; i < comments.Count - 1; i++)
+            {
+                if (comments[i + 1].content_offset_seconds != comments[i].content_offset_seconds
+                    || comments[i].content_offset_seconds % 1 != 0)
+                {
+                    continue;
+                }
+
+                var startIndex = i + 1;
+                while (i < comments.Count - 1 && comments[i + 1].content_offset_seconds == comments[i].content_offset_seconds)
+                {
+                    i++;
+                }
+
+                var scaleFactor = 1.0;
+                if (i < comments.Count - 1 && comments[i + 1].content_offset_seconds - comments[i].content_offset_seconds < 1)
+                {
+                    // If there happens to be 2+ comments on a whole second in a chat with decimal comment offsets
+                    // we don't want to inadvertently rearrange the comment order
+                    scaleFactor = comments[i + 1].content_offset_seconds - comments[i].content_offset_seconds;
+                }
+
+                var commentsToUpdate = i - startIndex;
+                for (var c = 1; c <= commentsToUpdate; c++) // Start at 1 so we don't offset the first comment on the second
+                {
+                    var jitter = jitterRnd.NextDouble() * 0.98 - 0.49; // Jitter the distributed comment offset between 0.51-1.49x
+                    var distributedOffset = (c + jitter) / (commentsToUpdate + 1); // Jitter must be addition to retain comment order
+                    comments[startIndex + c].content_offset_seconds += distributedOffset * scaleFactor;
+                }
             }
         }
 

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -200,23 +200,35 @@ namespace TwitchDownloaderCore
             }
         }
 
-        /* Due to Twitch changing the API to return only whole number offsets, renders have become less readable.
-         * To get around this we can disperse comment offsets according to their creation date milliseconds to
-         * help bring back the better readability of comments coming in 1-by-1 */
+        /// <summary>
+        /// Due to Twitch changing the API to return only whole number offsets, renders have become less readable.
+        /// To get around this we can re-evaluate comment offsets according to their creation date to help restore
+        /// the better readability of comments coming in 1-by-1.
+        /// </summary>
         private static void DisperseCommentOffsets(List<Comment> comments)
         {
-            // Enumerating over a span is faster than a list
             var commentSpan = CollectionsMarshal.AsSpan(comments);
+
+            // ChatRoot.Video.CreatedAt lacks millisecond accuracy
+            var estimatedVideoCreated = DateTime.MaxValue;
+            foreach (var c in commentSpan)
+            {
+                if (c.content_offset_seconds % 1 != 0)
+                {
+                    // This is an old chat with millisecond accuracy
+                    return;
+                }
+
+                var newEstimate = c.created_at - TimeSpan.FromSeconds(c.content_offset_seconds);
+                if (newEstimate < estimatedVideoCreated)
+                {
+                    estimatedVideoCreated = newEstimate;
+                }
+            }
 
             foreach (var c in commentSpan)
             {
-                if (c.content_offset_seconds % 1 == 0 && c.created_at.Millisecond != 0)
-                {
-                    const int MILLIS_PER_HALF_SECOND = 500;
-                    const double MILLIS_PER_SECOND = 1000.0;
-                    // Finding the difference between the creation dates and offsets is inconsistent. This approximation looks better more often.
-                    c.content_offset_seconds += (c.created_at.Millisecond - MILLIS_PER_HALF_SECOND) / MILLIS_PER_SECOND;
-                }
+                c.content_offset_seconds = (c.created_at - estimatedVideoCreated).TotalSeconds;
             }
         }
 

--- a/TwitchDownloaderCore/ChatRenderer.cs
+++ b/TwitchDownloaderCore/ChatRenderer.cs
@@ -226,12 +226,13 @@ namespace TwitchDownloaderCore
                 if (newEstimate > maxVideoCreated) maxVideoCreated = newEstimate;
             }
 
-            if ((maxVideoCreated - minVideoCreated).TotalSeconds < 2)
+            const double MAX_DRIFT_SECONDS = 1.5;
+            if ((maxVideoCreated - minVideoCreated).TotalSeconds < MAX_DRIFT_SECONDS)
             {
                 foreach (var c in commentSpan)
                 {
                     var newOffset = (c.created_at - minVideoCreated).TotalSeconds;
-                    Debug.Assert(Math.Abs(newOffset - c.content_offset_seconds) < 2);
+                    Debug.Assert(Math.Abs(newOffset - c.content_offset_seconds) < MAX_DRIFT_SECONDS);
                     c.content_offset_seconds = newOffset;
                 }
             }


### PR DESCRIPTION
- Estimates the actual `video.created_at` and calculates the actual `comment.comment_offset_seconds` for all comments
  - Several times, Twitch has broken the `comment.created_at` calculation. When this happens, fall back to dispersion v1 (jitter).
- Closes #1579