### PR TITLE
Stream download

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/StreamDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/StreamDownloadArgs.cs
@@ -22,7 +22,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("bandwidth", Default = -1, HelpText = "The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or -1 for no maximum.")]
         public int ThrottleKib { get; set; }
 
-        [Option("oauth", HelpText = "OAuth access token to download subscriber only streams or access logged-in only qualities. DO NOT SHARE THIS WITH ANYONE.")]
+        [Option("oauth", HelpText = "OAuth access token to download subscriber only streams or access logged-in only video qualities. DO NOT SHARE THIS WITH ANYONE.")]
         public string Oauth { get; set; }
 
         [Option("ffmpeg-path", HelpText = "Path to FFmpeg executable.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/StreamDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/StreamDownloadArgs.cs
@@ -1,0 +1,39 @@
+﻿using CommandLine;
+using TwitchDownloaderCLI.Models;
+using TwitchDownloaderCore.Models;
+
+namespace TwitchDownloaderCLI.Modes.Arguments
+{
+    [Verb("streamdownload", HelpText = "Downloads a stream live from Twitch")]
+    internal sealed class StreamDownloadArgs : IFileCollisionArgs, ITwitchDownloaderArgs
+    {
+        [Option('u', "login", Required = true, HelpText = "The login of the target channel.")]
+        public string ChannelLogin { get; set; }
+
+        [Option('o', "output", Required = true, HelpText = "Path to output file. File extension will be used to determine download type. Valid extensions are: .mp4 and .m4a.")]
+        public string OutputFile { get; set; }
+
+        [Option('q', "quality", HelpText = "The quality the program will attempt to download.")]
+        public string Quality { get; set; }
+
+        [Option('t', "threads", Default = 4, HelpText = "Number of parallel download threads. Large values may result in IP rate limiting.")]
+        public int DownloadThreads { get; set; }
+
+        [Option("bandwidth", Default = -1, HelpText = "The maximum bandwidth a thread will be allowed to use in kibibytes per second (KiB/s), or -1 for no maximum.")]
+        public int ThrottleKib { get; set; }
+
+        [Option("oauth", HelpText = "OAuth access token to download subscriber only streams or access logged-in only qualities. DO NOT SHARE THIS WITH ANYONE.")]
+        public string Oauth { get; set; }
+
+        [Option("ffmpeg-path", HelpText = "Path to FFmpeg executable.")]
+        public string FfmpegPath { get; set; }
+
+        [Option("temp-path", Default = "", HelpText = "Path to temporary caching folder.")]
+        public string TempFolder { get; set; }
+
+        // Interface args
+        public OverwriteBehavior OverwriteBehavior { get; set; }
+        public bool? ShowBanner { get; set; }
+        public LogLevel LogLevel { get; set; }
+    }
+}

--- a/TwitchDownloaderCLI/Modes/DownloadStream.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadStream.cs
@@ -20,7 +20,8 @@ namespace TwitchDownloaderCLI.Modes
             var downloadOptions = GetDownloadOptions(inputOptions, collisionHandler, progress);
 
             var streamDownloader = new StreamDownloader(downloadOptions, progress);
-            streamDownloader.DownloadAsync(new CancellationToken()).Wait();
+            //TODO: catch ^C signal and stop download.
+            streamDownloader.DownloadAsync(CancellationToken.None, CancellationToken.None).Wait();
         }
 
         private static StreamDownloadOptions GetDownloadOptions(StreamDownloadArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)

--- a/TwitchDownloaderCLI/Modes/DownloadStream.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadStream.cs
@@ -1,0 +1,68 @@
+﻿using TwitchDownloaderCLI.Modes.Arguments;
+using TwitchDownloaderCLI.Tools;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Interfaces;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Services;
+using TwitchDownloaderCore.Tools;
+
+namespace TwitchDownloaderCLI.Modes
+{
+    internal static class DownloadStream
+    {
+        internal static void Download(StreamDownloadArgs inputOptions)
+        {
+            using var progress = new CliTaskProgress(inputOptions.LogLevel);
+
+            FfmpegHandler.DetectFfmpeg(inputOptions.FfmpegPath, progress);
+
+            var collisionHandler = new FileCollisionHandler(inputOptions, progress);
+            var downloadOptions = GetDownloadOptions(inputOptions, collisionHandler, progress);
+
+            var streamDownloader = new StreamDownloader(downloadOptions, progress);
+            streamDownloader.DownloadAsync(new CancellationToken()).Wait();
+        }
+
+        private static StreamDownloadOptions GetDownloadOptions(StreamDownloadArgs inputOptions, FileCollisionHandler collisionHandler, ITaskLogger logger)
+        {
+            if (inputOptions.ChannelLogin is null)
+            {
+                logger.LogError("Channel login cannot be null!");
+                Environment.Exit(1);
+            }
+
+            if (!Path.HasExtension(inputOptions.OutputFile) && inputOptions.Quality is { Length: > 0 })
+            {
+                inputOptions.OutputFile += FilenameService.GuessVodFileExtension(inputOptions.Quality);
+            }
+
+            StreamDownloadOptions downloadOptions = new()
+            {
+                DownloadThreads = inputOptions.DownloadThreads,
+                ThrottleKib = inputOptions.ThrottleKib,
+                ChannelLogin = inputOptions.ChannelLogin,
+                Oauth = inputOptions.Oauth,
+                Filename = inputOptions.OutputFile,
+                Quality = Path.GetExtension(inputOptions.OutputFile)!.ToLower() switch
+                {
+                    ".mp4" => inputOptions.Quality,
+                    ".m4a" => "Audio",
+                    _ => throw new ArgumentException("Only MP4 and M4A audio files are supported.")
+                },
+                FfmpegPath = string.IsNullOrWhiteSpace(inputOptions.FfmpegPath) ? FfmpegHandler.FfmpegExecutableName : Path.GetFullPath(inputOptions.FfmpegPath),
+                TempFolder = inputOptions.TempFolder,
+                CacheCleanerCallback = directoryInfos =>
+                {
+                    logger.LogInfo(
+                        $"{directoryInfos.Length} unmanaged video caches were found at '{directoryInfos.FirstOrDefault()?.Parent?.FullName ?? inputOptions.TempFolder}' and can be safely deleted. " +
+                        "Run 'TwitchDownloaderCLI cache help' for more information.");
+
+                    return Array.Empty<DirectoryInfo>();
+                },
+                FileCollisionCallback = collisionHandler.HandleCollisionCallback,
+            };
+
+            return downloadOptions;
+        }
+    }
+}

--- a/TwitchDownloaderCLI/Modes/InfoHandler.cs
+++ b/TwitchDownloaderCLI/Modes/InfoHandler.cs
@@ -353,7 +353,7 @@ namespace TwitchDownloaderCLI.Modes
                     };
 
                     return new M3U8.Stream(
-                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Framerate, x.Item.quality, x.Item.quality, ivsGroups, "source"),
+                        new M3U8.Stream.ExtStreamInfo(0, x.BitRate, x.Item.codecs?.Split(','), x.Resolution, x.Framerate, "", x.Item.quality, x.Item.quality, ivsGroups, "source"),
                         $"{x.Item.sourceURL}?sig={clip.playbackAccessToken.signature}&token={HttpUtility.UrlEncode(clip.playbackAccessToken.value)}"
                     );
                 })

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -22,7 +22,7 @@ namespace TwitchDownloaderCLI
                 config.HelpWriter = null; // Use null instead of TextWriter.Null due to how CommandLine works internally
             });
 
-            var parserResult = parser.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, ChatUpdateArgs, ChatRenderArgs, InfoArgs, FfmpegArgs, CacheArgs, UpdateArgs, TsMergeArgs>(preParsedArgs);
+            var parserResult = parser.ParseArguments<VideoDownloadArgs, ClipDownloadArgs, ChatDownloadArgs, StreamDownloadArgs, ChatUpdateArgs, ChatRenderArgs, InfoArgs, FfmpegArgs, CacheArgs, UpdateArgs, TsMergeArgs>(preParsedArgs);
             parserResult.WithNotParsed(errors => WriteHelpText(errors, parserResult, parser.Settings));
 
             CoreLicensor.EnsureFilesExist(null);
@@ -32,6 +32,7 @@ namespace TwitchDownloaderCLI
                 .WithParsed<VideoDownloadArgs>(DownloadVideo.Download)
                 .WithParsed<ClipDownloadArgs>(DownloadClip.Download)
                 .WithParsed<ChatDownloadArgs>(DownloadChat.Download)
+                .WithParsed<StreamDownloadArgs>(DownloadStream.Download)
                 .WithParsed<ChatUpdateArgs>(UpdateChat.Update)
                 .WithParsed<ChatRenderArgs>(RenderChat.Render)
                 .WithParsed<InfoArgs>(InfoHandler.PrintInfo)

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -6,6 +6,8 @@ using TwitchDownloaderCLI.Models;
 using TwitchDownloaderCLI.Modes;
 using TwitchDownloaderCLI.Modes.Arguments;
 using TwitchDownloaderCLI.Tools;
+using TwitchDownloaderCore;
+using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Tools;
 
 namespace TwitchDownloaderCLI
@@ -14,6 +16,34 @@ namespace TwitchDownloaderCLI
     {
         private static void Main(string[] args)
         {
+            var options = new StreamDownloadOptions()
+            {
+                ChannelLogin = "cakejumper",
+                Quality = "worst",
+                DownloadThreads = 4,
+                FfmpegPath = FfmpegHandler.FfmpegExecutableName,
+                Filename = @"D:\Projets C#\temp\livetest\test.mp4",
+                TempFolder = @"D:\Projets C#\temp\livetest"
+            };
+            //var progress = new CliTaskProgress(LogLevel.Status | LogLevel.Error | LogLevel.Warning | LogLevel.Verbose);
+            var progress = new CliTaskProgress(LogLevel.All);
+            var downloader = new StreamDownloader(options, progress);
+
+            var cts = new CancellationTokenSource();
+
+            void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+            {
+                if (cts.IsCancellationRequested)
+                    return;
+
+                e.Cancel = true;
+                cts.Cancel();
+            }
+
+            Console.CancelKeyPress += Console_CancelKeyPress;
+
+            downloader.DownloadAsync(cts.Token, CancellationToken.None).GetAwaiter().GetResult();
+            return;
             var preParsedArgs = PreParseArgs.Parse(args, Path.GetFileName(Environment.ProcessPath));
 
             var parser = new Parser(config =>

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8Tests.cs
@@ -260,17 +260,17 @@ namespace TwitchDownloaderCore.Tests.ModelTests
 
             var streams = new M3U8.Stream[]
             {
-                new(new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), 59.995m, "1080p60", "1080p60", ["landscape"], "source"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 5898203, ["avc1.64002A", "mp4a.40.2"], (1920, 1080), 59.995m, "", "1080p60", "1080p60", ["landscape"], "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/chunked/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), 59.995m, "720p60", "720p60", ["landscape"], "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 3443956, ["avc1.4D0020", "mp4a.40.2"], (1280, 720), 59.995m, "", "720p60", "720p60", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/720p60/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), 29.998m, "480p30", "480p", ["landscape"], "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 1454397, ["avc1.4D001F", "mp4a.40.2"], (852, 480), 29.998m, "", "480p30", "480p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/480p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), 0m, "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 220328, ["mp4a.40.2"], (0, 0), 0m, "", "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/audio_only/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), 29.998m, "360p30", "360p", ["landscape"], "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 708016, ["avc1.4D001E", "mp4a.40.2"], (640, 360), 29.998m, "", "360p30", "360p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/360p30/index-dvr.m3u8"),
-                new(new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), 29.998m, "160p30", "160p", ["landscape"], "transcode"),
+                new(new M3U8.Stream.ExtStreamInfo(0, 288409, ["avc1.4D000C", "mp4a.40.2"], (284, 160), 29.998m, "", "160p30", "160p", ["landscape"], "transcode"),
                     "https://abc123def456gh.cloudfront.net/123abc456def789ghi01_streamer42_12345678901_1234567890/160p30/index-dvr.m3u8")
             };
 

--- a/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
+++ b/TwitchDownloaderCore.Tests/ModelTests/M3U8VideoQualitiesTests.cs
@@ -29,13 +29,13 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 60, "1080p60", "1080p60", ["landscape"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 60, "", "1080p60", "1080p60", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 60, "720p60", "720p60", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 60, "", "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 30, "720p30", "720p", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 30, "", "720p30", "720p", ["landscape"], "transcode"),
                     "720p30"),
             ]);
 
@@ -76,31 +76,31 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 58.644M, "1080p60", "1080p60", ["landscape"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 58.644M, "", "1080p60", "1080p60", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "", "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 28.814M, "720p30", "720p", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 28.814M, "", "720p30", "720p", ["landscape"], "transcode"),
                     "720p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), 30.159M, "480p30", "480p", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (852, 480), 30.159M, "", "480p30", "480p", ["landscape"], "transcode"),
                     "480p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), 30.159M, "360p30", "360p", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C01E", "mp4a.40.2"], (640, 360), 30.159M, "", "360p30", "360p", ["landscape"], "transcode"),
                     "360p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), 30.159M, "144p30", "144p", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.42C00C", "mp4a.40.2"], (256, 144), 30.159M, "", "144p30", "144p", ["landscape"], "transcode"),
                     "144p30"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), 0, "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["mp4a.40.2"], (256, 144), 0, "", "audio_only", "Audio Only", ["landscape", "portrait"], "source"),
                     "audio_only"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 58.644M, "1080p60-portrait", "1080p", ["portrait"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 58.644M, "", "1080p60-portrait", "1080p", ["portrait"], "source"),
                     "1080p60-portrait"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", ["portrait"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "", "720p60-portrait", "720p60", ["portrait"], "source"),
                     "720p60-portrait"),
             ]);
 
@@ -128,16 +128,16 @@ namespace TwitchDownloaderCore.Tests.ModelTests
         {
             var m3u8 = new M3U8(new M3U8.Metadata(), [
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 0, "1080p60", "1080p", ["landscape"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1920, 1080), 0, "", "1080p60", "1080p", ["landscape"], "source"),
                     "1080p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "720p60", "720p60", ["landscape"], "transcode"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1280, 720), 58.644M, "", "720p60", "720p60", ["landscape"], "transcode"),
                     "720p60"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 0, "1080p60-portrait", "1080p", ["portrait"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (1080, 1920), 0, "", "1080p60-portrait", "1080p", ["portrait"], "source"),
                     "1080p60-portrait"),
                 new M3U8.Stream(
-                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "720p60-portrait", "720p60", ["portrait"], "source"),
+                    new M3U8.Stream.ExtStreamInfo(0, 1, ["avc1.4D401F", "mp4a.40.2"], (720, 1280), 58.644M, "", "720p60-portrait", "720p60", ["portrait"], "source"),
                     "720p60-portrait"),
             ]);
 

--- a/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
+++ b/TwitchDownloaderCore/Extensions/M3U8Extensions.cs
@@ -75,7 +75,7 @@ namespace TwitchDownloaderCore.Extensions
 
         public static bool IsSource(this M3U8.Stream stream)
             => stream.Path.Contains("/chunked/", StringComparison.OrdinalIgnoreCase) ||
