### PR TITLE
Fix interactive prompts hanging when stdin is redirected

### DIFF
--- a/TwitchDownloaderCLI.Tests/ToolTests/UserPromptTests.cs
+++ b/TwitchDownloaderCLI.Tests/ToolTests/UserPromptTests.cs
@@ -1,0 +1,144 @@
+using TwitchDownloaderCLI.Models;
+using TwitchDownloaderCLI.Tools;
+
+namespace TwitchDownloaderCLI.Tests.ToolTests
+{
+    public class UserPromptTests
+    {
+        [Theory]
+        [InlineData("y")]
+        [InlineData("Y")]
+        [InlineData("yes")]
+        [InlineData("YES")]
+        [InlineData(" y ")]
+        [InlineData("\tYes\t")]
+        public void ShowYesNoReturnsYesForAffirmativeInput(string userInput)
+        {
+            using var input = new StringReader(userInput + Environment.NewLine);
+
+            var result = UserPrompt.ShowYesNo("Continue?", input, null);
+
+            Assert.Equal(UserPromptResult.Yes, result);
+        }
+
+        [Theory]
+        [InlineData("n")]
+        [InlineData("N")]
+        [InlineData("no")]
+        [InlineData("NO")]
+        [InlineData(" n ")]
+        [InlineData("\tNo\t")]
+        public void ShowYesNoReturnsNoForNegativeInput(string userInput)
+        {
+            using var input = new StringReader(userInput + Environment.NewLine);
+
+            var result = UserPrompt.ShowYesNo("Continue?", input, null);
+
+            Assert.Equal(UserPromptResult.No, result);
+        }
+
+        [Fact]
+        public void ShowYesNoRepromptsAfterUnrecognizedInput()
+        {
+            using var input = new StringReader($"maybe{Environment.NewLine}y{Environment.NewLine}");
+
+            var result = UserPrompt.ShowYesNo("Continue?", input, null);
+
+            Assert.Equal(UserPromptResult.Yes, result);
+        }
+
+        [Fact]
+        public void ShowYesNoReturnsUnknownAtEndOfInput()
+        {
+            using var input = new StringReader("");
+
+            var result = UserPrompt.ShowYesNo("Continue?", input, null);
+
+            Assert.Equal(UserPromptResult.Unknown, result);
+        }
+
+        [Fact]
+        public void ShowYesNoReturnsUnknownWhenNoInputIsAvailable()
+        {
+            var result = UserPrompt.ShowYesNo("Continue?", null, null);
+
+            Assert.Equal(UserPromptResult.Unknown, result);
+        }
+
+        [Theory]
+        [InlineData("o")]
+        [InlineData("O")]
+        [InlineData("overwrite")]
+        [InlineData("OVERWRITE")]
+        [InlineData(" o ")]
+        [InlineData("\tOverwrite\t")]
+        public void ShowOverwriteRenameExitReturnsOverwriteForOverwriteInput(string userInput)
+        {
+            using var input = new StringReader(userInput + Environment.NewLine);
+
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", input);
+
+            Assert.Equal(OverwriteBehavior.Overwrite, result);
+        }
+
+        [Theory]
+        [InlineData("r")]
+        [InlineData("R")]
+        [InlineData("rename")]
+        [InlineData("RENAME")]
+        [InlineData(" r ")]
+        [InlineData("\tRename\t")]
+        public void ShowOverwriteRenameExitReturnsRenameForRenameInput(string userInput)
+        {
+            using var input = new StringReader(userInput + Environment.NewLine);
+
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", input);
+
+            Assert.Equal(OverwriteBehavior.Rename, result);
+        }
+
+        [Theory]
+        [InlineData("e")]
+        [InlineData("E")]
+        [InlineData("exit")]
+        [InlineData("EXIT")]
+        [InlineData(" e ")]
+        [InlineData("\tExit\t")]
+        public void ShowOverwriteRenameExitReturnsExitForExitInput(string userInput)
+        {
+            using var input = new StringReader(userInput + Environment.NewLine);
+
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", input);
+
+            Assert.Equal(OverwriteBehavior.Exit, result);
+        }
+
+        [Fact]
+        public void ShowOverwriteRenameExitRepromptsAfterUnrecognizedInput()
+        {
+            using var input = new StringReader($"maybe{Environment.NewLine}r{Environment.NewLine}");
+
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", input);
+
+            Assert.Equal(OverwriteBehavior.Rename, result);
+        }
+
+        [Fact]
+        public void ShowOverwriteRenameExitReturnsNullAtEndOfInput()
+        {
+            using var input = new StringReader("");
+
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", input);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ShowOverwriteRenameExitReturnsNullWhenNoInputIsAvailable()
+        {
+            var result = UserPrompt.ShowOverwriteRenameExit("The file already exists.", null);
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/TwitchDownloaderCLI/Tools/FileCollisionHandler.cs
+++ b/TwitchDownloaderCLI/Tools/FileCollisionHandler.cs
@@ -37,31 +37,23 @@ namespace TwitchDownloaderCLI.Tools
 
         private FileInfo PromptUser(FileInfo fileInfo)
         {
-            // Deliberate use of Console.WriteLine instead of logger. Do not change.
-            Console.WriteLine($"The file '{fileInfo.FullName}' already exists.");
+            var behavior = UserPrompt.ShowOverwriteRenameExit($"The file '{fileInfo.FullName}' already exists.");
 
-            while (true)
+            switch (behavior)
             {
-                Console.Write("[O] Overwrite / [R] Rename / [E] Exit: ");
-
-                var userInput = Console.ReadLine();
-                if (userInput is null)
-                {
-                    Console.WriteLine();
+                case OverwriteBehavior.Overwrite:
+                    return fileInfo;
+                case OverwriteBehavior.Rename:
+                    return FilenameService.GetNonCollidingName(fileInfo);
+                case OverwriteBehavior.Exit:
+                    Environment.Exit(1);
+                    return null;
+                case null:
                     _logger.LogError("Could not read user input. Please specify the desired collision behavior with the CLI argument and try again.");
                     Environment.Exit(1);
-                }
-
-                switch (userInput.Trim().ToLower())
-                {
-                    case "o" or "overwrite":
-                        return fileInfo;
-                    case "e" or "exit":
-                        Environment.Exit(1);
-                        break;
-                    case "r" or "rename":
-                        return FilenameService.GetNonCollidingName(fileInfo);
-                }
+                    return null;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(behavior), behavior, null);
             }
         }
     }

--- a/TwitchDownloaderCLI/Tools/UserPrompt.cs
+++ b/TwitchDownloaderCLI/Tools/UserPrompt.cs
@@ -6,30 +6,74 @@ namespace TwitchDownloaderCLI.Tools
     public static class UserPrompt
     {
         public static UserPromptResult ShowYesNo(string message, ITaskLogger logger = null)
+            => ShowYesNo(message, GetInteractiveInput(), logger);
+
+        /// <param name="input">The reader to read the response from, or <see langword="null"/> if there is no interactive user to prompt.</param>
+        public static UserPromptResult ShowYesNo(string message, TextReader input, ITaskLogger logger)
         {
+            var response = Show(message, "[Y] Yes / [N] No: ", input, static userInput => userInput switch
+            {
+                "y" or "yes" => UserPromptResult.Yes,
+                "n" or "no" => UserPromptResult.No,
+                _ => (UserPromptResult?)null
+            });
+
+            if (response is null)
+            {
+                LogError("Could not read user input.", logger);
+                return UserPromptResult.Unknown;
+            }
+
+            return response.Value;
+        }
+
+        public static OverwriteBehavior? ShowOverwriteRenameExit(string message)
+            => ShowOverwriteRenameExit(message, GetInteractiveInput());
+
+        /// <param name="input">The reader to read the response from, or <see langword="null"/> if there is no interactive user to prompt.</param>
+        /// <returns>The chosen <see cref="OverwriteBehavior"/>, or <see langword="null"/> if no response could be read.</returns>
+        public static OverwriteBehavior? ShowOverwriteRenameExit(string message, TextReader input)
+            => Show(message, "[O] Overwrite / [R] Rename / [E] Exit: ", input, static userInput => userInput switch
+            {
+                "o" or "overwrite" => OverwriteBehavior.Overwrite,
+                "r" or "rename" => OverwriteBehavior.Rename,
+                "e" or "exit" => OverwriteBehavior.Exit,
+                _ => (OverwriteBehavior?)null
+            });
+
+        /// <returns>The parsed response, or <see langword="null"/> if no response could be read.</returns>
+        private static T? Show<T>(string message, string choices, TextReader input, Func<string, T?> parseResponse) where T : struct
+        {
+            // Deliberate use of Console.WriteLine instead of logger. Do not change.
             Console.WriteLine(message);
+
+            // There is nobody to answer the prompt, and reading anyway may block until the process is killed.
+            if (input is null)
+            {
+                return null;
+            }
 
             while (true)
             {
-                Console.Write("[Y] Yes / [N] No: ");
+                Console.Write(choices);
 
-                var userInput = Console.ReadLine();
+                var userInput = input.ReadLine();
                 if (userInput is null)
                 {
                     Console.WriteLine();
-                    LogError("Could not read user input.", logger);
-                    return UserPromptResult.Unknown;
+                    return null;
                 }
 
-                switch (userInput.Trim().ToLower())
+                var response = parseResponse(userInput.Trim().ToLower());
+                if (response is not null)
                 {
-                    case "y" or "yes":
-                        return UserPromptResult.Yes;
-                    case "n" or "no":
-                        return UserPromptResult.No;
+                    return response;
                 }
             }
         }
+
+        /// <returns>The standard input reader, or <see langword="null"/> if standard input is redirected and therefore has no interactive user.</returns>
+        private static TextReader GetInteractiveInput() => Console.IsInputRedirected ? null : Console.In;
 
         private static void LogError(string message, ITaskLogger logger = null)
         {


### PR DESCRIPTION
Hey gang—I'm a new contributor, but long-time follower of this project. For more than a year now, I've been tossing around and idea with it, and this weekend i finally started... In doing so, I ran into a small issue. Wanted to submit a PR, and get eyes on it, and feedback, in case i'm thinking about it wrong. 

### The problem

`Console.ReadLine()` returns `null` only at end of stream, so a prompt written to a stdin that is open and empty blocks in a read syscall _indefinitely_. The two interactive prompts therefore behave inconsistently depending on how stdin was redirected:

| stdin | reaches EOF? | today |
|---|---|---|
| terminal | on Ctrl-D | prompts, works |
| `echo o \| …` | after the data | reads `o`, works |
| `< /dev/null`, closed pipe | immediately | clean error, exit 1 |
| **open pipe, never written** | **never** | **blocks until killed**  (this is the problem)|

That last row is what any process wrapper produces: set the child's stdin to a pipe and never write to it. With the default `--collision Prompt`, a colliding output file then hangs the CLI forever with no output, no error, and no exit.

Reproducible offline, since `tsmerge` claims the output file before doing any work:

```sh
: > list.txt; : > out.ts    # empty input list, pre-existing output -> collision
mkfifo in.fifo
sleep 30 > in.fifo &        # holds the write end open, writes nothing
TwitchDownloaderCLI tsmerge -i list.txt -o out.ts < in.fifo
# hangs after printing "[O] Overwrite / [R] Rename / [E] Exit: "
```

Rows 3 and 4 are the same class of caller. 3rd one already gets the clean, actionable error `FileCollisionHandler` was written to produce; row 4 just never reaches it.

### My suggested change

Treat a redirected stdin as having no interactive user and skip the read, so the forth example behaves like the 3rd.

The two prompt loops differed only in their choice string and how they map a response, so they're now one implementation in `UserPrompt` that takes the reader as a parameter. `FileCollisionHandler` keeps its error message and exit code unchanged. The collision message still prints before the guard, so you keep the *which file collided* information; only the unanswerable choice line is suppressed:

```
The file '/tmp/out.ts' already exists.
[ERROR] - Could not read user input. Please specify the desired collision behavior with the CLI argument and try again.
```

### Why I'm a little concerned about this change 

(Also known as: why it's scary to submit to open source projects, and where i'd really want your feedback)

Piping an answer stops working — `echo o | …`, `echo y | … cache --clear`, `echo y | … update`.

Every prompt already has a first-class equivalent: `--collision Overwrite|Rename|Exit`, `cache --force-clear`, and `update --force`, the last already documented as "bypasses the confirmation prompt". Piping is also weaker, since it only answers the *first* prompt — `chatrender --generate-mask` claims two output files, so `echo o |` answers the video collision and then hits EOF on the mask one. `--collision` isn't mentioned in any README either, so it looks incidental rather than on purpose.

### Tests

Maybe went a bit overboard here, but it adds `UserPromptTests` covering both prompts: response parsing including casing and surrounding whitespace, the re-prompt after unrecognized input, end of input, and the regression itself — an unavailable reader returns without reading. Response parsing wasn't covered before.

`Console.IsInputRedirected` can't be unit tested, so that line is covered manually. Verified across the four cases above, with the terminal cases driven over a real pty to confirm the guard doesn't misfire: `o` overwrites, `r`
writes `out (1).ts`, both exit 0.

So. Tossing it out there. More than happy to chat about it if my head is screwed on wrong. 