### PR TITLE
CLI: Exit cleanly instead of aborting on expected failures

### DIFF
--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -18,7 +18,7 @@ namespace TwitchDownloaderCLI.Modes
             var downloadOptions = GetDownloadOptions(inputOptions, collisionHandler, progress);
 
             var chatDownloader = new ChatDownloader(downloadOptions, progress);
-            chatDownloader.DownloadAsync(CancellationToken.None).Wait();
+            chatDownloader.DownloadAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
 
         private static ChatDownloadOptions GetDownloadOptions(ChatDownloadArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Modes/DownloadClip.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadClip.cs
@@ -22,7 +22,7 @@ namespace TwitchDownloaderCLI.Modes
             var downloadOptions = GetDownloadOptions(inputOptions, collisionHandler, progress);
 
             var clipDownloader = new ClipDownloader(downloadOptions, progress);
-            clipDownloader.DownloadAsync(new CancellationToken()).Wait();
+            clipDownloader.DownloadAsync(new CancellationToken()).GetAwaiter().GetResult();
         }
 
         private static ClipDownloadOptions GetDownloadOptions(ClipDownloadArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Modes/DownloadVideo.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadVideo.cs
@@ -20,7 +20,7 @@ namespace TwitchDownloaderCLI.Modes
             var downloadOptions = GetDownloadOptions(inputOptions, collisionHandler, progress);
 
             var videoDownloader = new VideoDownloader(downloadOptions, progress);
-            videoDownloader.DownloadAsync(new CancellationToken()).Wait();
+            videoDownloader.DownloadAsync(new CancellationToken()).GetAwaiter().GetResult();
         }
 
         private static VideoDownloadOptions GetDownloadOptions(VideoDownloadArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Modes/MergeTs.cs
+++ b/TwitchDownloaderCLI/Modes/MergeTs.cs
@@ -17,7 +17,7 @@ namespace TwitchDownloaderCLI.Modes
             var mergeOptions = GetMergeOptions(inputOptions, collisionHandler);
 
             var tsMerger = new TsMerger(mergeOptions, progress);
-            tsMerger.MergeAsync(new CancellationToken()).Wait();
+            tsMerger.MergeAsync(new CancellationToken()).GetAwaiter().GetResult();
         }
 
         private static TsMergeOptions GetMergeOptions(TsMergeArgs inputOptions, FileCollisionHandler collisionHandler)

--- a/TwitchDownloaderCLI/Modes/RenderChat.cs
+++ b/TwitchDownloaderCLI/Modes/RenderChat.cs
@@ -21,8 +21,8 @@ namespace TwitchDownloaderCLI.Modes
             var renderOptions = GetRenderOptions(inputOptions, collisionHandler, progress);
 
             using var chatRenderer = new ChatRenderer(renderOptions, progress);