-                stream.StreamInfo.IvsVariantSource.Contains("source", StringComparison.OrdinalIgnoreCase);
+               stream.StreamInfo.IvsVariantSource.Contains("source", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsAudioOnly(this M3U8.Stream stream)
             => stream.Path.Contains("/audio_only/", StringComparison.OrdinalIgnoreCase) ||
@@ -100,6 +100,17 @@ namespace TwitchDownloaderCore.Extensions
                 : VideoOrientation.None;
         }
 
+        public static UnavailableMedia[] ParseUnavailableMedia(this M3U8 m3u8)
+        {
+            const string UNAVAILABLE_MEDIA_KEY = "com.amazon.ivs.unavailable-media";
+            if (!m3u8.FileMetadata.SessionData.TryGetValue(UNAVAILABLE_MEDIA_KEY, out var unavailableMediaBase64))
+            {
+                return [];
+            }
+            var unavailableMedia = JsonSerializer.Deserialize<UnavailableMedia[]>(Convert.FromBase64String(unavailableMediaBase64));
+            return unavailableMedia;
+        }
+
         public static M3U8 WithUnavailableMedia(this M3U8 m3u8)
         {
             if (m3u8.Streams.Length is 0)
@@ -107,13 +118,7 @@ namespace TwitchDownloaderCore.Extensions
                 return m3u8;
             }
 
-            const string UNAVAILABLE_MEDIA_KEY = "com.amazon.ivs.unavailable-media";
-            if (!m3u8.FileMetadata.SessionData.TryGetValue(UNAVAILABLE_MEDIA_KEY, out var unavailableMediaBase64))
-            {
-                return m3u8;
-            }
-
-            var unavailableMedia = JsonSerializer.Deserialize<UnavailableMedia[]>(Convert.FromBase64String(unavailableMediaBase64));
+            var unavailableMedia = m3u8.ParseUnavailableMedia();
             if (unavailableMedia is not { Length: > 0 })
             {
                 return m3u8;
@@ -123,7 +128,7 @@ namespace TwitchDownloaderCore.Extensions
 
             var unavailableStreams = unavailableMedia.Select(x =>
             {
-                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.FrameRate, x.StableVariantId, x.IvsName, x.IvsGroups, x.VariantSource);
+                var streamInfo = new M3U8.Stream.ExtStreamInfo(0, x.Bandwidth, x.Codecs.Split(','), M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution), x.FrameRate, "", x.StableVariantId, x.IvsName, x.IvsGroups, x.VariantSource);
                 var path = string.Format(pathFormat, x.StableVariantId);
                 return new M3U8.Stream(streamInfo, path);
             });

--- a/TwitchDownloaderCore/LiveDownloader.cs
+++ b/TwitchDownloaderCore/LiveDownloader.cs
@@ -1,0 +1,186 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using TwitchDownloaderCore.Interfaces;
+using TwitchDownloaderCore.Models;
+using TwitchDownloaderCore.Models.Interfaces;
+using TwitchDownloaderCore.Options;
+using TwitchDownloaderCore.Services;
+using TwitchDownloaderCore.TwitchObjects.Gql;
+
+namespace TwitchDownloaderCore
+{
+    public sealed partial class LiveDownloader
+    {
+        private readonly string _cacheDir;
+        private readonly LiveDownloadOptions _downloadOptions;
+        private readonly ITaskProgress _progress;
+
+        public LiveDownloader(LiveDownloadOptions downloadOptions, ITaskProgress progress = default)
+        {
+            _downloadOptions = downloadOptions;
+            _progress = progress;
+            _cacheDir = Path.Combine(CacheDirectoryService.GetCacheDirectory(downloadOptions.TempFolder), $"{downloadOptions.ChannelLogin}_{DateTimeOffset.UtcNow.Ticks}");
+            Directory.CreateDirectory(_cacheDir);
+        }
+
+        public async Task DownloadAsync(CancellationToken cancellationToken)
+        {
+            //var outputFileInfo = TwitchHelper.ClaimFile(downloadOptions.Filename, downloadOptions.FileCollisionCallback, progress);
+            //downloadOptions.Filename = outputFileInfo.FullName;
+
+            // Open the destination file so that it exists in the filesystem.
+            //await using var outputFs = outputFileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read);
+
+            try
+            {
+                await DownloadAsyncImpl(null, null, cancellationToken);
+            }
+            catch
+            {
+                await Task.Delay(100, CancellationToken.None);
+
+                //TwitchHelper.CleanUpClaimedFile(outputFileInfo, outputFs, progress);
+
+                throw;
+            }
+        }
+
+        public async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken cancellationToken)
+        {
+            _progress.SetStatus("Fetching Stream Info [1/2]");
+            IVideoQuality<StreamQuality> quality = await GetQuality();
+
+
+            _progress.SetStatus("Downloading Stream [1/2]");
+            await RunFfmpegDownload(quality, cancellationToken);
+        }
+
+        private async Task<IVideoQuality<StreamQuality>> GetQuality()
+        {
+            GqlStreamTokenResponse accessToken = await TwitchHelper.GetStreamToken(_downloadOptions.ChannelLogin, _downloadOptions.Oauth);
+
+            if (accessToken.data.streamPlaybackAccessToken is null)
+            {
+                throw new NullReferenceException("Invalid stream");
+            }
+
+            var playlistString = await TwitchHelper.GetStreamPlaylist(_downloadOptions.ChannelLogin, accessToken.data.streamPlaybackAccessToken.value, accessToken.data.streamPlaybackAccessToken.signature);
+            if (playlistString.Contains("Can not find channel"))
+            {
+                throw new Exception("Channel does not exist or is not live");
+            }
+
+            var m3u8 = M3U8.Parse(playlistString);
+            var qualities = VideoQualities.FromStreamM3U8(m3u8);
+            return qualities.GetQuality(_downloadOptions.Quality);
+        }
+
+        private async Task<int> RunFfmpegDownload(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
+        {
+            using var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = _downloadOptions.FfmpegPath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                }
+            };
+
+            var args = new List<string>
+            {
+                "-stats",
+                "-y",
+                "-i", quality.Path,
+                "-c", "copy",
+                //"out.mp4"
+                _downloadOptions.Filename
+            };
+
+            foreach (var arg in args)
+            {
+                process.StartInfo.ArgumentList.Add(arg);
+            }
+
+            var logQueue = new ConcurrentQueue<string>();
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (e.Data is null)
+                    return;
+
+                logQueue.Enqueue(e.Data); // We cannot use -report ffmpeg arg because it redirects stderr
+
+                HandleFfmpegOutput(e.Data);
+            };
+
+            _progress.LogVerbose($"Running \"{_downloadOptions.FfmpegPath}\" in \"{process.StartInfo.WorkingDirectory}\" with args: {CombineArguments(process.StartInfo.ArgumentList)}");
+
+            process.Start();
+            process.BeginErrorReadLine();
+
+            cancellationToken.Register(() =>
+            {
+                _progress.SetStatus("Stopping download...");
+                process.StandardInput.Write('q');
+            });
+
+            await using var logWriter = File.CreateText(Path.Combine(_cacheDir, "ffmpegLog.txt"));
+            logWriter.AutoFlush = true;
+            do // We cannot handle logging inside the ErrorDataReceived lambda because more than 1 can come in at once and cause a race condition. lay295#598
+            {
+                try
+                {
+                    await Task.Delay(200, cancellationToken);
+                }
+                catch { }
+
+                while (!logQueue.IsEmpty && logQueue.TryDequeue(out var logMessage))
+                {
+                    await logWriter.WriteLineAsync(logMessage);
+                }
+            } while (!process.HasExited || !logQueue.IsEmpty);
+
+            return process.ExitCode;
+
+            static string CombineArguments(IEnumerable<string> args)
+            {
+                return string.Join(' ', args.Select(x =>
+                {
+                    if (!x.StartsWith('"') && !x.StartsWith('\'') && x.Contains(' '))
+                        return $"\"{x}\"";
+
+                    return x;
+                }));
+            }
+        }
+
+
+        [GeneratedRegex(@"(?<=time=)(\d\d):(\d\d):(\d\d)\.(\d\d)")]
+        private static partial Regex EncodingTimeRegex { get; }
+
+        private void HandleFfmpegOutput(string output)
+        {
+            var encodingTimeMatch = EncodingTimeRegex.Match(output);
+            if (!encodingTimeMatch.Success)
+                return;
+
+            // TimeSpan.Parse insists that hours cannot be greater than 24, thus we must use the TimeSpan ctor.
+            if (!int.TryParse(encodingTimeMatch.Groups[1].ValueSpan, out var hours))
+                return;
+            if (!int.TryParse(encodingTimeMatch.Groups[2].ValueSpan, out var minutes))
+                return;
+            if (!int.TryParse(encodingTimeMatch.Groups[3].ValueSpan, out var seconds))
+                return;
+            if (!int.TryParse(encodingTimeMatch.Groups[4].ValueSpan, out var milliseconds))
+                return;
+            var encodingTime = new TimeSpan(0, hours, minutes, seconds, milliseconds);
+
+            _progress.SetStatus(encodingTime.ToString());
+        }
+    }
+}

--- a/TwitchDownloaderCore/Models/M3U8.cs
+++ b/TwitchDownloaderCore/Models/M3U8.cs
@@ -253,19 +253,22 @@ namespace TwitchDownloaderCore.Models
                     public override string ToString() => $"{Width}x{Height}";
 
                     public static implicit operator StreamResolution((uint width, uint height) tuple) => new(tuple.width, tuple.height);
+
+                    public static readonly StreamResolution None = new(0, 0);
                 }
 
                 internal const string STREAM_INFO_KEY = "#EXT-X-STREAM-INF:";
 
                 private ExtStreamInfo() { }
 
-                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, decimal framerate, string stableVariantId, string ivsName, string[] ivsGroups, string ivsVariantSource)
+                public ExtStreamInfo(int programId, int bandwidth, string[] codecs, StreamResolution resolution, decimal framerate, string video, string stableVariantId, string ivsName, string[] ivsGroups, string ivsVariantSource)
                 {
                     ProgramId = programId;
                     Bandwidth = bandwidth;
                     Codecs = codecs ?? [];
                     Resolution = resolution;
                     Framerate = framerate;
+                    Video = video ?? "";
                     StableVariantId = stableVariantId ?? "";
                     IvsName = ivsName ?? "";
                     IvsGroups = ivsGroups ?? [];
@@ -277,6 +280,7 @@ namespace TwitchDownloaderCore.Models
                 public IReadOnlyList<string> Codecs { get; internal set; } = [];
                 public StreamResolution Resolution { get; internal set; }
                 public decimal Framerate { get; internal set; }
+                public string Video { get; internal set; } = "";
                 public string StableVariantId { get; internal set; } = "";
                 public string IvsName { get; internal set; } = "";
                 public IReadOnlyList<string> IvsGroups { get; internal set; } = [];
@@ -301,6 +305,9 @@ namespace TwitchDownloaderCore.Models
 
                     if (Framerate != 0)
                         sb.AppendKeyValue("FRAME-RATE=", Framerate, default);
+
+                    if (!string.IsNullOrWhiteSpace(Video))
+                        sb.AppendKeyQuoteValue("VIDEO=", Video, keyValueSeparator);
 
                     if (!string.IsNullOrWhiteSpace(StableVariantId))
                         sb.AppendKeyQuoteValue("STABLE-VARIANT-ID=", StableVariantId, keyValueSeparator);

--- a/TwitchDownloaderCore/Models/M3U8Parse.cs
+++ b/TwitchDownloaderCore/Models/M3U8Parse.cs
@@ -430,6 +430,7 @@ namespace TwitchDownloaderCore.Models
                     const string KEY_CODECS = "CODECS=\"";
                     const string KEY_RESOLUTION = "RESOLUTION=";
                     const string KEY_FRAMERATE = "FRAME-RATE=";
+                    const string KEY_VIDEO = "VIDEO=\"";
                     const string KEY_STABLE_VARIANT_ID = "STABLE-VARIANT-ID=\"";
                     const string KEY_IVS_NAME = "IVS-NAME=\"";
                     const string KEY_IVS_GROUPS = "IVS-GROUPS=\"";
@@ -458,6 +459,10 @@ namespace TwitchDownloaderCore.Models
                         else if (text.StartsWith(KEY_FRAMERATE))
                         {
                             streamInfo.Framerate = ParsingHelpers.ParseDecimalValue(text, KEY_FRAMERATE, false);
+                        }
+                        else if (text.StartsWith(KEY_VIDEO))
+                        {
+                            streamInfo.Video = ParsingHelpers.ParseStringValue(text, KEY_VIDEO);
                         }
                         else if (text.StartsWith(KEY_STABLE_VARIANT_ID))
                         {

--- a/TwitchDownloaderCore/Models/StreamQuality.cs
+++ b/TwitchDownloaderCore/Models/StreamQuality.cs
@@ -9,7 +9,6 @@
         public string Video { get; set; }
         public string Name { get; set; }
         public string Path { get; set; }
-        public bool IsAvailable => !string.IsNullOrEmpty(Path);
-        public bool IsAudio => Video.Contains("audio_only", StringComparison.OrdinalIgnoreCase);
+        public bool IsAudio => Video.Contains("audio_only", StringComparison.OrdinalIgnoreCase) || (Resolution.Width == 0 && Resolution.Height == 0);
     }
 }

