### PR TITLE
Fix chat download crash when Twitch returns an error response instead of comments

### DIFF
--- a/TwitchDownloaderCore/ChatDownloader.cs
+++ b/TwitchDownloaderCore/ChatDownloader.cs
@@ -93,15 +93,20 @@ namespace TwitchDownloaderCore
                     continue;
                 }
 
-                // video.comments can be null for some dumb reason
-                if (commentResponse.data.video.comments?.edges is null)
+                // video.comments can be null for some dumb reason. Twitch also occasionally times out internally and
+                // returns HTTP 200 with {"errors":[{"message":"context deadline exceeded"}]} and no data object at all.
+                // Both are transient, so retry the same request.
+                // This issue was discovered when downloading chat just after a live stream ends, and VOD storage is enabled.
+                if (commentResponse?.data?.video?.comments?.edges is null)
                 {
+                    var errorMessage = commentResponse?.errors?.FirstOrDefault()?.message ?? "null comment list";
+
                     if (++nullCount > 10)
                     {
-                        throw new Exception("Received too many null comment lists. Try reducing your download threads.");
+                        throw new Exception($"Received too many null comment lists ('{errorMessage}'). Try reducing your download threads or retry a few hours later.");
                     }
 
-                    _progress.LogVerbose($"Received null comment list at {latestMessage}s ({cursor}) in range {downloadRange}. Current null factor: {nullCount}.");
+                    _progress.LogVerbose($"Received '{errorMessage}' at {latestMessage}s ({cursor}) in range {downloadRange}. Current null factor: {nullCount}.");
                     await Task.Delay((int)(100 * nullCount), cancellationToken);
                     continue;
                 }

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlCommentResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlCommentResponse.cs
@@ -70,9 +70,15 @@
         public bool hasPreviousPage { get; set; }
     }
 
+    public class GqlCommentError
+    {
+        public string message { get; set; }
+    }
+
     public class GqlCommentResponse
     {
         public CommentData data { get; set; }
+        public List<GqlCommentError> errors { get; set; }
         public Extensions extensions { get; set; }
     }
 


### PR DESCRIPTION
Error found on https://github.com/lay295/TwitchDownloader/commit/d4122d80214b08b3c7078003aae43088e601a435:

```
$ TwitchDownloaderCLI chatdownload
TwitchDownloaderCLI 1.56.5 Copyright (c) lay295 and contributors
[STATUS] - Downloading 82%Unhandled exception. System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at TwitchDownloaderCore.ChatDownloader.DownloadSection(Range downloadRange, String videoId, DateTime videoCreatedAt, Boolean runToEnd, IProgress`1 downloadProgress, CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatDownloader.DownloadComments(DownloadType downloadType, Video video, Int32 connectionCount, CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatDownloader.DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatDownloader.DownloadAsync(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatDownloader.DownloadAsync(CancellationToken cancellationToken)
   at TwitchDownloaderCore.ChatDownloader.DownloadAsync(CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at TwitchDownloaderCLI.Modes.DownloadChat.Download(ChatDownloadArgs inputOptions)
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at TwitchDownloaderCLI.Program.Main(String[] args)
```

Twitch's GQL endpoint occasionally answers VideoCommentsByOffsetOrCursor
with HTTP 200 and no "data" object at all:

```
  {"errors":[{"message":"context deadline exceeded"}],"extensions":{"durationMilliseconds":7269,...}}
```

Observed on a VOD a few minutes after the stream ended: 3 error responses
in ~216 requests, each one taking 7-12 seconds versus ~0.3 s normally.
All succeeded on the immediate retry with the same cursor, and the
resulting chat was identical page-for-page to a later clean run, so no
comments are skipped.