-            chatRenderer.ParseJsonAsync().Wait();
-            chatRenderer.RenderVideoAsync(new CancellationToken()).Wait();
+            chatRenderer.ParseJsonAsync().GetAwaiter().GetResult();
+            chatRenderer.RenderVideoAsync(new CancellationToken()).GetAwaiter().GetResult();
         }
 
         private static ChatRenderOptions GetRenderOptions(ChatRenderArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Modes/UpdateChat.cs
+++ b/TwitchDownloaderCLI/Modes/UpdateChat.cs
@@ -17,8 +17,8 @@ namespace TwitchDownloaderCLI.Modes
             var updateOptions = GetUpdateOptions(inputOptions, collisionHandler, progress);
 
             var chatUpdater = new ChatUpdater(updateOptions, progress);
-            chatUpdater.ParseJsonAsync().Wait();
-            chatUpdater.UpdateAsync(new CancellationToken()).Wait();
+            chatUpdater.ParseJsonAsync().GetAwaiter().GetResult();
+            chatUpdater.UpdateAsync(new CancellationToken()).GetAwaiter().GetResult();
         }
 
         private static ChatUpdateOptions GetUpdateOptions(ChatUpdateArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -6,6 +6,7 @@ using TwitchDownloaderCLI.Models;
 using TwitchDownloaderCLI.Modes;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
+using TwitchDownloaderCore;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI
@@ -25,20 +26,32 @@ namespace TwitchDownloaderCLI
             var parserResult = parser.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, InfoArgs, FfmpegArgs, CacheArgs, UpdateArgs, TsMergeArgs>(preParsedArgs);
             parserResult.WithNotParsed(errors => WriteHelpText(errors, parserResult, parser.Settings));
 
-            CoreLicensor.EnsureFilesExist(null);
-            WriteApplicationBanner((ITwitchDownloaderArgs)parserResult.Value);
+            var downloaderArgs = (ITwitchDownloaderArgs)parserResult.Value;
 
-            parserResult
-                .WithParsed<VideoDownloadArgs>(DownloadVideo.Download)
-                .WithParsed<ClipDownloadArgs>(DownloadClip.Download)
-                .WithParsed<ChatDownloadArgs>(DownloadChat.Download)
-                .WithParsed<ChatUpdateArgs>(UpdateChat.Update)
-                .WithParsed<ChatRenderArgs>(RenderChat.Render)
-                .WithParsed<InfoArgs>(InfoHandler.PrintInfo)
-                .WithParsed<FfmpegArgs>(FfmpegHandler.ParseArgs)
-                .WithParsed<CacheArgs>(CacheHandler.ParseArgs)
-                .WithParsed<UpdateArgs>(UpdateHandler.ParseArgs)
-                .WithParsed<TsMergeArgs>(MergeTs.Merge);
+            CoreLicensor.EnsureFilesExist(null);
+            WriteApplicationBanner(downloaderArgs);
+
+            try
+            {
+                parserResult
+                    .WithParsed<VideoDownloadArgs>(DownloadVideo.Download)
+                    .WithParsed<ClipDownloadArgs>(DownloadClip.Download)
+                    .WithParsed<ChatDownloadArgs>(DownloadChat.Download)
+                    .WithParsed<ChatUpdateArgs>(UpdateChat.Update)
+                    .WithParsed<ChatRenderArgs>(RenderChat.Render)
+                    .WithParsed<InfoArgs>(InfoHandler.PrintInfo)
+                    .WithParsed<FfmpegArgs>(FfmpegHandler.ParseArgs)
+                    .WithParsed<CacheArgs>(CacheHandler.ParseArgs)
+                    .WithParsed<UpdateArgs>(UpdateHandler.ParseArgs)
+                    .WithParsed<TsMergeArgs>(MergeTs.Merge);
+            }
+            catch (TwitchDownloaderException ex)
+            {
+                // Expected failures, such as an expired VOD, are reported without a stack trace.
+                using var progress = new CliTaskProgress(downloaderArgs.LogLevel);
+                progress.LogError(ex.Message);
+                Environment.Exit(1);
+            }
         }
 
         private static void WriteHelpText(IEnumerable<Error> errors, ParserResult<object> parserResult, ParserSettings parserSettings)

--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -265,7 +265,7 @@ namespace TwitchDownloaderCore
         {
             if (string.IsNullOrWhiteSpace(downloadOptions.Id))
             {
-                throw new NullReferenceException("Null or empty video/clip ID");
+                throw new TwitchDownloaderException("Null or empty video/clip ID");
             }
 
             var outputFileInfo = TwitchHelper.ClaimFile(downloadOptions.Filename, downloadOptions.FileCollisionCallback, _progress);
@@ -372,7 +372,7 @@ namespace TwitchDownloaderCore
                 GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(long.Parse(videoId));
                 if (videoInfoResponse.data.video == null)
                 {
-                    throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
+                    throw new TwitchDownloaderException("Invalid VOD, deleted/expired VOD possibly?");
                 }
 
                 chatRoot.streamer.name = videoInfoResponse.data.video.owner?.displayName;
@@ -415,7 +415,7 @@ namespace TwitchDownloaderCore
                 var clipInfoResponse = await TwitchHelper.GetShareClipRenderStatus(videoId);
                 if (clipInfoResponse.data.clip.video == null || clipInfoResponse.data.clip.videoOffsetSeconds == null)
                 {
-                    throw new NullReferenceException("Invalid VOD for clip, deleted/expired VOD possibly?");
+                    throw new TwitchDownloaderException("Invalid VOD for clip, deleted/expired VOD possibly?");
                 }
 
                 videoId = clipInfoResponse.data.clip.video.id;

--- a/TwitchDownloaderCore/ChatUpdater.cs
+++ b/TwitchDownloaderCore/ChatUpdater.cs
@@ -399,7 +399,7 @@ namespace TwitchDownloaderCore
                     await AppendCommentSection(downloadOptions, tempFile, cancellationToken);
                 }
             }
-            catch (NullReferenceException)
+            catch (TwitchDownloaderException)
             {
                 if (!_trimTaskReportedExpiredVod)
                 {
@@ -436,7 +436,7 @@ namespace TwitchDownloaderCore
                     await AppendCommentSection(downloadOptions, tempFile, cancellationToken);
                 }
             }