--- a/TwitchDownloaderCore/Models/StreamQuality.cs
+++ b/TwitchDownloaderCore/Models/StreamQuality.cs
@@ -1,0 +1,15 @@
+﻿namespace TwitchDownloaderCore.Models
+{
+    public sealed record StreamQuality
+    {
+        public IReadOnlyList<string> Codecs { get; set; }
+        public int Bandwidth { get; set; }
+        public Resolution Resolution { get; set; }
+        public decimal Framerate { get; set; }
+        public string Video { get; set; }
+        public string Name { get; set; }
+        public string Path { get; set; }
+        public bool IsAvailable => !string.IsNullOrEmpty(Path);
+        public bool IsAudio => Video.Contains("audio_only", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/TwitchDownloaderCore/Models/StreamVideoQualities.cs
+++ b/TwitchDownloaderCore/Models/StreamVideoQualities.cs
@@ -1,0 +1,105 @@
+﻿using TwitchDownloaderCore.Extensions;
+using TwitchDownloaderCore.Models.Interfaces;
+
+namespace TwitchDownloaderCore.Models
+{
+    public sealed class StreamVideoQualities : VideoQualities<StreamQuality>, IVideoQualities<StreamQuality>
+    {
+        public StreamVideoQualities(IReadOnlyList<IVideoQuality<StreamQuality>> qualities)
+        {
+            Qualities = qualities;
+        }
+
+        public override IVideoQuality<StreamQuality> BestQuality()
+        {
+            if (Qualities is null)
+            {
+                return null;
+            }
+
+            var bestQuality = Qualities.FirstOrDefault(x => x.IsSource && x.Item.IsAvailable);
+
+            bestQuality ??= Qualities
+                .WhereOnlyIf(x => x.Resolution.Width > x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
+                .MaxBy(x => x.Resolution.Height);
+
+            bestQuality ??= Qualities.MaxBy(x => x.Resolution.Height);
+
+            return bestQuality ?? Qualities.FirstOrDefault();
+        }
+
+        public override IVideoQuality<StreamQuality> GetQuality(string qualityString)
+        {
+            if (TryGetQuality(qualityString, out var foundQuality))
+            {
+                return foundQuality;
+            }
+
+            foreach (var quality in Qualities.Where(x => x.Item.IsAvailable))
+            {
+                var framerate = (int)Math.Round(quality.Framerate);
+                var framerateString = qualityString!.EndsWith('p') && framerate == 30
+                    ? ""
+                    : framerate.ToString("F0");
+
+                if ($"{quality.Item.Resolution.Height}p{framerateString}" == qualityString)
+                {
+                    return quality;
+                }
+            }
+
+            return null;
+        }
+
+        public override IVideoQuality<StreamQuality> WorstQuality()
+        {
+            if (Qualities is null)
+            {
+                return null;
+            }
+
+            var worstQuality = Qualities
+                .Where(x => !x.Item.IsAudio && x.Item.IsAvailable)
+                .WhereOnlyIf(x => x.Resolution.Width > x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
+                .MinBy(x => x.Resolution.Height);
+
+            worstQuality ??= Qualities.Where(x => !x.Item.IsAudio && x.Item.IsAvailable).MinBy(x => x.Resolution.Height);
+
+            return worstQuality ?? Qualities.LastOrDefault(x => !x.Item.IsAudio && x.Item.IsAvailable);
+        }
+
+        protected override bool TryGetKeywordQuality(string qualityString, out IVideoQuality<StreamQuality> quality)
+        {
+            if (string.IsNullOrWhiteSpace(qualityString))
+            {
+                quality = BestQuality();
+                return true;
+            }
+
+            // TODO: support portrait streams
+            if (qualityString.Contains("best", StringComparison.OrdinalIgnoreCase)
+                || qualityString.Contains("source", StringComparison.OrdinalIgnoreCase)
+                || qualityString.Contains("chunked", StringComparison.OrdinalIgnoreCase))
+            {
+                quality = BestQuality();
+                return true;
+            }
+
+            if (qualityString.Contains("worst", StringComparison.OrdinalIgnoreCase))
+            {
+                quality = WorstQuality();
+                return true;
+            }
+
+            if (qualityString.Contains("audio", StringComparison.OrdinalIgnoreCase)
+                && Qualities.FirstOrDefault(x => x.Item.IsAvailable && x.Item.IsAudio) is { } audioStream)
+            {
+                quality = audioStream;
+                return true;
+            }
+
+            quality = null;
+            return false;
+        }
+    }
+}

--- a/TwitchDownloaderCore/Models/StreamVideoQualities.cs
+++ b/TwitchDownloaderCore/Models/StreamVideoQualities.cs
@@ -17,7 +17,7 @@ namespace TwitchDownloaderCore.Models
                 return null;
             }
 
-            var bestQuality = Qualities.FirstOrDefault(x => x.IsSource && x.Item.IsAvailable);
+            var bestQuality = Qualities.FirstOrDefault(x => x.IsSource);
 
             bestQuality ??= Qualities
                 .WhereOnlyIf(x => x.Resolution.Width > x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
@@ -35,7 +35,7 @@ namespace TwitchDownloaderCore.Models
                 return foundQuality;
             }
 
-            foreach (var quality in Qualities.Where(x => x.Item.IsAvailable))
+            foreach (var quality in Qualities)
             {
                 var framerate = (int)Math.Round(quality.Framerate);
                 var framerateString = qualityString!.EndsWith('p') && framerate == 30
@@ -59,13 +59,13 @@ namespace TwitchDownloaderCore.Models
             }
 
             var worstQuality = Qualities
-                .Where(x => !x.Item.IsAudio && x.Item.IsAvailable)
+                .Where(x => !x.Item.IsAudio)
                 .WhereOnlyIf(x => x.Resolution.Width > x.Resolution.Height, Qualities.All(x => x.Resolution.HasWidth))
                 .MinBy(x => x.Resolution.Height);
 
-            worstQuality ??= Qualities.Where(x => !x.Item.IsAudio && x.Item.IsAvailable).MinBy(x => x.Resolution.Height);
+            worstQuality ??= Qualities.Where(x => !x.Item.IsAudio).MinBy(x => x.Resolution.Height);
 
-            return worstQuality ?? Qualities.LastOrDefault(x => !x.Item.IsAudio && x.Item.IsAvailable);
+            return worstQuality ?? Qualities.LastOrDefault(x => !x.Item.IsAudio);
         }
 
         protected override bool TryGetKeywordQuality(string qualityString, out IVideoQuality<StreamQuality> quality)
@@ -92,7 +92,7 @@ namespace TwitchDownloaderCore.Models
             }
 
             if (qualityString.Contains("audio", StringComparison.OrdinalIgnoreCase)
-                && Qualities.FirstOrDefault(x => x.Item.IsAvailable && x.Item.IsAudio) is { } audioStream)
+                && Qualities.FirstOrDefault(x => x.Item.IsAudio) is { } audioStream)
             {
                 quality = audioStream;
                 return true;

--- a/TwitchDownloaderCore/Models/StreamVideoQuality.cs
+++ b/TwitchDownloaderCore/Models/StreamVideoQuality.cs
@@ -5,7 +5,7 @@ namespace TwitchDownloaderCore.Models
     public sealed class StreamVideoQuality : IVideoQuality<StreamQuality>
     {
         public StreamQuality Item { get; }
-        public string Name => !string.IsNullOrEmpty(Item.Name) ? Item.Name : Item.Video;
+        public string Name { get; }
 
         public Resolution Resolution => Item.Resolution;
 
@@ -19,9 +19,10 @@ namespace TwitchDownloaderCore.Models
 
         public VideoOrientation Orientation => VideoOrientation.Landscape;
 
-        internal StreamVideoQuality(StreamQuality item)
+        internal StreamVideoQuality(StreamQuality item, string name)
         {
             Item = item;
+            Name = name;
         }
     }
 }

--- a/TwitchDownloaderCore/Models/StreamVideoQuality.cs
+++ b/TwitchDownloaderCore/Models/StreamVideoQuality.cs
@@ -1,0 +1,27 @@
+﻿using TwitchDownloaderCore.Models.Interfaces;
+
+namespace TwitchDownloaderCore.Models
+{
+    public sealed class StreamVideoQuality : IVideoQuality<StreamQuality>
+    {
+        public StreamQuality Item { get; }
+        public string Name => !string.IsNullOrEmpty(Item.Name) ? Item.Name : Item.Video;
+
+        public Resolution Resolution => Item.Resolution;
+
+        public decimal Framerate => Item.Framerate;
+
+        public bool IsSource => Item.Video.Equals("chunked", StringComparison.OrdinalIgnoreCase);
+
+        public string Path => Item.Path;
+
+        public int BitRate => Item.Bandwidth;
+
+        public VideoOrientation Orientation => VideoOrientation.Landscape;
+
+        internal StreamVideoQuality(StreamQuality item)
+        {
+            Item = item;
+        }
+    }
+}

--- a/TwitchDownloaderCore/Models/VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/VideoQualities.cs
@@ -130,52 +130,40 @@ namespace TwitchDownloaderCore.Models
             return name;
         }
 
-        public static IVideoQualities<StreamQuality> FromStreamM3U8(M3U8 m3u8)
+        public static (IVideoQualities<StreamQuality> available, IVideoQualities<StreamQuality> unavailable) FromStreamM3U8(M3U8 m3u8)
         {
             var unavailableMedia = m3u8.ParseUnavailableMedia();
-            var unavailableStreams = unavailableMedia.Select(x =>
+            var unavailableQualities = BuildQualityList(unavailableMedia.Select(x => new StreamQuality()
             {
-                var streamQuality = new StreamQuality()
-                {
-                    Bandwidth = x.Bandwidth,
-                    Codecs = x.Codecs.Split(','),
-                    Resolution = string.IsNullOrEmpty(x.Resolution) ? M3U8.Stream.ExtStreamInfo.StreamResolution.None : M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution),
-                    Framerate = x.FrameRate,
-                    Name = x.Name,
-                    Path = null,
-                    Video = ""
-                };
-                return new StreamVideoQuality(streamQuality);
-            });
-
-            var availableStreams = m3u8.Streams.Select(x =>
-            {
-                var streamQuality = new StreamQuality()
-                {
-                    Bandwidth = x.StreamInfo.Bandwidth,
-                    Codecs = x.StreamInfo.Codecs,
-                    Resolution = x.StreamInfo.Resolution,
-                    Framerate = x.StreamInfo.Framerate,
-                    Name = x.StreamInfo.IvsName,
-                    Path = x.Path,
-                    Video = x.StreamInfo.Video
-                };
-                return new StreamVideoQuality(streamQuality);
-            });
-
-            var allStreams = unavailableStreams
-                .Where(x => availableStreams.All(y => x.Path != y.Path))
-                .Concat(availableStreams)
-                .ToArray();
-
-            var sortedQualities = allStreams
-                .OrderBy(x => !x.Item.IsAvailable)
-                .ThenByDescending(x => x.Resolution.Height)
+                Bandwidth = x.Bandwidth,
+                Codecs = x.Codecs.Split(','),
+                Resolution = string.IsNullOrEmpty(x.Resolution) ? M3U8.Stream.ExtStreamInfo.StreamResolution.None : M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution),
+                Framerate = x.FrameRate,
+                Name = x.Name,
+                Path = null,
+                Video = string.Join(',', x.FilterReasons)
+            }).ToList(), x => !string.IsNullOrEmpty(x.Name) ? x.Name : x.Video, (quality, name) => new StreamVideoQuality(quality, name))
+                .OrderByDescending(x => x.Resolution.Height)
                 .ThenByDescending(x => x.Framerate)
                 .ThenByDescending(x => x.Name)
-                .ToArray();
+                .ToList();
 
-            return new StreamVideoQualities(sortedQualities);
+            var availableQualities = BuildQualityList(m3u8.Streams.Select(x => new StreamQuality()
+            {
+                Bandwidth = x.StreamInfo.Bandwidth,
+                Codecs = x.StreamInfo.Codecs,
+                Resolution = x.StreamInfo.Resolution,
+                Framerate = x.StreamInfo.Framerate,
+                Name = x.StreamInfo.IvsName,
+                Path = x.Path,
+                Video = x.StreamInfo.Video
+            }).ToList(), x => !string.IsNullOrEmpty(x.Name) ? x.Name : x.Video, (quality, name) => new StreamVideoQuality(quality, name))
+                .OrderByDescending(x => x.Resolution.Height)
+                .ThenByDescending(x => x.Framerate)
+                .ThenByDescending(x => x.Name)
+                .ToList();
+
+            return (new StreamVideoQualities(availableQualities), new StreamVideoQualities(unavailableQualities));
         }
 
         public static IVideoQualities<ClipQuality> FromClip(ShareClipRenderStatusClip clip)

--- a/TwitchDownloaderCore/Models/VideoQualities.cs
+++ b/TwitchDownloaderCore/Models/VideoQualities.cs
@@ -130,6 +130,54 @@ namespace TwitchDownloaderCore.Models
             return name;
         }
 
+        public static IVideoQualities<StreamQuality> FromStreamM3U8(M3U8 m3u8)
+        {
+            var unavailableMedia = m3u8.ParseUnavailableMedia();
+            var unavailableStreams = unavailableMedia.Select(x =>
+            {
+                var streamQuality = new StreamQuality()
+                {
+                    Bandwidth = x.Bandwidth,
+                    Codecs = x.Codecs.Split(','),
+                    Resolution = string.IsNullOrEmpty(x.Resolution) ? M3U8.Stream.ExtStreamInfo.StreamResolution.None : M3U8.Stream.ExtStreamInfo.StreamResolution.Parse(x.Resolution),
+                    Framerate = x.FrameRate,
+                    Name = x.Name,
+                    Path = null,
+                    Video = ""
+                };
+                return new StreamVideoQuality(streamQuality);
+            });
+
+            var availableStreams = m3u8.Streams.Select(x =>
+            {
+                var streamQuality = new StreamQuality()
+                {
+                    Bandwidth = x.StreamInfo.Bandwidth,
+                    Codecs = x.StreamInfo.Codecs,
+                    Resolution = x.StreamInfo.Resolution,
+                    Framerate = x.StreamInfo.Framerate,
+                    Name = x.StreamInfo.IvsName,
+                    Path = x.Path,
+                    Video = x.StreamInfo.Video
+                };
+                return new StreamVideoQuality(streamQuality);
+            });
+
+            var allStreams = unavailableStreams
+                .Where(x => availableStreams.All(y => x.Path != y.Path))
+                .Concat(availableStreams)
+                .ToArray();
+
+            var sortedQualities = allStreams
+                .OrderBy(x => !x.Item.IsAvailable)
+                .ThenByDescending(x => x.Resolution.Height)
+                .ThenByDescending(x => x.Framerate)
+                .ThenByDescending(x => x.Name)
+                .ToArray();
+
+            return new StreamVideoQualities(sortedQualities);
+        }
+
         public static IVideoQualities<ClipQuality> FromClip(ShareClipRenderStatusClip clip)
         {
             const string PORTRAIT_SUFFIX = "Portrait";

--- a/TwitchDownloaderCore/Options/LiveDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/LiveDownloadOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace TwitchDownloaderCore.Options
+{
+    public class LiveDownloadOptions
+    {
+        public string ChannelLogin { get; set; }
+        public string Quality { get; set; }
+        public string Filename { get; set; }
+        public string Oauth { get; set; }
+        public string FfmpegPath { get; set; }
+        public string TempFolder { get; set; }
+        public Func<FileInfo, FileInfo> FileCollisionCallback { get; set; } = info => info;
+    }
+}

--- a/TwitchDownloaderCore/Options/StreamDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/StreamDownloadOptions.cs
@@ -1,13 +1,16 @@
 ﻿namespace TwitchDownloaderCore.Options
 {
-    public class LiveDownloadOptions
+    public class StreamDownloadOptions
     {
         public string ChannelLogin { get; set; }
         public string Quality { get; set; }
         public string Filename { get; set; }
+        public int DownloadThreads { get; set; }
+        public int ThrottleKib { get; set; }
         public string Oauth { get; set; }
         public string FfmpegPath { get; set; }
         public string TempFolder { get; set; }
+        public Func<DirectoryInfo[], DirectoryInfo[]> CacheCleanerCallback { get; set; }
         public Func<FileInfo, FileInfo> FileCollisionCallback { get; set; } = info => info;
     }
 }

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -71,7 +71,7 @@ namespace TwitchDownloaderCore
             }
         }
 
-        public async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken stoppingToken, CancellationToken cancellationToken)
+        private async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken stoppingToken, CancellationToken cancellationToken)
         {
             var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, cancellationToken);
 
@@ -102,7 +102,7 @@ namespace TwitchDownloaderCore
             _progress.SetTemplateStatus("Downloading Stream ({0}h{1:m\\ms\\s} downloaded) [2/3]", 0, TimeSpan.Zero, TimeSpan.Zero);
             var progressTemplateIncludesMissingTime = false;
 
-            var downloadState = new StreamDownloadState();
+            var downloadState = new StreamDownloadState(_progress);
             var downloadThreads = new StreamDownloadThread[_downloadOptions.DownloadThreads];
             for (var i = 0; i < _downloadOptions.DownloadThreads; i++)
             {
@@ -114,7 +114,7 @@ namespace TwitchDownloaderCore
 
             try
             {
-                using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+                using var timer = new PeriodicTimer(TimeSpan.FromSeconds(20));
                 do
                 {
                     var playlist = await GetPlaylistAsync(quality, linkedCts.Token);
@@ -127,6 +127,8 @@ namespace TwitchDownloaderCore
                     }
                     streamIds ??= GetStreamIds(playlist);
 
+                    var completedParts = downloadState.AppendSegment(playlist);
+
                     if (!progressTemplateIncludesMissingTime && downloadState.TotalMissingTime > TimeSpan.Zero)
                     {
                         _progress.SetTemplateStatus(
@@ -136,8 +138,6 @@ namespace TwitchDownloaderCore
                             downloadState.TotalMissingTime);
                         progressTemplateIncludesMissingTime = true;
                     }
-
-                    var completedParts = downloadState.AppendSegment(playlist);
 
                     await using var fs = new FileStream(concatListPath, FileMode.Append, FileAccess.Write, FileShare.Read);
                     await FfmpegConcatList.SerializeAsync(fs, completedParts.Select(x => (x.FileName, (decimal)x.Duration.TotalSeconds)), streamIds, cancellationToken);

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -17,6 +17,7 @@ namespace TwitchDownloaderCore
         private readonly HttpClient _httpClient;
         private readonly ITaskProgress _progress;
         private readonly string _cacheDir;
+        private bool _shouldClearCache = true;
 
         public StreamDownloader(StreamDownloadOptions downloadOptions, ITaskProgress progress = default)
         {
@@ -26,7 +27,9 @@ namespace TwitchDownloaderCore
             _cacheDir = Path.Combine(CacheDirectoryService.GetCacheDirectory(downloadOptions.TempFolder), $"{downloadOptions.ChannelLogin}_{DateTimeOffset.UtcNow.Ticks}");
         }
 
-        public async Task DownloadAsync(CancellationToken cancellationToken)
+        /// <param name="stoppingToken">A <see cref="CancellationToken"/> used to stop the stream download, but still finalize downloaded parts to the output file.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the download.</param>
+        public async Task DownloadAsync(CancellationToken stoppingToken, CancellationToken cancellationToken)
         {
             //var outputFileInfo = TwitchHelper.ClaimFile(downloadOptions.Filename, downloadOptions.FileCollisionCallback, progress);
             //downloadOptions.Filename = outputFileInfo.FullName;
@@ -34,31 +37,8 @@ namespace TwitchDownloaderCore
             // Open the destination file so that it exists in the filesystem.
             //await using var outputFs = outputFileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read);
 
-            try
-            {
-                await DownloadAsyncImpl(null, null, cancellationToken);
-            }
-            catch
-            {
-                await Task.Delay(100, CancellationToken.None);
-
-                //TwitchHelper.CleanUpClaimedFile(outputFileInfo, outputFs, progress);
-
-                throw;
-            }
-        }
-
-        public async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken cancellationToken)
-        {
+            // Create and delete cache folder here to avoid surrounding DownloadAsyncImpl with a try/finally
             await TwitchHelper.CleanupAbandonedVideoCaches(_cacheDir, _downloadOptions.CacheCleanerCallback, _progress);
-
-            _progress.SetStatus("Fetching Stream Info [1/4]");
-            IVideoQuality<StreamQuality> quality = await GetQuality();
-            cancellationToken.ThrowIfCancellationRequested();
-            //TODO: check available space and warn user if less than 24h
-
-            _progress.SetStatus("Downloading Stream [2/4]");
-
             if (Directory.Exists(_cacheDir))
             {
                 _progress.LogWarning("Download cache already exists!");
@@ -68,6 +48,57 @@ namespace TwitchDownloaderCore
                 TwitchHelper.CreateDirectory(_cacheDir);
             }
 
+            try
+            {
+                await DownloadAsyncImpl(null, null, stoppingToken, cancellationToken);
+            }
+            catch
+            {
+                await Task.Delay(100, CancellationToken.None);
+
+                //TwitchHelper.CleanUpClaimedFile(outputFileInfo, outputFs, progress);
+
+                throw;
+            }
+            finally
+            {
+                await Task.Delay(100, CancellationToken.None);
+
+                if (_shouldClearCache)
+                {
+                    Cleanup(_cacheDir);
+                }
+            }
+        }
+
+        public async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken stoppingToken, CancellationToken cancellationToken)
+        {
+            var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, cancellationToken);
+
+            _progress.SetStatus("Fetching Stream Info [1/4]");
+            IVideoQuality<StreamQuality> quality;
+            try
+            {
+                quality = await GetQuality(linkedCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    _progress.LogWarning("No stream parts downloaded");
+                    return;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            //TODO: check available space and warn user if it is less than 24h
+            //TODO: display how long the stream has been live for
+
+
+            _progress.SetStatus("Downloading Stream [2/4]");
+
             var downloadState = new StreamDownloadState();
             var downloadThreads = new StreamDownloadThread[_downloadOptions.DownloadThreads];
             for (var i = 0; i < _downloadOptions.DownloadThreads; i++)
@@ -75,43 +106,66 @@ namespace TwitchDownloaderCore
                 downloadThreads[i] = new StreamDownloadThread(downloadState, _httpClient, _cacheDir, _downloadOptions.ThrottleKib, _progress, cancellationToken);
             }
 
-            DateTimeOffset nextProgrameDateTimeNeeded = DateTimeOffset.MaxValue;
-            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
-            do
+            try
             {
-                _progress.SetStatus(DateTime.Now.ToString());
-
-                var playlist = await GetPlaylistAsync(quality, cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
-
-
-                var firstStream = playlist.Streams[0];
-                if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
+                DateTimeOffset nextProgrameDateTimeNeeded = DateTimeOffset.MaxValue;
+                using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+                do
                 {
-                    _progress.LogWarning($"Missing stream part from {nextProgrameDateTimeNeeded} to {firstStream.ProgramDateTime}");
+                    //TODO: display better info (seconds downloaded, parts in queue still waiting to be downloaded by download threads...)
+                    _progress.SetStatus(DateTime.Now.ToString());
+
+                    var playlist = await GetPlaylistAsync(quality, linkedCts.Token);
+
+                    var firstStream = playlist.Streams[0];
+                    if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
+                    {
+                        _progress.LogWarning($"Missing stream part from {nextProgrameDateTimeNeeded} to {firstStream.ProgramDateTime}");
+                    }
+
+                    downloadState.AppendSegment(playlist.Streams);
+
+                    var lastStream = playlist.Streams[^1];
+                    nextProgrameDateTimeNeeded = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
+                } while (await timer.WaitForNextTickAsync(linkedCts.Token));
+            }
+            catch (OperationCanceledException)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    _progress.LogInfo("Stopping stream download");
                 }
+                else
+                {
+                    throw;
+                }
+            }
 
-                downloadState.AppendSegment(playlist.Streams);
-
-                var lastStream = playlist.Streams[^1];
-                nextProgrameDateTimeNeeded = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
-            } while (await timer.WaitForNextTickAsync(cancellationToken));
+            // StoppingToken does nothing past this point
+            cancellationToken.ThrowIfCancellationRequested();
+            linkedCts.Dispose();
 
             downloadState.StopDownload();
 
-            //await RunFfmpegDownload(quality, cancellationToken);
+
+            _progress.SetTemplateStatus("Verifying Parts {0}% [3/4]", 0);
         }
 
-        private async Task<IVideoQuality<StreamQuality>> GetQuality()
+        private async Task<IVideoQuality<StreamQuality>> GetQuality(CancellationToken cancellationToken)
         {
-            GqlStreamTokenResponse accessToken = await TwitchHelper.GetStreamToken(_downloadOptions.ChannelLogin, _downloadOptions.Oauth);
+            GqlStreamTokenResponse accessToken = await TwitchHelper.GetStreamToken(_downloadOptions.ChannelLogin, _downloadOptions.Oauth, cancellationToken);
+            //TODO: get token expiration date
 
             if (accessToken.data.streamPlaybackAccessToken is null)
             {
                 throw new NullReferenceException("Invalid stream");
             }
 
-            var playlistString = await TwitchHelper.GetStreamPlaylist(_downloadOptions.ChannelLogin, accessToken.data.streamPlaybackAccessToken.value, accessToken.data.streamPlaybackAccessToken.signature);
+            var playlistString = await TwitchHelper.GetStreamPlaylist(
+                _downloadOptions.ChannelLogin,
+                accessToken.data.streamPlaybackAccessToken.value,
+                accessToken.data.streamPlaybackAccessToken.signature,
+                cancellationToken);
             if (playlistString.Contains("Can not find channel"))
             {
                 throw new Exception("Channel does not exist or is not live");
@@ -138,6 +192,21 @@ namespace TwitchDownloaderCore
             string playlistString = await _httpClient.GetStringAsync(quality.Path, cancellationToken);
             var playlist = M3U8.Parse(playlistString);
             return playlist;
+        }
+
+        private void Cleanup(string downloadFolder)
+        {
+            try
+            {
+                if (Directory.Exists(downloadFolder))
+                {
+                    Directory.Delete(downloadFolder, true);
+                }
+            }
+            catch (IOException e)
+            {
+                _progress.LogWarning($"Failed to delete download cache: {e.Message}");
+            }
         }
 
         private async Task<int> RunFfmpegDownload(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -95,9 +95,12 @@ namespace TwitchDownloaderCore
             }
             // TODO: check available space and warn user if it is less than 24h
             // TODO: display how long the stream has been live for
+            // TODO: option to download earlier parts from the VOD, either now or at end of stream download
 
 
-            _progress.SetStatus("Downloading Stream [2/3]");
+            // Hacky workaroud to display more than 23h
+            _progress.SetTemplateStatus("Downloading Stream ({0}h{1:m\\ms\\s} downloaded) [2/3]", 0, TimeSpan.Zero, TimeSpan.Zero);
+            var progressTemplateIncludesMissingTime = false;
 
             var downloadState = new StreamDownloadState();
             var downloadThreads = new StreamDownloadThread[_downloadOptions.DownloadThreads];
@@ -107,18 +110,13 @@ namespace TwitchDownloaderCore
             }
 
             var concatListPath = Path.Combine(_cacheDir, "concat.txt");
-            DateTimeOffset videoStart = default;
-            DateTimeOffset videoEnd = default;
+            FfmpegConcatList.StreamIds streamIds = null;
 
             try
             {
-                DateTimeOffset nextProgrameDateTimeNeeded = DateTimeOffset.MaxValue;
                 using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
                 do
                 {
-                    // TODO: display better info (seconds downloaded, parts in queue still waiting to be downloaded by download threads...)
-                    _progress.SetStatus(DateTime.Now.ToString());
-
                     var playlist = await GetPlaylistAsync(quality, linkedCts.Token);
                     if (playlist is null)
                         break;
@@ -127,26 +125,22 @@ namespace TwitchDownloaderCore
                     {
                         downloadState.HeaderFile = await GetHeaderFile(playlist, cancellationToken);
                     }
+                    streamIds ??= GetStreamIds(playlist);
 
-                    var firstStream = playlist.Streams[0];
-                    var lastStream = playlist.Streams[^1];
-                    if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
+                    if (!progressTemplateIncludesMissingTime && downloadState.TotalMissingTime > TimeSpan.Zero)
                     {
-                        _progress.LogWarning($"Missing stream part from {nextProgrameDateTimeNeeded} to {firstStream.ProgramDateTime}");
+                        _progress.SetTemplateStatus(
+                            "Downloading Stream ({0}h{1:m\\ms\\s} downloaded, {2:h\\hm\\ms\\s} missing) [2/3]",
+                            (int)downloadState.TotalDownloadedTime.TotalHours,
+                            downloadState.TotalDownloadedTime,
+                            downloadState.TotalMissingTime);
+                        progressTemplateIncludesMissingTime = true;
                     }
 
-                    if (videoStart == default)
-                    {
-                        videoStart = firstStream.ProgramDateTime;
-                    }
-                    videoEnd = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
-
-                    downloadState.AppendSegment(playlist.Streams);
+                    var completedParts = downloadState.AppendSegment(playlist);
 
                     await using var fs = new FileStream(concatListPath, FileMode.Append, FileAccess.Write, FileShare.Read);
-                    await FfmpegConcatList.SerializeAsync(fs, playlist.Streams.Select(x => (downloadState.PartStates[x.Path].FileName, x.PartInfo.Duration)), GetStreamIds(playlist), cancellationToken);
-
-                    nextProgrameDateTimeNeeded = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
+                    await FfmpegConcatList.SerializeAsync(fs, completedParts.Select(x => (x.FileName, (decimal)x.Duration.TotalSeconds)), streamIds, cancellationToken);
                 } while (await timer.WaitForNextTickAsync(linkedCts.Token));
             }
             catch (OperationCanceledException)
@@ -160,7 +154,12 @@ namespace TwitchDownloaderCore
                     throw;
                 }
             }
-            // TODO: if end of stream, wait a minute or two before finalizing in case the stream crashed. If so resume the download
+
+            if (!linkedCts.IsCancellationRequested)
+            {
+                // TODO: wait a minute or two before finalizing in case the stream crashed. If channel goes back live, resume the download
+                _progress.LogInfo("End of live stream");
+            }
 
             cancellationToken.ThrowIfCancellationRequested();
             downloadState.StopDownload();
@@ -171,6 +170,12 @@ namespace TwitchDownloaderCore
             // Download threads only throw when cancelled, we can just wait they all exit
             await Task.WhenAll(downloadThreads.Select(x => x.ThreadTask));
             cancellationToken.ThrowIfCancellationRequested();