-            catch (NullReferenceException)
+            catch (TwitchDownloaderException)
             {
                 if (!_trimTaskReportedExpiredVod)
                 {

--- a/TwitchDownloaderCore/ClipDownloader.cs
+++ b/TwitchDownloaderCore/ClipDownloader.cs
@@ -112,12 +112,12 @@ namespace TwitchDownloaderCore
 
             if (clip.playbackAccessToken is null)
             {
-                throw new NullReferenceException("Invalid Clip, deleted possibly?");
+                throw new TwitchDownloaderException("Invalid Clip, deleted possibly?");
             }
 
             if (clip.assets is not { Length: > 0 } || clip.assets[0].videoQualities is not { Length: > 0 })
             {
-                throw new NullReferenceException("Clip has no video qualities, deleted possibly?");
+                throw new TwitchDownloaderException("Clip has no video qualities, deleted possibly?");
             }
 
             var qualityUrl = GetDownloadUrlForQuality(clip, downloadOptions.Quality);
@@ -131,7 +131,7 @@ namespace TwitchDownloaderCore
             var qualities = VideoQualities.FromClip(clip);
             var userQuality = qualities.GetQuality(qualityString) ?? qualities.BestQuality();
 
-            return userQuality?.Item.sourceURL ?? throw new NullReferenceException($"Unknown Quality: {qualityString}");
+            return userQuality?.Item.sourceURL ?? throw new TwitchDownloaderException($"Unknown Quality: {qualityString}");
         }
 
         private static async Task DownloadFileTaskAsync(string url, FileStream fs, int throttleKib, IProgress<StreamCopyProgress> progress, CancellationToken cancellationToken)

--- a/TwitchDownloaderCore/TwitchDownloaderException.cs
+++ b/TwitchDownloaderCore/TwitchDownloaderException.cs
@@ -1,0 +1,18 @@
+namespace TwitchDownloaderCore
+{
+    /// <summary>
+    /// Represents an expected, user-facing failure such as a deleted or expired VOD, rather than a programming error.
+    /// </summary>
+    /// <remarks>
+    /// Consumers are expected to present <see cref="Exception.Message"/> to the user as-is. It should not be necessary
+    /// to display a stack trace for these failures.
+    /// </remarks>
+    public class TwitchDownloaderException : Exception
+    {
+        public TwitchDownloaderException() { }
+
+        public TwitchDownloaderException(string message) : base(message) { }
+
+        public TwitchDownloaderException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -64,7 +64,7 @@ namespace TwitchDownloaderCore
                 GqlVideoResponse videoInfoResponse = await TwitchHelper.GetVideoInfo(downloadOptions.Id);
                 if (videoInfoResponse.data.video == null)
                 {
-                    throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
+                    throw new TwitchDownloaderException("Invalid VOD, deleted/expired VOD possibly?");
                 }
 
                 GqlVideoChapterResponse videoChapterResponse = await TwitchHelper.GetOrGenerateVideoChapters(downloadOptions.Id, videoInfoResponse.data.video, _progress);
@@ -678,13 +678,13 @@ namespace TwitchDownloaderCore
 
             if (accessToken.data.videoPlaybackAccessToken is null)
             {
-                throw new NullReferenceException("Invalid VOD, deleted/expired VOD possibly?");
+                throw new TwitchDownloaderException("Invalid VOD, deleted/expired VOD possibly?");
             }
 
             var playlistString = await TwitchHelper.GetVideoPlaylist(downloadOptions.Id, accessToken.data.videoPlaybackAccessToken.value, accessToken.data.videoPlaybackAccessToken.signature);
             if (playlistString.Contains("vod_manifest_restricted") || playlistString.Contains("unauthorized_entitlements"))
             {
-                throw new NullReferenceException("Insufficient access to VOD, OAuth may be required.");
+                throw new TwitchDownloaderException("Insufficient access to VOD, OAuth may be required.");
             }
 
             var m3u8 = M3U8.Parse(playlistString);
@@ -700,7 +700,7 @@ namespace TwitchDownloaderCore
                 })
                 .ToArray();
 
-            return (allQualityPaths, userQuality?.Item ?? throw new NullReferenceException($"Unknown quality: {downloadOptions.Quality}"));
+            return (allQualityPaths, userQuality?.Item ?? throw new TwitchDownloaderException($"Unknown quality: {downloadOptions.Quality}"));
         }
 
         private void Cleanup(string downloadFolder)


### PR DESCRIPTION
## The Problem

Downloading the chat of a clip whose parent VOD has been deleted or expired terminates the process on `SIGABRT` with an ugly unhandled exception and a full stack trace. A clip's chat is reconstructed from the broadcast it was cut from, so the clip's *video* downloads fine and only chat fails.