+
+            var lastParts = downloadState.GetLastParts();
+            await using var concatFs = new FileStream(concatListPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            await FfmpegConcatList.SerializeAsync(concatFs, lastParts.Select(x => (x.FileName, (decimal)x.Duration.TotalSeconds)), streamIds, cancellationToken);
+
+            // TODO: option to download missing parts from VOD
 
 
             _progress.SetTemplateStatus("Finalizing Video {0}% [3/3]", 0);
@@ -183,7 +188,7 @@ namespace TwitchDownloaderCore
             do
             {
                 // For some reason using the full concatListPath makes ffmpeg not use _cacheDir as working directory
-                ffmpegExitCode = await RunFfmpegVideoCopy(outputFileInfo, "concat.txt", videoEnd - videoStart, ffmpegRetries > 0, cancellationToken);
+                ffmpegExitCode = await RunFfmpegVideoCopy(outputFileInfo, "concat.txt", downloadState.TotalDownloadedTime + downloadState.TotalMissingTime, ffmpegRetries > 0, cancellationToken);
                 if (ffmpegExitCode != 0)
                 {
                     _progress.LogError($"Failed to finalize video (code {ffmpegExitCode}), retrying in 5 seconds...");

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -31,11 +31,11 @@ namespace TwitchDownloaderCore
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the download.</param>
         public async Task DownloadAsync(CancellationToken stoppingToken, CancellationToken cancellationToken)
         {
-            //var outputFileInfo = TwitchHelper.ClaimFile(downloadOptions.Filename, downloadOptions.FileCollisionCallback, progress);
-            //downloadOptions.Filename = outputFileInfo.FullName;
+            var outputFileInfo = TwitchHelper.ClaimFile(_downloadOptions.Filename, _downloadOptions.FileCollisionCallback, _progress);
+            _downloadOptions.Filename = outputFileInfo.FullName;
 
             // Open the destination file so that it exists in the filesystem.
-            //await using var outputFs = outputFileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read);
+            await using var outputFs = outputFileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read);
 
             // Create and delete cache folder here to avoid surrounding DownloadAsyncImpl with a try/finally
             await TwitchHelper.CleanupAbandonedVideoCaches(_cacheDir, _downloadOptions.CacheCleanerCallback, _progress);
@@ -50,13 +50,13 @@ namespace TwitchDownloaderCore
 
             try
             {
-                await DownloadAsyncImpl(null, null, stoppingToken, cancellationToken);
+                await DownloadAsyncImpl(outputFileInfo, outputFs, stoppingToken, cancellationToken);
             }
             catch
             {
                 await Task.Delay(100, CancellationToken.None);
 
-                //TwitchHelper.CleanUpClaimedFile(outputFileInfo, outputFs, progress);
+                TwitchHelper.CleanUpClaimedFile(outputFileInfo, outputFs, _progress);
 
                 throw;
             }
@@ -106,6 +106,10 @@ namespace TwitchDownloaderCore
                 downloadThreads[i] = new StreamDownloadThread(downloadState, _httpClient, _cacheDir, _downloadOptions.ThrottleKib, _progress, cancellationToken);
             }
 
+            var concatListPath = Path.Combine(_cacheDir, "concat.txt");
+            DateTimeOffset videoStart = default;
+            DateTimeOffset videoEnd = default;
+
             try
             {
                 DateTimeOffset nextProgrameDateTimeNeeded = DateTimeOffset.MaxValue;
@@ -123,14 +127,23 @@ namespace TwitchDownloaderCore
                     }
 
                     var firstStream = playlist.Streams[0];
+                    var lastStream = playlist.Streams[^1];
                     if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
                     {
                         _progress.LogWarning($"Missing stream part from {nextProgrameDateTimeNeeded} to {firstStream.ProgramDateTime}");
                     }
 
+                    if (videoStart == default)
+                    {
+                        videoStart = firstStream.ProgramDateTime;
+                    }
+                    videoEnd = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
+
                     downloadState.AppendSegment(playlist.Streams);
 
-                    var lastStream = playlist.Streams[^1];
+                    await using var fs = new FileStream(concatListPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                    await FfmpegConcatList.SerializeAsync(fs, playlist.Streams.Select(x => (downloadState.PartStates[x.Path].FileName, x.PartInfo.Duration)), GetStreamIds(playlist), cancellationToken);
+
                     nextProgrameDateTimeNeeded = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
                 } while (await timer.WaitForNextTickAsync(linkedCts.Token));
             }
@@ -157,8 +170,31 @@ namespace TwitchDownloaderCore
 
 
             _progress.SetTemplateStatus("Finalizing Video {0}% [3/3]", 0);
-
             // TODO: try to get vod info if it exists (or fallback to channel info) to serialize metadata
+
+            outputFs.Close();
+
+            int ffmpegExitCode;
+            var ffmpegRetries = 0;
+            do
+            {
+                // For some reason using the full concatListPath makes ffmpeg not use _cacheDir as working directory
+                ffmpegExitCode = await RunFfmpegVideoCopy(outputFileInfo, "concat.txt", videoEnd - videoStart, ffmpegRetries > 0, cancellationToken);
+                if (ffmpegExitCode != 0)
+                {
+                    _progress.LogError($"Failed to finalize video (code {ffmpegExitCode}), retrying in 5 seconds...");
+                    await Task.Delay(5_000, cancellationToken);
+                }
+            } while (ffmpegExitCode != 0 && ffmpegRetries++ < 1);
+
+            outputFileInfo.Refresh();
+            if (ffmpegExitCode != 0 || !outputFileInfo.Exists || outputFileInfo.Length == 0)
+            {
+                _shouldClearCache = false;
+                throw new Exception($"Failed to finalize video. The download cache has not been cleared and can be found at {_cacheDir} along with a log file.");
+            }
+
+            _progress.ReportProgress(100);
         }
 
         private async Task<IVideoQuality<StreamQuality>> GetQuality(CancellationToken cancellationToken)
@@ -227,22 +263,23 @@ namespace TwitchDownloaderCore
             return destinationFile;
         }
 
-        private void Cleanup(string downloadFolder)
+        private FfmpegConcatList.StreamIds GetStreamIds(M3U8 playlist)
         {
-            try
+            var path = playlist.Streams.FirstOrDefault()?.Path ?? "";
+            var extension = DownloadTools.GetStreamPartFileExtension(path);
+            switch (extension)
             {
-                if (Directory.Exists(downloadFolder))
-                {
-                    Directory.Delete(downloadFolder, true);
-                }
-            }
-            catch (IOException e)
-            {
-                _progress.LogWarning($"Failed to delete download cache: {e.Message}");
+                case ".mp4":
+                    return FfmpegConcatList.StreamIds.Mp4;
+                case ".ts":
+                    return FfmpegConcatList.StreamIds.TransportStream;
+                default:
+                    _progress.LogWarning("No file extension was found! Assuming TS.");
+                    return FfmpegConcatList.StreamIds.TransportStream;
             }
         }
 
-        private async Task<int> RunFfmpegDownload(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
+        private async Task<int> RunFfmpegVideoCopy(FileInfo outputFile, string concatListPath, TimeSpan videoLength, bool disableAudioCopy, CancellationToken cancellationToken)
         {
             using var process = new Process
             {
@@ -251,9 +288,10 @@ namespace TwitchDownloaderCore
                     FileName = _downloadOptions.FfmpegPath,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                    RedirectStandardInput = true,
+                    RedirectStandardInput = false,
                     RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    RedirectStandardError = true,
+                    WorkingDirectory = _cacheDir
                 }
             };
 
@@ -261,11 +299,22 @@ namespace TwitchDownloaderCore
             {
                 "-stats",
                 "-y",
-                "-i", quality.Path,
-                "-c", "copy",
-                //"out.mp4"
-                _downloadOptions.Filename
+                "-avoid_negative_ts", "make_zero",
+                "-analyzeduration", $"{int.MaxValue}",
+                "-probesize", $"{int.MaxValue}",
+                "-f", "concat",
+                "-max_streams", $"{int.MaxValue}",
+                "-i", concatListPath,
+                disableAudioCopy ? "-c:v" : "-c", "copy",
+                outputFile.FullName
             };
+
+            if (disableAudioCopy)
+            {
+                // Some VODs have bad audio data which FFmpeg doesn't like in copy mode. See lay295#1121 for more info
+                // No idea if this is necessary with live streams
+                _progress.LogVerbose("Running with audio copy disabled.");
+            }
 
             foreach (var arg in args)
             {
@@ -281,33 +330,25 @@ namespace TwitchDownloaderCore
 
                 logQueue.Enqueue(e.Data); // We cannot use -report ffmpeg arg because it redirects stderr
 
-                HandleFfmpegOutput(e.Data);
+                HandleFfmpegOutput(e.Data, videoLength);
             };
+            cancellationToken.Register(process.Kill);
+            cancellationToken.ThrowIfCancellationRequested();
 
             _progress.LogVerbose($"Running \"{_downloadOptions.FfmpegPath}\" in \"{process.StartInfo.WorkingDirectory}\" with args: {CombineArguments(process.StartInfo.ArgumentList)}");
 
             process.Start();
             process.BeginErrorReadLine();
 
-            cancellationToken.Register(() =>
-            {
-                _progress.SetStatus("Stopping download...");
-                process.StandardInput.Write('q');
-            });
-
-            await using var logWriter = File.CreateText(Path.Combine(_cacheDir, "ffmpegLog.txt"));
+            await using var logWriter = File.AppendText(Path.Combine(_cacheDir, "ffmpegLog.txt"));
             logWriter.AutoFlush = true;
             do // We cannot handle logging inside the ErrorDataReceived lambda because more than 1 can come in at once and cause a race condition. lay295#598
             {
-                try
-                {
-                    await Task.Delay(200, cancellationToken);
-                }
-                catch { }
-
+                await Task.Delay(200, cancellationToken);
                 while (!logQueue.IsEmpty && logQueue.TryDequeue(out var logMessage))
                 {
                     await logWriter.WriteLineAsync(logMessage);
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
             } while (!process.HasExited || !logQueue.IsEmpty);
 
@@ -325,10 +366,10 @@ namespace TwitchDownloaderCore
             }
         }
 
-
         [GeneratedRegex(@"(?<=time=)(\d\d):(\d\d):(\d\d)\.(\d\d)")]
         private static partial Regex EncodingTimeRegex { get; }
-        private void HandleFfmpegOutput(string output)
+
+        private void HandleFfmpegOutput(string output, TimeSpan videoLength)
         {
             var encodingTimeMatch = EncodingTimeRegex.Match(output);
             if (!encodingTimeMatch.Success)
@@ -345,7 +386,24 @@ namespace TwitchDownloaderCore
                 return;
             var encodingTime = new TimeSpan(0, hours, minutes, seconds, milliseconds);
 
-            _progress.SetStatus(encodingTime.ToString());
+            var percent = (int)Math.Round(encodingTime / videoLength * 100);
+
+            _progress.ReportProgress(Math.Clamp(percent, 0, 100));
+        }
+
+        private void Cleanup(string downloadFolder)
+        {
+            try
+            {
+                if (Directory.Exists(downloadFolder))
+                {
+                    Directory.Delete(downloadFolder, true);
+                }
+            }
+            catch (IOException e)
+            {
+                _progress.LogWarning($"Failed to delete download cache: {e.Message}");
+            }
         }
     }
 }

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -10,13 +10,13 @@ using TwitchDownloaderCore.TwitchObjects.Gql;
 
 namespace TwitchDownloaderCore
 {
-    public sealed partial class LiveDownloader
+    public sealed partial class StreamDownloader
     {
         private readonly string _cacheDir;
-        private readonly LiveDownloadOptions _downloadOptions;
+        private readonly StreamDownloadOptions _downloadOptions;
         private readonly ITaskProgress _progress;
 
-        public LiveDownloader(LiveDownloadOptions downloadOptions, ITaskProgress progress = default)
+        public StreamDownloader(StreamDownloadOptions downloadOptions, ITaskProgress progress = default)
         {
             _downloadOptions = downloadOptions;
             _progress = progress;

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -120,6 +120,8 @@ namespace TwitchDownloaderCore
                     _progress.SetStatus(DateTime.Now.ToString());
 
                     var playlist = await GetPlaylistAsync(quality, linkedCts.Token);
+                    if (playlist is null)
+                        break;
 
                     if (downloadState.HeaderFile is null && playlist.FileMetadata.Map?.Uri is not null)
                     {
@@ -158,6 +160,8 @@ namespace TwitchDownloaderCore
                     throw;
                 }
             }
+            // TODO: if end of stream, wait a minute or two before finalizing in case the stream crashed. If so resume the download
+
             cancellationToken.ThrowIfCancellationRequested();
             downloadState.StopDownload();
 
@@ -234,8 +238,23 @@ namespace TwitchDownloaderCore
 
         private async Task<M3U8> GetPlaylistAsync(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
         {
-            // TODO: catch when stream goes offline
-            string playlistString = await _httpClient.GetStringAsync(quality.Path, cancellationToken);
+            string playlistString;
+            try
+            {
+                playlistString = await _httpClient.GetStringAsync(quality.Path, cancellationToken);
+            }
+            catch (HttpRequestException e)
+            {
+                if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    // Stream went offline
+                    return null;
+                }
+                else
+                {
+                    throw;
+                }
+            }
             var playlist = M3U8.Parse(playlistString);
             return playlist;
         }

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -6,6 +6,7 @@ using TwitchDownloaderCore.Models;
 using TwitchDownloaderCore.Models.Interfaces;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.Services;
+using TwitchDownloaderCore.Tools;
 using TwitchDownloaderCore.TwitchObjects.Gql;
 
 namespace TwitchDownloaderCore
@@ -13,15 +14,16 @@ namespace TwitchDownloaderCore
     public sealed partial class StreamDownloader
     {
         private readonly StreamDownloadOptions _downloadOptions;
+        private readonly HttpClient _httpClient;
         private readonly ITaskProgress _progress;
         private readonly string _cacheDir;
 
         public StreamDownloader(StreamDownloadOptions downloadOptions, ITaskProgress progress = default)
         {
             _downloadOptions = downloadOptions;
+            _httpClient = new() { Timeout = TimeSpan.FromSeconds(25) };
             _progress = progress;
             _cacheDir = Path.Combine(CacheDirectoryService.GetCacheDirectory(downloadOptions.TempFolder), $"{downloadOptions.ChannelLogin}_{DateTimeOffset.UtcNow.Ticks}");
-            Directory.CreateDirectory(_cacheDir);
         }
 
         public async Task DownloadAsync(CancellationToken cancellationToken)
@@ -48,12 +50,56 @@ namespace TwitchDownloaderCore
 
         public async Task DownloadAsyncImpl(FileInfo outputFileInfo, FileStream outputFs, CancellationToken cancellationToken)
         {
-            _progress.SetStatus("Fetching Stream Info [1/2]");
+            await TwitchHelper.CleanupAbandonedVideoCaches(_cacheDir, _downloadOptions.CacheCleanerCallback, _progress);
+
+            _progress.SetStatus("Fetching Stream Info [1/4]");
             IVideoQuality<StreamQuality> quality = await GetQuality();
+            cancellationToken.ThrowIfCancellationRequested();
+            //TODO: check available space and warn user if less than 24h
+
+            _progress.SetStatus("Downloading Stream [2/4]");
+
+            if (Directory.Exists(_cacheDir))
+            {
+                _progress.LogWarning("Download cache already exists!");
+            }
+            else
+            {
+                TwitchHelper.CreateDirectory(_cacheDir);
+            }
+
+            var downloadState = new StreamDownloadState();
+            var downloadThreads = new StreamDownloadThread[_downloadOptions.DownloadThreads];
+            for (var i = 0; i < _downloadOptions.DownloadThreads; i++)
+            {
+                downloadThreads[i] = new StreamDownloadThread(downloadState, _httpClient, _cacheDir, _downloadOptions.ThrottleKib, _progress, cancellationToken);
+            }
+
+            DateTimeOffset nextProgrameDateTimeNeeded = DateTimeOffset.MaxValue;
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+            do
+            {
+                _progress.SetStatus(DateTime.Now.ToString());
+
+                var playlist = await GetPlaylistAsync(quality, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
 
 
-            _progress.SetStatus("Downloading Stream [1/2]");
-            await RunFfmpegDownload(quality, cancellationToken);
+                var firstStream = playlist.Streams[0];
+                if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
+                {
+                    _progress.LogWarning($"Missing stream part from {nextProgrameDateTimeNeeded} to {firstStream.ProgramDateTime}");
+                }
+
+                downloadState.AppendSegment(playlist.Streams);
+
+                var lastStream = playlist.Streams[^1];
+                nextProgrameDateTimeNeeded = lastStream.ProgramDateTime + TimeSpan.FromSeconds((double)lastStream.PartInfo.Duration);
+            } while (await timer.WaitForNextTickAsync(cancellationToken));
+
+            downloadState.StopDownload();
+
+            //await RunFfmpegDownload(quality, cancellationToken);
         }
 
         private async Task<IVideoQuality<StreamQuality>> GetQuality()
@@ -73,7 +119,7 @@ namespace TwitchDownloaderCore
 
             var m3u8 = M3U8.Parse(playlistString);
             var (availableQualities, unavailableQualities) = VideoQualities.FromStreamM3U8(m3u8);
-            var allQualities = new StreamVideoQualities(availableQualities.Qualities.Concat(unavailableQualities.Qualities).ToList());
+            var allQualities = new StreamVideoQualities([.. availableQualities.Qualities, .. unavailableQualities.Qualities]);
 
             var quality = allQualities.GetQuality(_downloadOptions.Quality);
             if (quality.Path is null)
@@ -84,6 +130,14 @@ namespace TwitchDownloaderCore
             }
 
             return quality;
+        }
+
+        private async Task<M3U8> GetPlaylistAsync(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
+        {
+            //TODO: catch when stream goes offline
+            string playlistString = await _httpClient.GetStringAsync(quality.Path, cancellationToken);
+            var playlist = M3U8.Parse(playlistString);
+            return playlist;
         }
 
         private async Task<int> RunFfmpegDownload(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -75,7 +75,7 @@ namespace TwitchDownloaderCore
         {
             var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, cancellationToken);
 
-            _progress.SetStatus("Fetching Stream Info [1/4]");
+            _progress.SetStatus("Fetching Stream Info [1/3]");
             IVideoQuality<StreamQuality> quality;
             try
             {
@@ -93,11 +93,11 @@ namespace TwitchDownloaderCore
                     throw;
                 }
             }
-            //TODO: check available space and warn user if it is less than 24h
-            //TODO: display how long the stream has been live for
+            // TODO: check available space and warn user if it is less than 24h
+            // TODO: display how long the stream has been live for
 
 
-            _progress.SetStatus("Downloading Stream [2/4]");
+            _progress.SetStatus("Downloading Stream [2/3]");
 
             var downloadState = new StreamDownloadState();
             var downloadThreads = new StreamDownloadThread[_downloadOptions.DownloadThreads];
@@ -112,10 +112,15 @@ namespace TwitchDownloaderCore
                 using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
                 do
                 {
-                    //TODO: display better info (seconds downloaded, parts in queue still waiting to be downloaded by download threads...)
+                    // TODO: display better info (seconds downloaded, parts in queue still waiting to be downloaded by download threads...)
                     _progress.SetStatus(DateTime.Now.ToString());
 
                     var playlist = await GetPlaylistAsync(quality, linkedCts.Token);
+
+                    if (downloadState.HeaderFile is null && playlist.FileMetadata.Map?.Uri is not null)
+                    {
+                        downloadState.HeaderFile = await GetHeaderFile(playlist, cancellationToken);
+                    }
 
                     var firstStream = playlist.Streams[0];
                     if (nextProgrameDateTimeNeeded - firstStream.ProgramDateTime < TimeSpan.Zero)
@@ -140,21 +145,26 @@ namespace TwitchDownloaderCore
                     throw;
                 }
             }
-
-            // StoppingToken does nothing past this point
             cancellationToken.ThrowIfCancellationRequested();
-            linkedCts.Dispose();
-
             downloadState.StopDownload();
 
+            // StoppingToken does nothing past this point
+            linkedCts.Dispose();
 
-            _progress.SetTemplateStatus("Verifying Parts {0}% [3/4]", 0);
+            // Download threads only throw when cancelled, we can just wait they all exit
+            await Task.WhenAll(downloadThreads.Select(x => x.ThreadTask));
+            cancellationToken.ThrowIfCancellationRequested();
+
+
+            _progress.SetTemplateStatus("Finalizing Video {0}% [3/3]", 0);
+
+            // TODO: try to get vod info if it exists (or fallback to channel info) to serialize metadata
         }
 
         private async Task<IVideoQuality<StreamQuality>> GetQuality(CancellationToken cancellationToken)
         {
             GqlStreamTokenResponse accessToken = await TwitchHelper.GetStreamToken(_downloadOptions.ChannelLogin, _downloadOptions.Oauth, cancellationToken);
-            //TODO: get token expiration date
+            // TODO: get token expiration date
 
             if (accessToken.data.streamPlaybackAccessToken is null)
             {
@@ -188,10 +198,33 @@ namespace TwitchDownloaderCore
 
         private async Task<M3U8> GetPlaylistAsync(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
         {
-            //TODO: catch when stream goes offline
+            // TODO: catch when stream goes offline
             string playlistString = await _httpClient.GetStringAsync(quality.Path, cancellationToken);
             var playlist = M3U8.Parse(playlistString);
             return playlist;
+        }
+
+        private async Task<string> GetHeaderFile(M3U8 playlist, CancellationToken cancellationToken)
+        {
+            var map = playlist.FileMetadata.Map;
+            if (string.IsNullOrWhiteSpace(map?.Uri))
+            {
+                return null;
+            }
+
+            if (map.ByteRange != default)
+            {
+                _progress.LogWarning($"Byte range was {map.ByteRange}, but is not yet implemented!");
+            }
+
+            var destinationFile = Path.Combine(_cacheDir, "header" + DownloadTools.GetStreamPartFileExtension(map.Uri));
+
+            var uri = new Uri(map.Uri);
+            _progress.LogVerbose($"Downloading header file from '{uri}' to '{destinationFile}'");
+
+            await DownloadTools.DownloadFileAsync(_httpClient, uri, destinationFile, null, _downloadOptions.ThrottleKib, _progress, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken));
+
+            return destinationFile;
         }
 
         private void Cleanup(string downloadFolder)

--- a/TwitchDownloaderCore/StreamDownloader.cs
+++ b/TwitchDownloaderCore/StreamDownloader.cs
@@ -12,9 +12,9 @@ namespace TwitchDownloaderCore
 {
     public sealed partial class StreamDownloader
     {
-        private readonly string _cacheDir;
         private readonly StreamDownloadOptions _downloadOptions;
         private readonly ITaskProgress _progress;
+        private readonly string _cacheDir;
 
         public StreamDownloader(StreamDownloadOptions downloadOptions, ITaskProgress progress = default)
         {
@@ -72,8 +72,18 @@ namespace TwitchDownloaderCore
             }
 
             var m3u8 = M3U8.Parse(playlistString);
-            var qualities = VideoQualities.FromStreamM3U8(m3u8);
-            return qualities.GetQuality(_downloadOptions.Quality);
+            var (availableQualities, unavailableQualities) = VideoQualities.FromStreamM3U8(m3u8);
+            var allQualities = new StreamVideoQualities(availableQualities.Qualities.Concat(unavailableQualities.Qualities).ToList());
+
+            var quality = allQualities.GetQuality(_downloadOptions.Quality);
+            if (quality.Path is null)
+            {
+                var fallback = availableQualities.GetQuality(_downloadOptions.Quality);
+                _progress.LogWarning($"Quality {quality.Name} is unavailable for reasons: {quality.Item.Video}. Switching to {fallback.Name}");
+                return fallback;
+            }
+
+            return quality;
         }
 
         private async Task<int> RunFfmpegDownload(IVideoQuality<StreamQuality> quality, CancellationToken cancellationToken)
@@ -162,7 +172,6 @@ namespace TwitchDownloaderCore
 
         [GeneratedRegex(@"(?<=time=)(\d\d):(\d\d):(\d\d)\.(\d\d)")]
         private static partial Regex EncodingTimeRegex { get; }
-
         private void HandleFfmpegOutput(string output)
         {
             var encodingTimeMatch = EncodingTimeRegex.Match(output);

--- a/TwitchDownloaderCore/Tools/DownloadTools.cs
+++ b/TwitchDownloaderCore/Tools/DownloadTools.cs
@@ -105,5 +105,19 @@ namespace TwitchDownloaderCore.Tools
 
             return inputString[..queryIndex];
         }
+
+        /// <summary>
+        /// Extract the file extension from a stream part's path
+        /// </summary>
+        public static string GetStreamPartFileExtension(string path)
+        {
+            var queryIndex = path.IndexOf('?');
+            if (queryIndex == -1)
+            {
+                return path[path.LastIndexOf('.')..];
+            }
+
+            return path[path.LastIndexOf('.')..queryIndex];
+        }
     }
 }

--- a/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using TwitchDownloaderCore.Models;
 
 namespace TwitchDownloaderCore.Tools
 {

--- a/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
+++ b/TwitchDownloaderCore/Tools/FfmpegConcatList.cs
@@ -8,19 +8,18 @@ namespace TwitchDownloaderCore.Tools
     {
         private const string LINE_FEED = "\u000A";
 
-        public static async Task SerializeAsync(string filePath, IEnumerable<M3U8.Stream> playlist, StreamIds streamIds, CancellationToken cancellationToken = default)
+        public static async Task SerializeAsync(Stream fs, IEnumerable<(string filePath, decimal duration)> playlist, StreamIds streamIds, CancellationToken cancellationToken = default)
         {
-            await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
             await using var sw = new StreamWriter(fs) { NewLine = LINE_FEED };
 
             await sw.WriteLineAsync("ffconcat version 1.0");
 
-            foreach (var stream in playlist)
+            foreach (var (filePath, duration) in playlist)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 await sw.WriteAsync("file '");
-                await sw.WriteAsync(DownloadTools.RemoveQueryString(stream.Path));
+                await sw.WriteAsync(filePath);
                 await sw.WriteLineAsync('\'');
 
                 foreach (var id in streamIds.Ids)
@@ -30,7 +29,7 @@ namespace TwitchDownloaderCore.Tools
                 }
 
                 await sw.WriteAsync("duration ");
-                await sw.WriteLineAsync(stream.PartInfo.Duration.ToString(CultureInfo.InvariantCulture));
+                await sw.WriteLineAsync(duration.ToString(CultureInfo.InvariantCulture));
             }
         }
 

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -33,7 +33,7 @@ namespace TwitchDownloaderCore.Tools
 
         public IEnumerable<PartState> AppendSegment(M3U8 playlist)
         {
-            uint? startId = playlist.FileMetadata.MediaSequence ?? playlist.FileMetadata.TwitchLiveSequence;
+            uint? startId = playlist.FileMetadata.TwitchLiveSequence ?? playlist.FileMetadata.MediaSequence;
             for (int i = 0; i < playlist.Streams.Length; i++)
             {
                 M3U8.Stream stream = playlist.Streams[i];

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -3,12 +3,13 @@ using TwitchDownloaderCore.Models;
 
 namespace TwitchDownloaderCore.Tools
 {
-    public class StreamDownloadState
+    internal sealed class StreamDownloadState
     {
         public class PartState
         {
             public byte DownloadAttempts;
             public DateTimeOffset ProgramDateTime;
+            public string FileName { get; set; }
         }
 
         public bool DownloadInProgress { get; private set; }
@@ -17,6 +18,8 @@ namespace TwitchDownloaderCore.Tools
 
         public Dictionary<string, PartState> PartStates { get; }
 
+        public string HeaderFile { get; set; }
+
         public int PartCount => PartStates.Count;
 
         public StreamDownloadState()
@@ -24,14 +27,19 @@ namespace TwitchDownloaderCore.Tools
             PartQueue = new();
             PartStates = [];
             DownloadInProgress = true;
+            HeaderFile = null;
         }
 
-        public void AppendSegment(IReadOnlyCollection<M3U8.Stream> playlist)
+        public void AppendSegment(IEnumerable<M3U8.Stream> playlist)
         {
             foreach (var stream in playlist)
             {
                 PartQueue.Enqueue(stream.Path);
-                PartStates[stream.Path] = new PartState() { ProgramDateTime = stream.ProgramDateTime };
+                PartStates[stream.Path] = new PartState()
+                {
+                    ProgramDateTime = stream.ProgramDateTime,
+                    FileName = stream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff") + DownloadTools.GetStreamPartFileExtension(stream.Path)
+                };
             }
         }
 

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -30,6 +30,8 @@ namespace TwitchDownloaderCore.Tools
 
         public TimeSpan TotalMissingTime { get; set; } = TimeSpan.Zero;
 
+        public Lock TimeWriteLock { get; } = new();
+
         private DateTimeOffset _expectedNextPart = default;
 
         private PartState _lastPartProcessed;
@@ -46,7 +48,11 @@ namespace TwitchDownloaderCore.Tools
                 if (firstStream.ProgramDateTime - _expectedNextPart > TimeSpan.Zero)
                 {
                     logger.LogWarning($"Parts from {_expectedNextPart.ToString("yyyy-MM-ddTHH-mm-ss.fffffff")} to {firstStream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff")} are missing and will be missing from the finalized video");
-                    TotalMissingTime += firstStream.ProgramDateTime - _expectedNextPart;
+
+                    lock (TimeWriteLock)
+                    {
+                        TotalMissingTime += firstStream.ProgramDateTime - _expectedNextPart;
+                    }
                 }
             }
 

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -1,9 +1,10 @@
 using System.Collections.Concurrent;
+using TwitchDownloaderCore.Interfaces;
 using TwitchDownloaderCore.Models;
 
 namespace TwitchDownloaderCore.Tools
 {
-    internal sealed class StreamDownloadState
+    internal sealed class StreamDownloadState(ITaskLogger logger)
     {
         public class PartState
         {
@@ -29,14 +30,33 @@ namespace TwitchDownloaderCore.Tools
 
         public TimeSpan TotalMissingTime { get; set; } = TimeSpan.Zero;
 
+        private DateTimeOffset _expectedNextPart = default;
+
         private PartState _lastPartProcessed;
 
         public IEnumerable<PartState> AppendSegment(M3U8 playlist)
         {
+            var firstStream = playlist.Streams[0];
+            if (_expectedNextPart == default)
+            {
+                _expectedNextPart = firstStream.ProgramDateTime;
+            }
+            else
+            {
+                if (firstStream.ProgramDateTime - _expectedNextPart > TimeSpan.Zero)
+                {
+                    logger.LogWarning($"Parts from {_expectedNextPart.ToString("yyyy-MM-ddTHH-mm-ss.fffffff")} to {firstStream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff")} are missing and will be missing from the finalized video");
+                    TotalMissingTime += firstStream.ProgramDateTime - _expectedNextPart;
+                }
+            }
+
             uint? startId = playlist.FileMetadata.TwitchLiveSequence ?? playlist.FileMetadata.MediaSequence;
             for (int i = 0; i < playlist.Streams.Length; i++)
             {
                 M3U8.Stream stream = playlist.Streams[i];
+                if (stream.ProgramDateTime < _expectedNextPart)
+                    continue;
+
                 var filename = startId is not null ? (startId + i).ToString() : stream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff");
                 PartQueue.Enqueue(new()
                 {
@@ -45,6 +65,7 @@ namespace TwitchDownloaderCore.Tools
                     Duration = TimeSpan.FromSeconds((double)stream.PartInfo.Duration),
                     FileName = filename + DownloadTools.GetStreamPartFileExtension(stream.Path)
                 });
+                _expectedNextPart = stream.ProgramDateTime + TimeSpan.FromSeconds((double)stream.PartInfo.Duration);
             }
 
             return GetCorrectedPartStates();
@@ -55,7 +76,11 @@ namespace TwitchDownloaderCore.Tools
             DownloadInProgress = false;
         }
 
-        public IEnumerable<PartState> GetLastParts() => GetCorrectedPartStates().Concat([_lastPartProcessed]);
+        public IEnumerable<PartState> GetLastParts()
+        {
+            _expectedNextPart = DateTimeOffset.MaxValue;
+            return GetCorrectedPartStates().Concat([_lastPartProcessed]);
+        }
 
         private List<PartState> GetCorrectedPartStates()
         {
@@ -80,6 +105,23 @@ namespace TwitchDownloaderCore.Tools
                     correctedParts.Add(_lastPartProcessed);
                     _lastPartProcessed = nextPart;
                 }
+            }
+
+            if (!ProcessedParts.IsEmpty && _expectedNextPart - _lastPartProcessed.ProgramDateTime > TimeSpan.FromSeconds(60))
+            {
+                // There was some parts missing
+                var oldest = ProcessedParts.Values.MinBy(x => x.ProgramDateTime);
+                _lastPartProcessed.Duration = oldest.ProgramDateTime - _lastPartProcessed.ProgramDateTime;
+                correctedParts.Add(_lastPartProcessed);
+                ProcessedParts.TryRemove(oldest.ProgramDateTime, out _lastPartProcessed);
+
+                bool stop = false;
+                do
+                {
+                    var nextParts = GetCorrectedPartStates();
+                    stop = nextParts.Count == 0 || ProcessedParts.IsEmpty;
+                    correctedParts.AddRange(nextParts);
+                } while (!stop);
             }
 
             return correctedParts;

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -7,45 +7,82 @@ namespace TwitchDownloaderCore.Tools
     {
         public class PartState
         {
-            public byte DownloadAttempts;
-            public DateTimeOffset ProgramDateTime;
-            public string FileName { get; set; }
+            public byte DownloadAttempts { get; set; } = 0;
+            public bool IsDownloaded { get; set; } = false;
+            public required string Path { get; init; }
+            public required DateTimeOffset ProgramDateTime { get; init; }
+            public required TimeSpan Duration { get; set; }
+            public required string FileName { get; init; }
+
+            public override string ToString() => FileName;
         }
 
-        public bool DownloadInProgress { get; private set; }
+        public bool DownloadInProgress { get; private set; } = true;
 
-        public ConcurrentQueue<string> PartQueue { get; }
+        public ConcurrentQueue<PartState> PartQueue { get; } = new();
 
-        public Dictionary<string, PartState> PartStates { get; }
+        public ConcurrentDictionary<DateTimeOffset, PartState> ProcessedParts { get; } = [];
 
-        public string HeaderFile { get; set; }
+        public string HeaderFile { get; set; } = null;
 
-        public int PartCount => PartStates.Count;
+        public TimeSpan TotalDownloadedTime { get; set; } = TimeSpan.Zero;
 
-        public StreamDownloadState()
+        public TimeSpan TotalMissingTime { get; set; } = TimeSpan.Zero;
+
+        private PartState _lastPartProcessed;
+
+        public IEnumerable<PartState> AppendSegment(M3U8 playlist)
         {
-            PartQueue = new();
-            PartStates = [];
-            DownloadInProgress = true;
-            HeaderFile = null;
-        }
-
-        public void AppendSegment(IEnumerable<M3U8.Stream> playlist)
-        {
-            foreach (var stream in playlist)
+            uint? startId = playlist.FileMetadata.MediaSequence ?? playlist.FileMetadata.TwitchLiveSequence;
+            for (int i = 0; i < playlist.Streams.Length; i++)
             {
-                PartQueue.Enqueue(stream.Path);
-                PartStates[stream.Path] = new PartState()
+                M3U8.Stream stream = playlist.Streams[i];
+                var filename = startId is not null ? (startId + i).ToString() : stream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff");
+                PartQueue.Enqueue(new()
                 {
+                    Path = stream.Path,
                     ProgramDateTime = stream.ProgramDateTime,
-                    FileName = stream.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffff") + DownloadTools.GetStreamPartFileExtension(stream.Path)
-                };
+                    Duration = TimeSpan.FromSeconds((double)stream.PartInfo.Duration),
+                    FileName = filename + DownloadTools.GetStreamPartFileExtension(stream.Path)
+                });
             }
+
+            return GetCorrectedPartStates();
         }
 
         public void StopDownload()
         {
             DownloadInProgress = false;
+        }
+
+        public IEnumerable<PartState> GetLastParts() => GetCorrectedPartStates().Concat([_lastPartProcessed]);
+
+        private List<PartState> GetCorrectedPartStates()
+        {
+            while (_lastPartProcessed is null || !_lastPartProcessed.IsDownloaded)
+            {
+                if (ProcessedParts.IsEmpty)
+                    return [];
+
+                var oldest = ProcessedParts.Keys.Min();
+                ProcessedParts.TryRemove(oldest, out _lastPartProcessed);
+            }
+
+            List<PartState> correctedParts = [];
+            while (ProcessedParts.TryRemove(_lastPartProcessed.ProgramDateTime + _lastPartProcessed.Duration, out var nextPart))
+            {
+                if (!nextPart.IsDownloaded)
+                {
+                    _lastPartProcessed.Duration += nextPart.Duration;
+                }
+                else
+                {
+                    correctedParts.Add(_lastPartProcessed);
+                    _lastPartProcessed = nextPart;
+                }
+            }
+
+            return correctedParts;
         }
     }
 }

--- a/TwitchDownloaderCore/Tools/StreamDownloadState.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadState.cs
@@ -1,0 +1,43 @@
+using System.Collections.Concurrent;
+using TwitchDownloaderCore.Models;
+
+namespace TwitchDownloaderCore.Tools
+{
+    public class StreamDownloadState
+    {
+        public class PartState
+        {
+            public byte DownloadAttempts;
+            public DateTimeOffset ProgramDateTime;
+        }
+
+        public bool DownloadInProgress { get; private set; }
+
+        public ConcurrentQueue<string> PartQueue { get; }
+
+        public Dictionary<string, PartState> PartStates { get; }
+
+        public int PartCount => PartStates.Count;
+
+        public StreamDownloadState()
+        {
+            PartQueue = new();
+            PartStates = [];
+            DownloadInProgress = true;
+        }
+
+        public void AppendSegment(IReadOnlyCollection<M3U8.Stream> playlist)
+        {
+            foreach (var stream in playlist)
+            {
+                PartQueue.Enqueue(stream.Path);
+                PartStates[stream.Path] = new PartState() { ProgramDateTime = stream.ProgramDateTime };
+            }
+        }
+
+        public void StopDownload()
+        {
+            DownloadInProgress = false;
+        }
+    }
+}

--- a/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
@@ -59,7 +59,11 @@ namespace TwitchDownloaderCore.Tools
                         {
                             videoPart.IsDownloaded = true;
                             _downloadState.ProcessedParts[videoPart.ProgramDateTime] = videoPart;
-                            _downloadState.TotalDownloadedTime += videoPart.Duration;
+
+                            lock (_downloadState.TimeWriteLock)
+                            {
+                                _downloadState.TotalDownloadedTime += videoPart.Duration;
+                            }
                             _progress.ReportProgress((int)_downloadState.TotalDownloadedTime.TotalHours, _downloadState.TotalDownloadedTime, _downloadState.TotalMissingTime);
                         }
                     }
@@ -71,7 +75,12 @@ namespace TwitchDownloaderCore.Tools
 
                         videoPart.IsDownloaded = false;
                         _downloadState.ProcessedParts[videoPart.ProgramDateTime] = videoPart;
-                        _downloadState.TotalMissingTime += videoPart.Duration;
+
+                        lock (_downloadState.TimeWriteLock)
+                        {
+                            _downloadState.TotalMissingTime += videoPart.Duration;
+                        }
+
                         _progress.ReportProgress((int)_downloadState.TotalDownloadedTime.TotalHours, _downloadState.TotalDownloadedTime, _downloadState.TotalMissingTime);
                     }
                 }