```console
$ TwitchDownloaderCLI chatdownload --banner=false --collision Overwrite \
    --id AdorableStylishPotatoPlanking-5UAS4GFYHTkDW4xX -o chat.json
Unhandled exception. System.AggregateException: One or more errors occurred. (Invalid VOD for clip, deleted/expired VOD possibly?)
 ---> System.NullReferenceException: Invalid VOD for clip, deleted/expired VOD possibly?
   at TwitchDownloaderCore.ChatDownloader.InitChatRoot(DownloadType downloadType) in TwitchDownloaderCore/ChatDownloader.cs:line 418
   at TwitchDownloaderCore.ChatDownloader.DownloadAsyncImpl(...) in TwitchDownloaderCore/ChatDownloader.cs:line 295
   ... 10 more frames ...
   at TwitchDownloaderCLI.Program.Main(String[] args) in TwitchDownloaderCLI/Program.cs:line 31
$ echo $?
134
```

There are two separate issues here:

1. **The exception type is wrong.** An expired VOD is an expected, user-facing state, not a programming error. `NullReferenceException` should be reserved for the runtime; throwing it deliberately is what CA2201 exists to flag, and it makes the condition indistinguishable from a genuine null-deref bug in a crash report.
2. **Nothing catches it.** `Program.Main` has no try/catch, so the exception goes unhandled, .NET calls `abort()`, and no exit code is ever set. A script cannot tell _"the VOD expired"_ from a crash without parsing the stack trace.

This is the same class of failure reported in #521, whose opening example is a deleted VOD passed to `videodownload`. That case is fixed here too.

## Changes

- Adds `TwitchDownloaderCore.TwitchDownloaderException` for expected, user-facing failures.
- Throws it in place of `NullReferenceException` at all 10 deliberate sites in `TwitchDownloaderCore` (`ChatDownloader`, `ClipDownloader`, `VideoDownloader`). The messages stay unchanged.
- Catches it once in `Program.Main`, logging `ex.Message` through `CliTaskProgress` (so `--log-level` is respected) and exiting `1`,matching the existing `logger.LogError(...)` + `Environment.Exit(1)` idiom already used in `DownloadChat`, `DownloadVideo`, `DownloadClip` and `InfoHandler`.
- Switches the remaining `.Wait()` calls in `TwitchDownloaderCLI/Modes` to `.GetAwaiter().GetResult()`, so exceptions arrive unwrapped rather than inside an `AggregateException`. `InfoHandler`, `UpdateHandler` and `FfmpegHandler` already did this; this makes the folder consistent and de-noises every unhandled trace, not just this one.

### One kinda non-obvious change

`ChatUpdater`'s two trim tasks deliberately caught `NullReferenceException` to tolerate an
expired source VOD while backfilling missing comments:

```csharp
catch (NullReferenceException)
{
    ...
    _progress.LogInfo("Unable to fetch possible missing comments: source VOD is expired or embedded ID is corrupt");
}
```

These catch the throws at `ChatDownloader.cs:268` and `:375`, so they are retargeted to `TwitchDownloaderException` in the same commit. Without that, `chatupdate --beginning` against an expired VOD would regress from "log a line and carry on" to aborting the whole update:

```console
# with the catches left on NullReferenceException:
[STATUS] - Updating Chat Trim [2/3]
[ERROR] - Invalid VOD, deleted/expired VOD possibly? # exit 1, output never written
```

`TwitchHelper.cs:1458` also catches `NullReferenceException`, but that one guards a genuine null-deref during chapter deserialization rather than a deliberate throw, so it is left alone.

## Scope is minimal

Deliberately limited to `TwitchDownloaderCore`. The same pattern exists at 4 sites in `TwitchDownloaderCLI/Modes/InfoHandler.cs` and 2 in `TwitchDownloaderWPF/PageVodDownload.xaml.cs`; happy to convert those here or in a follow-up, whichever you prefer. **No WPF changes are required either way**; its pages catch bare `Exception`, so we're good there.

## Verification

Since this project has pretty pure unit tests, I didn't want to introduce a bunch of new test scaffolding to fake a network request, so here's some real before & after: 

| Command | Before | After |
| --- | --- | --- |
| `chatdownload --id AdorableStylishPotatoPlanking-5UAS4GFYHTkDW4xX` | stack trace, `SIGABRT`, exit 134 | `[ERROR] - Invalid VOD for clip, deleted/expired VOD possibly?`, exit 1 |
| `chatdownload --id PoisedTiredMageMcaT-kZoegdGzXOorUAZ2` | stack trace, `SIGABRT`, exit 134 | `[ERROR] - Invalid VOD for clip, deleted/expired VOD possibly?`, exit 1 |
| `videodownload --id 1659138963` (deleted VOD, from #521) | stack trace, `SIGABRT`, exit 134 | `[ERROR] - Invalid VOD, deleted/expired VOD possibly?`, exit 1 |
| `chatdownload ... --log-level None` | stack trace regardless | no output, exit 1 |
| `chatupdate --beginning 0` on a chat whose VOD is expired | `[INFO] - Unable to fetch possible missing comments...`, completes 3/3 | unchanged — completes 3/3 |

Let me know what you think, happy to make changes. 