--- a/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
@@ -41,7 +41,7 @@ namespace TwitchDownloaderCore.Tools
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
 
-            while (_downloadState.DownloadInProgress)
+            while (_downloadState.DownloadInProgress || !_downloadState.PartQueue.IsEmpty)
             {
                 _cancellationToken.ThrowIfCancellationRequested();
 
@@ -73,7 +73,7 @@ namespace TwitchDownloaderCore.Tools
         {
             var partState = _downloadState.PartStates[videoPartName];
             var partUri = new Uri(videoPartName);
-            var partFile = Path.Combine(_cacheFolder, partState.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffffzz") + ".ts");
+            var partFile = Path.Combine(_cacheFolder, partState.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffffzz") + Path.GetExtension(partUri.LocalPath));
             var partFi = new FileInfo(partFile);
 
             if (partFi.Exists)

--- a/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
@@ -59,11 +59,11 @@ namespace TwitchDownloaderCore.Tools
                     catch (Exception ex)
                     {
                         // Deliberately do not re-enqueue the part on exceptions
-                        _logger.LogVerbose($"Error while downloading {videoPart}: {ex.Message}");
-                        throw;
+                        _logger.LogWarning($"Error while downloading {videoPart}: {ex.Message}");
                     }
                 }
 
+				// TODO: use mutexes to avoid busy-waiting
                 Thread.Sleep(Random.Shared.Next(100, 200));
             }
         }
@@ -73,7 +73,7 @@ namespace TwitchDownloaderCore.Tools
         {
             var partState = _downloadState.PartStates[videoPartName];
             var partUri = new Uri(videoPartName);
-            var partFile = Path.Combine(_cacheFolder, partState.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffffzz") + Path.GetExtension(partUri.LocalPath));
+            var partFile = Path.Combine(_cacheFolder, partState.FileName);
             var partFi = new FileInfo(partFile);
 
             if (partFi.Exists)
@@ -93,7 +93,7 @@ namespace TwitchDownloaderCore.Tools
 
                 // Download file
                 // Stream parts don't have a Content-Length header, so this always returns -1
-                await DownloadTools.DownloadFileAsync(_client, partUri, partFile, null, _throttleKib, _logger, cancellationTokenSource);
+                await DownloadTools.DownloadFileAsync(_client, partUri, partFile, _downloadState.HeaderFile, _throttleKib, _logger, cancellationTokenSource);
 
                 // Check file size
                 partFi.Refresh();

--- a/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
@@ -1,0 +1,142 @@
+using TwitchDownloaderCore.Interfaces;
+
+namespace TwitchDownloaderCore.Tools
+{
+    internal sealed record StreamDownloadThread
+    {
+        private readonly StreamDownloadState _downloadState;
+        private readonly HttpClient _client;
+        private readonly string _cacheFolder;
+        private readonly int _throttleKib;
+        private readonly ITaskLogger _logger;
+        private readonly CancellationToken _cancellationToken;
+        public Task ThreadTask { get; private set; }
+
+        public StreamDownloadThread(StreamDownloadState downloadState, HttpClient httpClient, string cacheFolder, int throttleKib, ITaskLogger logger, CancellationToken cancellationToken)
+        {
+            _downloadState = downloadState;
+            _client = httpClient;
+            _cacheFolder = cacheFolder;
+            _throttleKib = throttleKib;
+            _logger = logger;
+            _cancellationToken = cancellationToken;
+            StartDownload();
+        }
+
+        public void StartDownload()
+        {
+            if (ThreadTask is { Status: TaskStatus.Created or TaskStatus.WaitingForActivation or TaskStatus.WaitingToRun or TaskStatus.Running })
+            {
+                throw new InvalidOperationException($"Tried to start a thread that was already running or waiting to run ({ThreadTask.Status}).");
+            }
+
+            ThreadTask = Task.Factory.StartNew(
+                Execute,
+                _cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Current);
+        }
+
+        private void Execute()
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
+
+            while (_downloadState.DownloadInProgress)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+
+                if (_downloadState.PartQueue.TryDequeue(out var videoPart))
+                {
+                    try
+                    {
+                        var result = DownloadStreamPartAsync(videoPart, cts).GetAwaiter().GetResult();
+                        if (!result)
+                        {
+                            Thread.Sleep(Random.Shared.Next(100, 1_000));
+                            _downloadState.PartQueue.Enqueue(videoPart);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Deliberately do not re-enqueue the part on exceptions
+                        _logger.LogVerbose($"Error while downloading {videoPart}: {ex.Message}");
+                        throw;
+                    }
+                }
+
+                Thread.Sleep(Random.Shared.Next(100, 200));
+            }
+        }
+
+        /// <remarks>The <paramref name="cancellationTokenSource"/> may be canceled by this method.</remarks>
+        private async Task<bool> DownloadStreamPartAsync(string videoPartName, CancellationTokenSource cancellationTokenSource)
+        {
+            var partState = _downloadState.PartStates[videoPartName];
+            var partUri = new Uri(videoPartName);
+            var partFile = Path.Combine(_cacheFolder, partState.ProgramDateTime.ToString("yyyy-MM-ddTHH-mm-ss.fffffffzz") + ".ts");
+            var partFi = new FileInfo(partFile);
+
+            if (partFi.Exists)
+            {
+                _logger.LogWarning($"Tried to redownload already downloaded part: {videoPartName}.");
+                return true;
+            }
+
+            try
+            {
+                // Check download attempts
+                const int MAX_DOWNLOAD_ATTEMPTS = 5;
+                if (partState.DownloadAttempts++ >= MAX_DOWNLOAD_ATTEMPTS)
+                {
+                    throw new Exception($"{videoPartName} failed to download after {partState.DownloadAttempts - 1} attempts.");
+                }
+
+                // Download file
+                // Stream parts don't have a Content-Length header, so this always returns -1
+                await DownloadTools.DownloadFileAsync(_client, partUri, partFile, null, _throttleKib, _logger, cancellationTokenSource);
+
+                // Check file size
+                partFi.Refresh();
+                CheckTsLength(partFile, partFi.Length);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogVerbose(ex.StatusCode.HasValue
+                    ? $"Received {(int)ex.StatusCode}: {ex.StatusCode} for {videoPartName}."
+                    : $"{videoPartName}: {ex.Message}");
+
+                await Delay(1_000, cancellationTokenSource.Token);
+                return false;
+            }
+            catch (TaskCanceledException ex) when (ex.Message.Contains("HttpClient.Timeout"))
+            {
+                _logger.LogVerbose($"{videoPartName} timed out.");
+
+                await Delay(5_000, cancellationTokenSource.Token);
+                return false;
+            }
+
+            return true;
+        }
+
+        private void CheckTsLength(string partFile, long length)
+        {
+            if (!partFile.EndsWith(".ts"))
+            {
+                return;
+            }
+
+            const int TS_PACKET_LENGTH = 188; // MPEG TS packets are made of a header and a body: [ 4B ][   184B   ] - https://tsduck.io/download/docs/mpegts-introduction.pdf
+            if (length % TS_PACKET_LENGTH != 0)
+            {
+                _logger.LogWarning($"{Path.GetFileName(partFile)} contains malformed packets and may cause encoding issues.");
+            }
+        }
+
+        private static Task Delay(int millis, CancellationToken cancellationToken)
+        {
+            var jitteredMillis = millis + Random.Shared.Next(-200, 200);
+            return Task.Delay(Math.Clamp(jitteredMillis, millis / 2, millis * 2), cancellationToken);
+        }
+    }
+}

--- a/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
+++ b/TwitchDownloaderCore/Tools/StreamDownloadThread.cs
@@ -8,17 +8,17 @@ namespace TwitchDownloaderCore.Tools
         private readonly HttpClient _client;
         private readonly string _cacheFolder;
         private readonly int _throttleKib;
-        private readonly ITaskLogger _logger;
+        private readonly ITaskProgress _progress;
         private readonly CancellationToken _cancellationToken;
         public Task ThreadTask { get; private set; }
 
-        public StreamDownloadThread(StreamDownloadState downloadState, HttpClient httpClient, string cacheFolder, int throttleKib, ITaskLogger logger, CancellationToken cancellationToken)
+        public StreamDownloadThread(StreamDownloadState downloadState, HttpClient httpClient, string cacheFolder, int throttleKib, ITaskProgress progress, CancellationToken cancellationToken)
         {
             _downloadState = downloadState;
             _client = httpClient;
             _cacheFolder = cacheFolder;
             _throttleKib = throttleKib;
-            _logger = logger;
+            _progress = progress;
             _cancellationToken = cancellationToken;
             StartDownload();
         }
@@ -55,30 +55,42 @@ namespace TwitchDownloaderCore.Tools
                             Thread.Sleep(Random.Shared.Next(100, 1_000));
                             _downloadState.PartQueue.Enqueue(videoPart);
                         }
+                        else
+                        {
+                            videoPart.IsDownloaded = true;
+                            _downloadState.ProcessedParts[videoPart.ProgramDateTime] = videoPart;
+                            _downloadState.TotalDownloadedTime += videoPart.Duration;
+                            _progress.ReportProgress((int)_downloadState.TotalDownloadedTime.TotalHours, _downloadState.TotalDownloadedTime, _downloadState.TotalMissingTime);
+                        }
                     }
                     catch (Exception ex)
                     {
                         // Deliberately do not re-enqueue the part on exceptions
-                        _logger.LogWarning($"Error while downloading {videoPart}: {ex.Message}");
+                        _progress.LogWarning($"Part {videoPart.FileName} could not be downloaded and will be missing from the finalized video.");
+                        _progress.LogVerbose($"Error while downloading {videoPart.FileName}: {ex.Message}");
+
+                        videoPart.IsDownloaded = false;
+                        _downloadState.ProcessedParts[videoPart.ProgramDateTime] = videoPart;
+                        _downloadState.TotalMissingTime += videoPart.Duration;
+                        _progress.ReportProgress((int)_downloadState.TotalDownloadedTime.TotalHours, _downloadState.TotalDownloadedTime, _downloadState.TotalMissingTime);
                     }
                 }
 
-				// TODO: use mutexes to avoid busy-waiting
+                // TODO: use mutexes to avoid busy-waiting
                 Thread.Sleep(Random.Shared.Next(100, 200));
             }
         }
 
         /// <remarks>The <paramref name="cancellationTokenSource"/> may be canceled by this method.</remarks>
-        private async Task<bool> DownloadStreamPartAsync(string videoPartName, CancellationTokenSource cancellationTokenSource)
+        private async Task<bool> DownloadStreamPartAsync(StreamDownloadState.PartState videoPart, CancellationTokenSource cancellationTokenSource)
         {
-            var partState = _downloadState.PartStates[videoPartName];
-            var partUri = new Uri(videoPartName);
-            var partFile = Path.Combine(_cacheFolder, partState.FileName);
+            var partUri = new Uri(videoPart.Path);
+            var partFile = Path.Combine(_cacheFolder, videoPart.FileName);
             var partFi = new FileInfo(partFile);
 
             if (partFi.Exists)
             {
-                _logger.LogWarning($"Tried to redownload already downloaded part: {videoPartName}.");
+                _progress.LogWarning($"Tried to redownload already downloaded part: {videoPart.FileName}.");
                 return true;
             }
 
@@ -86,14 +98,14 @@ namespace TwitchDownloaderCore.Tools
             {
                 // Check download attempts
                 const int MAX_DOWNLOAD_ATTEMPTS = 5;
-                if (partState.DownloadAttempts++ >= MAX_DOWNLOAD_ATTEMPTS)
+                if (videoPart.DownloadAttempts++ >= MAX_DOWNLOAD_ATTEMPTS)
                 {
-                    throw new Exception($"{videoPartName} failed to download after {partState.DownloadAttempts - 1} attempts.");
+                    throw new Exception($"{videoPart.FileName} failed to download after {videoPart.DownloadAttempts - 1} attempts.");
                 }
 
                 // Download file
                 // Stream parts don't have a Content-Length header, so this always returns -1
-                await DownloadTools.DownloadFileAsync(_client, partUri, partFile, _downloadState.HeaderFile, _throttleKib, _logger, cancellationTokenSource);
+                await DownloadTools.DownloadFileAsync(_client, partUri, partFile, _downloadState.HeaderFile, _throttleKib, _progress, cancellationTokenSource);
 
                 // Check file size
                 partFi.Refresh();
@@ -101,16 +113,16 @@ namespace TwitchDownloaderCore.Tools
             }
             catch (HttpRequestException ex)
             {
-                _logger.LogVerbose(ex.StatusCode.HasValue
-                    ? $"Received {(int)ex.StatusCode}: {ex.StatusCode} for {videoPartName}."
-                    : $"{videoPartName}: {ex.Message}");
+                _progress.LogVerbose(ex.StatusCode.HasValue
+                    ? $"Received {(int)ex.StatusCode}: {ex.StatusCode} for {videoPart.FileName}."
+                    : $"{videoPart.FileName}: {ex.Message}");
 
                 await Delay(1_000, cancellationTokenSource.Token);
                 return false;
             }
             catch (TaskCanceledException ex) when (ex.Message.Contains("HttpClient.Timeout"))
             {
-                _logger.LogVerbose($"{videoPartName} timed out.");
+                _progress.LogVerbose($"{videoPart.FileName} timed out.");
 
                 await Delay(5_000, cancellationTokenSource.Token);
                 return false;
@@ -129,7 +141,7 @@ namespace TwitchDownloaderCore.Tools
             const int TS_PACKET_LENGTH = 188; // MPEG TS packets are made of a header and a body: [ 4B ][   184B   ] - https://tsduck.io/download/docs/mpegts-introduction.pdf
             if (length % TS_PACKET_LENGTH != 0)
             {
-                _logger.LogWarning($"{Path.GetFileName(partFile)} contains malformed packets and may cause encoding issues.");
+                _progress.LogWarning($"{Path.GetFileName(partFile)} contains malformed packets and may cause encoding issues.");
             }
         }
 

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -68,7 +68,7 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlVideoTokenResponse>();
         }
 
-        public static async Task<GqlStreamTokenResponse> GetStreamToken(string channelLogin, string authToken)
+        public static async Task<GqlStreamTokenResponse> GetStreamToken(string channelLogin, string authToken, CancellationToken cancellationToken)
         {
             var request = new HttpRequestMessage()
             {
@@ -79,9 +79,9 @@ namespace TwitchDownloaderCore
             request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
             if (!string.IsNullOrWhiteSpace(authToken))
                 request.Headers.Add("Authorization", $"OAuth {authToken}");
-            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<GqlStreamTokenResponse>();
+            return await response.Content.ReadFromJsonAsync<GqlStreamTokenResponse>(cancellationToken);
         }
 
         public static async Task<string> GetVideoPlaylist(long videoId, string token, string sig)
@@ -130,7 +130,7 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadAsStringAsync();
         }
 
-        public static async Task<string> GetStreamPlaylist(string channelLogin, string token, string sig)
+        public static async Task<string> GetStreamPlaylist(string channelLogin, string token, string sig, CancellationToken cancellationToken)
         {
             HttpRequestMessage request;
             HttpResponseMessage response;
@@ -140,12 +140,12 @@ namespace TwitchDownloaderCore
                 RequestUri = new Uri($"https://usher.ttvnw.net/api/channel/hls/{channelLogin}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
                 Method = HttpMethod.Get
             };
-            response = await httpClient.SendAsync(request);
+            response = await httpClient.SendAsync(request, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 // Twitch returns 404 not found if channel is not live
-                var error = await response.Content.ReadAsStringAsync();
+                var error = await response.Content.ReadAsStringAsync(cancellationToken);
                 if (error.Contains("Can not find channel"))
                 {
                     return error;
@@ -153,7 +153,7 @@ namespace TwitchDownloaderCore
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
+            return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
         private static bool IsAuthException(Exception ex)

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -68,6 +68,22 @@ namespace TwitchDownloaderCore
             return await response.Content.ReadFromJsonAsync<GqlVideoTokenResponse>();
         }
 
+        public static async Task<GqlStreamTokenResponse> GetStreamToken(string channelLogin, string authToken)
+        {
+            var request = new HttpRequestMessage()
+            {
+                RequestUri = new Uri("https://gql.twitch.tv/gql"),
+                Method = HttpMethod.Post,
+                Content = new StringContent("{\"operationName\":\"PlaybackAccessToken_Template\",\"query\":\"query PlaybackAccessToken_Template($login: String!, $isLive: Boolean!, $vodID: ID!, $isVod: Boolean!, $playerType: String!) {  streamPlaybackAccessToken(channelName: $login, params: {platform: \\\"web\\\", playerBackend: \\\"mediaplayer\\\", playerType: $playerType}) @include(if: $isLive) {    value    signature    __typename  }  videoPlaybackAccessToken(id: $vodID, params: {platform: \\\"web\\\", playerBackend: \\\"mediaplayer\\\", playerType: $playerType}) @include(if: $isVod) {    value    signature    __typename  }}\",\"variables\":{\"isLive\":true,\"login\":\"" + channelLogin + "\",\"isVod\":false,\"vodID\":\"\",\"playerType\":\"embed\"}}", Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            if (!string.IsNullOrWhiteSpace(authToken))
+                request.Headers.Add("Authorization", $"OAuth {authToken}");
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<GqlStreamTokenResponse>();
+        }
+
         public static async Task<string> GetVideoPlaylist(long videoId, string token, string sig)
         {
             HttpRequestMessage request;
@@ -111,7 +127,32 @@ namespace TwitchDownloaderCore
             }
 
             response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
 
+        public static async Task<string> GetStreamPlaylist(string channelLogin, string token, string sig)
+        {
+            HttpRequestMessage request;
+            HttpResponseMessage response;
+
+            request = new HttpRequestMessage()
+            {
+                RequestUri = new Uri($"https://usher.ttvnw.net/api/channel/hls/{channelLogin}.m3u8?sig={sig}&token={token}&allow_source=true&allow_audio_only=true&include_unavailable=true&platform=web&player_backend=mediaplayer&playlist_include_framerate=true&supported_codecs=av1,h265,h264"),
+                Method = HttpMethod.Get
+            };
+            response = await httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Twitch returns 404 not found if channel is not live
+                var error = await response.Content.ReadAsStringAsync();
+                if (error.Contains("Can not find channel"))
+                {
+                    return error;
+                }
+            }
+
+            response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();
         }
 

--- a/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Api/UnavailableMedia.cs
@@ -10,6 +10,9 @@ namespace TwitchDownloaderCore.TwitchObjects.Api
         [JsonPropertyName("IVS_NAME")]
         public string IvsName { get; set; }
 
+        [JsonPropertyName("NAME")]
+        public string Name { get; set; }
+
         [JsonPropertyName("BANDWIDTH")]
         public int Bandwidth { get; set; }
 

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipTokenResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlClipTokenResponse.cs
@@ -12,12 +12,6 @@
         public ClipToken clip { get; set; }
     }
 
-    public class PlaybackAccessToken
-    {
-        public string signature { get; set; }
-        public string value { get; set; }
-    }
-
     public class GqlClipTokenResponse
     {
         public ClipTokenData data { get; set; }

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlStreamTokenResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlStreamTokenResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace TwitchDownloaderCore.TwitchObjects.Gql
+{
+    public class GqlStreamTokenData
+    {
+        public PlaybackAccessToken streamPlaybackAccessToken { get; set; }
+    }
+
+    public class GqlStreamTokenResponse
+    {
+        public GqlStreamTokenData data { get; set; }
+        public Extensions extensions { get; set; }
+    }
+}

--- a/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoTokenResponse.cs
+++ b/TwitchDownloaderCore/TwitchObjects/Gql/GqlVideoTokenResponse.cs
@@ -1,17 +1,17 @@
 ﻿namespace TwitchDownloaderCore.TwitchObjects.Gql
 {
-    public class GqlVideoData
+    public class GqlVideoTokenData
     {
-        public VideoPlaybackAccessToken videoPlaybackAccessToken { get; set; }
+        public PlaybackAccessToken videoPlaybackAccessToken { get; set; }
     }
 
     public class GqlVideoTokenResponse
     {
-        public GqlVideoData data { get; set; }
+        public GqlVideoTokenData data { get; set; }
         public Extensions extensions { get; set; }
     }
 
-    public class VideoPlaybackAccessToken
+    public class PlaybackAccessToken
     {
         public string value { get; set; }
         public string signature { get; set; }

--- a/TwitchDownloaderCore/VideoDownloader.cs
+++ b/TwitchDownloaderCore/VideoDownloader.cs
@@ -130,7 +130,8 @@ namespace TwitchDownloaderCore
                     _progress.LogWarning($"The following parts could not be downloaded and will be missing from the finalized video: {string.Join(", ", missingParts.Select(x => x.Path))}");
                 }
 
-                await FfmpegConcatList.SerializeAsync(concatListPath, validParts, streamIds, cancellationToken);
+                await using var fs = new FileStream(concatListPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+                await FfmpegConcatList.SerializeAsync(fs, validParts.Select(x => (DownloadTools.RemoveQueryString(x.Path), x.PartInfo.Duration)), streamIds, cancellationToken);
 
                 outputFs.Close();
 


### PR DESCRIPTION
Download a stream directly from the live feed, allowing the recording of audio tracks not present on the VOD. This is still work in progress but it's getting close to done and I wanted to get some feedback.
### Features
- CLI endpoint
- Pressing ctrl+C only interrupts the download but still finalizes the output video. Pressing ctrl+C a second time kills the process as usual
- Option to delay the download until the stream starts (on the CLI part, not in Core)
- Option to wait for some time after the end of stream. If another stream starts, we assume the previous one crashed, and resume the download
- Fetches stream info to serialize metadata to the output video
- Downloads parts manually, ffmpeg is only used to concatenate them

### Additional thoughts
- No GUI yet. With a potential migration to Avalonia, a WPF version is maybe not neccessary.
- I did some testing by streaming and throttling my internet connection, but it's far from exhaustive. It would be nice to see what happens when twitch itself is struggling.
- I didn't quite understand how the qualities system works, I added 3 classes, StreamQuality, StreamVideoQuality, StreamVideoQualities, not sure if this is what is needed.
- The StreamDownloadState is a bit of a mess, it could see a refactor at some point. I didn't want to keep the stream parts data in memory adding up over time, so they get written to the ffmpeg concat list when they are downloaded. Currently the StreamDownloadState handles keeping track of proccessed parts, modifying the duration of a part if the next one is missing/failed to download, but that wouldn't work if we want to download missing parts from the VOD.
- I experimented a bit with using a websocket for waiting until the stream starts, but removed it since it doesn't really make sense for CLI. Could work for the GUI though, as it's only a single websocket for any number of waits.
- A connection with #1645 would be nice, to end up with syncronized chat&stream videos.
- File metadata is fetched from the stream info at the start of the download, but it doesn't include any chapters. We could try to get them from the corresponding VODs if they exist, but a more reliable solution would be getting them live, like a live chat recorder would do.
- Since stream parts length is around 2s, a long stream can have thousands of video files and the ffmpeg concat takes a long time, we could have an option to concat them into larger parts while downloading
- Output video doesn't seem to have ad segments, but I didn't do nearly enough tests of different types of stream to say this is always the case.
- An option to download the earlier part of the stream, and the parts that failed to be downloaded, from the VOD (if available) is planned.